### PR TITLE
Implements Work-Steal Scheduler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,4 @@ cabal.project.local~
 .ghc.environment.*
 *.eventlog
 /bench-results
+*.png

--- a/app/convert-qsort-bench-csv.hs
+++ b/app/convert-qsort-bench-csv.hs
@@ -89,12 +89,13 @@ fromRawRow RawRow {..} = fromMaybe mempty do
     "sequential" -> pure mempty {sequentialMean = Sum mean, sequentialStddev = Sum stddev, sequentialAlloc = Sum alloc, sequentialCopied = Sum copied, sequentialPeak = Sum peak}
     "parallel (budget = 4)" -> pure mempty {parallel4Mean = Sum mean, parallel4Stddev = Sum stddev, parallel4Alloc = Sum alloc, parallel4Copied = Sum copied, parallel4Peak = Sum peak}
     "parallel (budget = 8)" -> pure mempty {parallel8Mean = Sum mean, parallel8Stddev = Sum stddev, parallel8Alloc = Sum alloc, parallel8Copied = Sum copied, parallel8Peak = Sum peak}
-    "parallel (budget = 12)" -> pure mempty {parallel12Mean = Sum mean, parallel12Stddev = Sum stddev, parallel12Alloc = Sum alloc, parallel12Copied = Sum copied, parallel12Peak = Sum peak}
     "parallel (budget = 16)" -> pure mempty {parallel16Mean = Sum mean, parallel16Stddev = Sum stddev, parallel16Alloc = Sum alloc, parallel16Copied = Sum copied, parallel16Peak = Sum peak}
-    "parallel (budget = 20)" -> pure mempty {parallel20Mean = Sum mean, parallel20Stddev = Sum stddev, parallel20Alloc = Sum alloc, parallel20Copied = Sum copied, parallel20Peak = Sum peak}
-    "parallel (budget = 24)" -> pure mempty {parallel24Mean = Sum mean, parallel24Stddev = Sum stddev, parallel24Alloc = Sum alloc, parallel24Copied = Sum copied, parallel24Peak = Sum peak}
-    "parallel (budget = 28)" -> pure mempty {parallel28Mean = Sum mean, parallel28Stddev = Sum stddev, parallel28Alloc = Sum alloc, parallel28Copied = Sum copied, parallel28Peak = Sum peak}
     "parallel (budget = 32)" -> pure mempty {parallel32Mean = Sum mean, parallel32Stddev = Sum stddev, parallel32Alloc = Sum alloc, parallel32Copied = Sum copied, parallel32Peak = Sum peak}
+    "worksteal (workers = 2)" -> pure mempty {workSteal2Mean = Sum mean, workSteal2Stddev = Sum stddev, workSteal2Alloc = Sum alloc, workSteal2Copied = Sum copied, workSteal2Peak = Sum peak}
+    "worksteal (workers = 4)" -> pure mempty {workSteal4Mean = Sum mean, workSteal4Stddev = Sum stddev, workSteal4Alloc = Sum alloc, workSteal4Copied = Sum copied, workSteal4Peak = Sum peak}
+    "worksteal (workers = 6)" -> pure mempty {workSteal6Mean = Sum mean, workSteal6Stddev = Sum stddev, workSteal6Alloc = Sum alloc, workSteal6Copied = Sum copied, workSteal6Peak = Sum peak}
+    "worksteal (workers = 8)" -> pure mempty {workSteal8Mean = Sum mean, workSteal8Stddev = Sum stddev, workSteal8Alloc = Sum alloc, workSteal8Copied = Sum copied, workSteal8Peak = Sum peak}
+    "worksteal (workers = 10)" -> pure mempty {workSteal10Mean = Sum mean, workSteal10Stddev = Sum stddev, workSteal10Alloc = Sum alloc, workSteal10Copied = Sum copied, workSteal10Peak = Sum peak}
     _ -> Nothing
   pure (MIM.singleton size dat)
 
@@ -119,36 +120,41 @@ data SizeData = SizeData
   , parallel8Alloc :: !(Sum Int)
   , parallel8Copied :: !(Sum Int)
   , parallel8Peak :: !(Sum Int)
-  , parallel12Mean :: !(Sum Int)
-  , parallel12Stddev :: !(Sum Int)
-  , parallel12Alloc :: !(Sum Int)
-  , parallel12Copied :: !(Sum Int)
-  , parallel12Peak :: !(Sum Int)
   , parallel16Mean :: !(Sum Int)
   , parallel16Stddev :: !(Sum Int)
   , parallel16Alloc :: !(Sum Int)
   , parallel16Copied :: !(Sum Int)
   , parallel16Peak :: !(Sum Int)
-  , parallel20Mean :: !(Sum Int)
-  , parallel20Stddev :: !(Sum Int)
-  , parallel20Alloc :: !(Sum Int)
-  , parallel20Copied :: !(Sum Int)
-  , parallel20Peak :: !(Sum Int)
-  , parallel24Mean :: !(Sum Int)
-  , parallel24Stddev :: !(Sum Int)
-  , parallel24Alloc :: !(Sum Int)
-  , parallel24Copied :: !(Sum Int)
-  , parallel24Peak :: !(Sum Int)
-  , parallel28Mean :: !(Sum Int)
-  , parallel28Stddev :: !(Sum Int)
-  , parallel28Alloc :: !(Sum Int)
-  , parallel28Copied :: !(Sum Int)
-  , parallel28Peak :: !(Sum Int)
   , parallel32Mean :: !(Sum Int)
   , parallel32Stddev :: !(Sum Int)
   , parallel32Alloc :: !(Sum Int)
   , parallel32Copied :: !(Sum Int)
   , parallel32Peak :: !(Sum Int)
+  , workSteal2Mean :: !(Sum Int)
+  , workSteal2Stddev :: !(Sum Int)
+  , workSteal2Alloc :: !(Sum Int)
+  , workSteal2Copied :: !(Sum Int)
+  , workSteal2Peak :: !(Sum Int)
+  , workSteal4Mean :: !(Sum Int)
+  , workSteal4Stddev :: !(Sum Int)
+  , workSteal4Alloc :: !(Sum Int)
+  , workSteal4Copied :: !(Sum Int)
+  , workSteal4Peak :: !(Sum Int)
+  , workSteal6Mean :: !(Sum Int)
+  , workSteal6Stddev :: !(Sum Int)
+  , workSteal6Alloc :: !(Sum Int)
+  , workSteal6Copied :: !(Sum Int)
+  , workSteal6Peak :: !(Sum Int)
+  , workSteal8Mean :: !(Sum Int)
+  , workSteal8Stddev :: !(Sum Int)
+  , workSteal8Alloc :: !(Sum Int)
+  , workSteal8Copied :: !(Sum Int)
+  , workSteal8Peak :: !(Sum Int)
+  , workSteal10Mean :: !(Sum Int)
+  , workSteal10Stddev :: !(Sum Int)
+  , workSteal10Alloc :: !(Sum Int)
+  , workSteal10Copied :: !(Sum Int)
+  , workSteal10Peak :: !(Sum Int)
   }
   deriving (Show, Eq, Ord, Generic)
   deriving anyclass (ToNamedRecord, DefaultOrdered)

--- a/pure-borrow.cabal
+++ b/pure-borrow.cabal
@@ -76,7 +76,7 @@ library
 
   -- cabal-gild: discover src --include src/**/Utils.hs --include src/**/Utils/**/*.hs
   other-modules:
-    Control.Concurrent.DivideConquer.Utils.BMQueue.Linear
+    Control.Concurrent.DivideConquer.Utils.MQueue.Linear
     Control.Monad.Borrow.Pure.Utils
 
   build-tool-depends: cabal-gild:cabal-gild >=1.6.0.0

--- a/pure-borrow.cabal
+++ b/pure-borrow.cabal
@@ -46,11 +46,14 @@ library
     containers,
     deepseq,
     linear-generics,
+    stm,
+    stm-chans,
     vector,
 
   hs-source-dirs: src
-  -- cabal-gild: discover src --exclude src/**/Utils.hs
+  -- cabal-gild: discover src --exclude src/**/Utils.hs --exclude src/**/Utils/**/*.hs
   exposed-modules:
+    Control.Concurrent.DivideConquer.Linear
     Control.Monad.Borrow.Pure
     Control.Monad.Borrow.Pure.Affine
     Control.Monad.Borrow.Pure.Affine.Internal
@@ -65,12 +68,17 @@ library
     Data.Array.Mutable.Unlifted.Linear.Witness
     Data.Coerce.Directed
     Data.Comonad.Linear
+    Data.OnceChan.Linear
+    Data.OnceChan.Linear.Unlifted
     Data.Var.Linear
     Data.Var.Linear.Unlifted
     Data.Vector.Mutable.Linear.Borrow
 
-  -- cabal-gild: discover src --include src/**/Utils.hs
-  other-modules: Control.Monad.Borrow.Pure.Utils
+  -- cabal-gild: discover src --include src/**/Utils.hs --include src/**/Utils/**/*.hs
+  other-modules:
+    Control.Concurrent.DivideConquer.Utils.BMQueue.Linear
+    Control.Monad.Borrow.Pure.Utils
+
   build-tool-depends: cabal-gild:cabal-gild >=1.6.0.0
   build-depends:
 

--- a/pure-borrow.cabal
+++ b/pure-borrow.cabal
@@ -90,6 +90,7 @@ test-suite pure-borrow-test
   main-is: Main.hs
   -- cabal-gild: discover test --exclude=test/Main.hs
   other-modules:
+    Control.Concurrent.DivideConquer.LinearSpec
     Control.Monad.Borrow.Pure.Lifetime.TypingCases
     Control.Monad.Borrow.Pure.LifetimeSpec
     Data.Vector.Mutable.Linear.BorrowSpec

--- a/src/Control/Concurrent/DivideConquer/Linear.hs
+++ b/src/Control/Concurrent/DivideConquer/Linear.hs
@@ -1,0 +1,216 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE ImpredicativeTypes #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE LinearTypes #-}
+{-# LANGUAGE MultiWayIf #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE QualifiedDo #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# OPTIONS_GHC -Wno-name-shadowing #-}
+{-# OPTIONS_GHC -Wno-partial-type-signatures #-}
+
+module Control.Concurrent.DivideConquer.Linear (
+  divideAndConquer,
+  DivideConquer (..),
+
+  -- *  Examples
+  qsortDC,
+) where
+
+import Control.Concurrent (ThreadId, forkIO)
+import Control.Concurrent qualified as Conc
+import Control.Concurrent.DivideConquer.Utils.BMQueue.Linear (newBMQueue)
+import Control.Concurrent.DivideConquer.Utils.BMQueue.Linear qualified as BMQ
+import Control.Functor.Linear (runStateT)
+import Control.Functor.Linear qualified as Control
+import Control.Monad.Borrow.Pure
+import Control.Monad.Borrow.Pure.Affine (Affable, GenericallyAffable (..))
+import Control.Monad.Borrow.Pure.Internal
+import Control.Syntax.DataFlow qualified as DataFlow
+import Data.Coerce qualified as NonLinear
+import Data.Functor.Linear qualified as Data
+import Data.Kind (Type)
+import Data.OnceChan.Linear (Sink, Source)
+import Data.OnceChan.Linear qualified as Once
+import Data.Proxy (Proxy (..))
+import Data.Unrestricted.Linear (AsMovable (..))
+import Data.Vector.Mutable.Linear.Borrow qualified as LV
+import GHC.Generics qualified as GHC
+import GHC.TypeNats (SomeNat (..), someNatVal)
+import Generics.Linear.TH (deriveGenericAnd1)
+import Prelude.Linear
+import Prelude.Linear.Generically (Generically, Generically1)
+import Unsafe.Linear qualified as Unsafe
+import Prelude qualified as NonLinear
+
+data DivideConquer α t a r = DivideConquer
+  { divide :: forall β. (β <= α) => Mut β a %1 -> BO β (Result β t a r)
+  , conquer :: Conquer α t r
+  }
+
+divideAndConquer ::
+  forall α t a r.
+  (Data.Traversable t, Consumable (t ())) =>
+  -- | The # of workers
+  Int ->
+  DivideConquer α t a r ->
+  Linearly %1 ->
+  Mut α a %1 ->
+  BO α (r, Mut α a)
+divideAndConquer n DivideConquer {..} lin ini =
+  dup2 lin & \(lin, lin') ->
+    reborrowing ini \(ini :: Mut γ a) ->
+      someNatVal (fromIntegral n) & \(SomeNat (_ :: Proxy n)) -> Control.do
+        (q, lend) <- newBMQueue 128 lin
+        DataFlow.do
+          (q, q') <- BMQ.unsafeClone q
+          (rootSink, rootSource) <- Once.new lin'
+          qs <- BMQ.unsafeCloneN @n q'
+          Control.do
+            q <- BMQ.writeBMQueueMany q [Divide ini rootSink]
+            chs <- concurrentMap worker qs
+            !r <- Once.take rootSource
+            BMQ.closeBMQueue q
+            Control.void $ forkBO $ Control.void $ Data.traverse killThreadBO chs
+            Control.pure (\end -> reclaim end lend `lseq` r)
+  where
+    worker :: (β <= α) => Mut β (BMQ.BMQueue (Work β a t r)) %1 -> BO β ()
+    worker q =
+      whileJust_ q BMQ.readBMQueue \q -> \case
+        Divide !inp !sink -> Control.do
+          resl <- divide inp
+          case resl of
+            Done !r -> Control.do
+              Once.put sink r
+              Control.pure q
+            Continue ts -> Control.do
+              (sources, q) <- flip runStateT q Control.do
+                Data.for ts \work -> Control.do
+                  lin <- Control.state withLinearly
+                  Once.new lin & \(sink, source) -> Control.do
+                    Control.StateT \q ->
+                      ((),) Control.<$> BMQ.writeBMQueue q (Divide work sink)
+                    Control.pure source
+              q <- BMQ.writeBMQueue q (Unite sources sink)
+              Control.pure q
+        Unite sources sink -> Control.do
+          pieces <- Data.traverse Once.take sources
+          case conquer of
+            NoOp ->
+              pieces `lseq` Control.do
+                Once.put sink ()
+                Control.pure q
+            Conquer k -> Control.do
+              !res <- k pieces
+              Once.put sink res
+              Control.pure q
+
+killThreadBO :: ThreadId_ %1 -> BO α ()
+killThreadBO = Unsafe.toLinear \tid ->
+  unsafeSystemIOToBO (Conc.killThread $ NonLinear.coerce tid)
+
+newtype ThreadId_ = ThreadId_ ThreadId
+  deriving stock (GHC.Generic)
+  deriving (Consumable, Dupable) via AsMovable ThreadId_
+
+instance Movable ThreadId_ where
+  move = Unsafe.toLinear Ur
+
+concurrentMap ::
+  (Data.Traversable t) =>
+  (a %1 -> BO α ()) -> t a %1 -> BO α (t ThreadId_)
+concurrentMap k = Data.traverse (forkBO . k)
+
+forkBO :: BO α () %1 -> BO α ThreadId_
+forkBO = Unsafe.toLinear \bo ->
+  unsafeSystemIOToBO (ThreadId_ NonLinear.<$> forkIO (unsafeBOToSystemIO bo))
+
+whileJust_ ::
+  (Control.Monad m) =>
+  r %1 ->
+  (r %1 -> m (Maybe (a, r))) ->
+  (r %1 -> a %1 -> m r) ->
+  m ()
+whileJust_ ini next action = loop ini
+  where
+    loop cur = Control.do
+      m <- next cur
+      case m of
+        Nothing -> Control.pure ()
+        Just (!x, !cur) -> Control.do
+          cur <- action cur x
+          loop cur
+
+data Result β t a r = Done r | Continue (t (Mut β a))
+
+data Conquer α t r where
+  NoOp :: Conquer α t ()
+  Conquer :: (forall β. (β <= α) => t r %1 -> BO β r) -> Conquer α t r
+
+data Work α a (t :: Type -> Type) (r :: Type) where
+  Divide :: Mut α a %1 -> Sink r %1 -> Work α a t r
+  Unite :: t (Source r) %1 -> Sink r %1 -> Work α a t r
+
+data Pair a where
+  Pair :: !a %1 -> !a %1 -> Pair a
+  deriving (GHC.Generic, GHC.Generic1)
+
+deriveGenericAnd1 ''Pair
+
+deriving via Generically1 Pair instance Data.Functor Pair
+
+deriving via
+  Generically (Pair a)
+  instance
+    (Consumable a) => Consumable (Pair a)
+
+deriving via
+  Generically (Pair a)
+  instance
+    (Dupable a) => Dupable (Pair a)
+
+deriving via
+  GenericallyAffable (Pair a)
+  instance
+    (Affable a) => Affable (Pair a)
+
+deriving via
+  Generically (Pair a)
+  instance
+    (Movable a) => Movable (Pair a)
+
+instance Data.Traversable Pair where
+  traverse = Data.genericTraverse
+  {-# INLINE traverse #-}
+
+qsortDC ::
+  (Ord a, Movable a, Derefable a) =>
+  -- | Threshold for the length of vector to switch to sequential sort
+  Int ->
+  DivideConquer α Pair (LV.Vector a) ()
+qsortDC thresh =
+  DivideConquer
+    { divide = \vs ->
+        case LV.size vs of
+          (Ur n, v)
+            | n <= 1 ->
+                v `lseq` Control.pure (Done ())
+            | n <= thresh ->
+                Done Control.<$> LV.qsort 0 v
+            | otherwise -> Control.do
+                let i = n `quot` 2
+                (pivot, v) <- sharing_ v \v ->
+                  move . derefShare Control.<$> LV.unsafeGet i v
+                pivot & \(Ur pivot) -> Control.do
+                  (lo, hi) <- LV.divide pivot v 0 n
+                  Control.pure $ Continue $ Pair lo hi
+    , conquer = NoOp
+    }

--- a/src/Control/Concurrent/DivideConquer/Linear.hs
+++ b/src/Control/Concurrent/DivideConquer/Linear.hs
@@ -94,12 +94,15 @@ divideAndConquer n DivideConquer {..} ini = DataFlow.do
         Control.do
           q <- MQ.writeMQueue q $ Divide ini rootSink
           chs <- concurrentMap lin'' worker qs
-          r <- case conquer of
-            NoOp -> Control.do
-              Once.take rootSource
-              MQ.closeMQueue q
-              Control.void $ Data.traverse wait chs
-              Control.pure ()
+          r <-
+            ( case conquer of
+                NoOp -> Control.do
+                  Once.take rootSource
+                  MQ.closeMQueue q
+                  Control.void $ Data.traverse wait chs
+                  Control.pure ()
+            ) ::
+              BO γ r
           {-
             -- NOTE: To handle conquer correctly, we need to be more careful
             -- with the dependency between tasks and easily deadlocks / starvation.

--- a/src/Control/Concurrent/DivideConquer/Linear.hs
+++ b/src/Control/Concurrent/DivideConquer/Linear.hs
@@ -92,7 +92,7 @@ divideAndConquer n DivideConquer {..} ini = DataFlow.do
         (rootSink, rootSource) <- Once.new lin'
         qs <- MQ.unsafeCloneN @n q'
         Control.do
-          q <- MQ.writeMQueueMany q [Divide ini rootSink]
+          q <- MQ.writeMQueue q $ Divide ini rootSink
           chs <- concurrentMap lin'' worker qs
           r <- case conquer of
             NoOp -> Control.do
@@ -129,8 +129,7 @@ divideAndConquer n DivideConquer {..} ini = DataFlow.do
                     Control.StateT \q ->
                       ((),) Control.<$> MQ.writeMQueue q (Divide work sink)
                     Control.pure source
-              q <- MQ.writeMQueue q (Unite sources sink)
-              Control.pure q
+              MQ.writeMQueue q (Unite sources sink)
         Unite sources sink -> Control.do
           case conquer of
             NoOp -> Control.do

--- a/src/Control/Concurrent/DivideConquer/Utils/BMQueue/Linear.hs
+++ b/src/Control/Concurrent/DivideConquer/Utils/BMQueue/Linear.hs
@@ -1,0 +1,121 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE ImpredicativeTypes #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE LinearTypes #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE MultiWayIf #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE QualifiedDo #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UnboxedTuples #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# OPTIONS_GHC -Wno-name-shadowing #-}
+{-# OPTIONS_GHC -Wno-partial-type-signatures #-}
+
+{- | NOTE: This is only for internal use, and is not meant to be used by end users.
+This is because multiple existence of @'Mut' α 'BMQueue'@ breaks purity!
+-}
+module Control.Concurrent.DivideConquer.Utils.BMQueue.Linear (
+  BMQueue,
+  newBMQueue,
+  unsafeClone,
+  unsafeCloneN,
+  writeBMQueue,
+  writeBMQueueMany,
+  readBMQueue,
+  closeBMQueue,
+) where
+
+import Control.Concurrent.STM (atomically)
+import Control.Concurrent.STM.TBMQueue (TBMQueue)
+import Control.Concurrent.STM.TBMQueue qualified as TBMQ
+import Control.Functor.Linear qualified as Control
+import Control.Monad.Borrow.Pure
+import Control.Monad.Borrow.Pure.Internal
+import Control.Monad.STM (STM)
+import Data.Coerce qualified as NonLinear
+import Data.Functor.Linear qualified as Data
+import Data.Unrestricted.Linear (UrT (..), runUrT)
+import Data.V.Linear (V)
+import Data.V.Linear qualified as V
+import GHC.Conc qualified as GHC
+import GHC.Exts qualified as GHC
+import GHC.IO qualified as GHC
+import GHC.TypeLits (ErrorMessage (..), KnownNat)
+import Prelude.Linear
+import Prelude.Linear.Unsatisfiable
+import Unsafe.Linear qualified as Unsafe
+import Prelude qualified as NonLinear
+
+-- | A bounded closable queue
+newtype BMQueue a = MkBMQ (TBMQueue a)
+
+newBMQueue ::
+  forall α a.
+  Int ->
+  Linearly %1 ->
+  BO α (Mut α (BMQueue a), Lend α (BMQueue a))
+newBMQueue n lin = Control.do
+  q <- unsafeSystemIOToBO $ MkBMQ NonLinear.<$> TBMQ.newTBMQueueIO n
+  Control.pure $ borrow q lin
+
+instance
+  (Unsatisfiable (ShowType (BMQueue a) :<>: Text " cannot be dereferenced!")) =>
+  Derefable (BMQueue a)
+  where
+  unsafeDeref = unsatisfiable
+
+-- | NOTE: unconditional use of this function MAY BREAK PURITY!
+unsafeClone :: Mut α (BMQueue a) %1 -> (Mut α (BMQueue a), Mut α (BMQueue a))
+unsafeClone = Unsafe.toLinear \mut -> (mut, mut)
+
+-- | NOTE: unconditional use of this function MAY BREAK PURITY!
+unsafeCloneN :: forall n α a. (KnownNat n) => Mut α (BMQueue a) %1 -> V n (Mut α (BMQueue a))
+unsafeCloneN = Unsafe.toLinear \q ->
+  V.fromReplicator (Data.pure q)
+
+writeBMQueue ::
+  Mut α (BMQueue a) %1 ->
+  a %1 ->
+  BO α (Mut α (BMQueue a))
+writeBMQueue = Unsafe.toLinear2 \q a -> Control.do
+  unsafeSystemIOToBO $ q NonLinear.<$ atomically (TBMQ.writeTBMQueue (NonLinear.coerce q) a)
+
+writeBMQueueMany ::
+  (Data.Traversable t, Consumable (t ())) =>
+  Mut α (BMQueue a) %1 ->
+  t a %1 ->
+  BO α (Mut α (BMQueue a))
+writeBMQueueMany = Unsafe.toLinear2 \q as ->
+  Control.fmap (`lseq` q)
+    $ unsafeAtomically
+    $ Data.traverse (unsafeSTMToBO . Unsafe.toLinear (TBMQ.writeTBMQueue (NonLinear.coerce q))) as
+
+readBMQueue :: Mut α (BMQueue a) %1 -> BO α (Maybe (a, Mut α (BMQueue a)))
+readBMQueue = Unsafe.toLinear \mutq@(UnsafeMut (MkBMQ q)) ->
+  unsafeSystemIOToBO (atomically $ TBMQ.readTBMQueue q) Control.<&> \case
+    Nothing -> mutq `lseq` Nothing
+    Just a -> Just (a, mutq)
+
+unsafeSTMToBO :: STM a %1 -> BO α a
+unsafeSTMToBO (GHC.STM f) = BO (Unsafe.coerce f)
+
+unsafeAtomically :: BO α a %1 -> BO α a
+unsafeAtomically = Unsafe.toLinear \(BO f) -> unsafeSystemIOToBO (atomically (GHC.STM (Unsafe.coerce f)))
+
+closeBMQueue :: Mut α (BMQueue a) %1 -> BO α ()
+closeBMQueue = Unsafe.toLinear \(UnsafeMut (MkBMQ q)) ->
+  unsafeSystemIOToBO $ atomically $ TBMQ.closeTBMQueue q
+
+instance Consumable (BMQueue a) where
+  {-# NOINLINE consume #-}
+  consume = GHC.noinline $ Unsafe.toLinear \(MkBMQ q) -> do
+    case GHC.runRW# (GHC.unIO (atomically $ TBMQ.closeTBMQueue q)) of
+      (# _, () #) -> ()

--- a/src/Control/Concurrent/DivideConquer/Utils/BMQueue/Linear.hs
+++ b/src/Control/Concurrent/DivideConquer/Utils/BMQueue/Linear.hs
@@ -42,7 +42,6 @@ import Control.Monad.Borrow.Pure.Internal
 import Control.Monad.STM (STM)
 import Data.Coerce qualified as NonLinear
 import Data.Functor.Linear qualified as Data
-import Data.Unrestricted.Linear (UrT (..), runUrT)
 import Data.V.Linear (V)
 import Data.V.Linear qualified as V
 import GHC.Conc qualified as GHC

--- a/src/Control/Monad/Borrow/Pure.hs
+++ b/src/Control/Monad/Borrow/Pure.hs
@@ -148,13 +148,13 @@ reborrowing ::
   Mut α a %1 ->
   (forall β. (β <= α) => Mut β a -> BO β (End β -> r)) %1 ->
   BO α (r, Mut α a)
-reborrowing mutα k = DataFlow.do
-  (lin, v) <- withLinearly mutα
-  scope lin \(Proxy :: Proxy β) ->
-    reborrow v & \(v, lend) ->
-      Control.do
-        v <- k v
-        Control.pure $ \end -> (v (upcast end), reclaim (upcast end) lend)
+reborrowing mutα k =
+  withLinearly mutα & \(lin, v) ->
+    scope lin \(Proxy :: Proxy β) ->
+      reborrow v & \(v, lend) ->
+        Control.do
+          v <- k v
+          Control.pure $ \end -> (v (upcast end), reclaim (upcast end) lend)
 
 reborrowing_ ::
   Mut α a %1 ->

--- a/src/Control/Monad/Borrow/Pure.hs
+++ b/src/Control/Monad/Borrow/Pure.hs
@@ -151,8 +151,7 @@ reborrowing ::
 reborrowing mutα k = DataFlow.do
   (lin, v) <- withLinearly mutα
   scope lin \(Proxy :: Proxy β) ->
-    DataFlow.do
-      (v, lend) <- reborrow v
+    reborrow v & \(v, lend) ->
       Control.do
         v <- k v
         Control.pure $ \end -> (v (upcast end), reclaim (upcast end) lend)

--- a/src/Control/Monad/Borrow/Pure.hs
+++ b/src/Control/Monad/Borrow/Pure.hs
@@ -27,6 +27,9 @@ module Control.Monad.Borrow.Pure (
   borrow,
   borrow_,
   sharing,
+  sharing_,
+  reborrowing,
+  reborrowing_,
   share,
   reclaim,
   reborrow,
@@ -81,7 +84,7 @@ runBO lin bo =
     MkSomeNow now -> DataFlow.do
       (now, f) <- execBO bo now
       case endLifetime now of
-        Ur end -> f end 
+        Ur end -> f end
 
 runBOLend :: Linearly %1 -> (forall α. BO α (Lend α a)) %1 -> a
 {-# INLINE runBOLend #-}
@@ -110,11 +113,26 @@ scope = flip srunBO
 
 {- | Executes an operation on 'Share'd reference in sub lifetime.
 You may need @-XImpredicativeTypes@ extension to use this function.
+
+See also: 'sharing'.
+-}
+sharing_ ::
+  forall α a r.
+  Mut α a %1 ->
+  (forall β. (β <= α) => Share β a -> BO β r) %1 ->
+  BO α (r, Mut α a)
+{-# INLINE sharing_ #-}
+sharing_ v k = sharing v (\mut -> k mut Control.<&> \a _ -> a)
+
+{- | Executes an operation on 'Share'd reference in sub lifetime.
+You may need @-XImpredicativeTypes@ extension to use this function.
+
+See also: 'sharing_'.
 -}
 sharing ::
   forall α a r.
   Mut α a %1 ->
-  (forall β. (β <= α) => Share β a -> BO β r) %1 ->
+  (forall β. (β <= α) => Share β a -> BO β (End β -> r)) %1 ->
   BO α (r, Mut α a)
 {-# INLINE sharing #-}
 sharing v k = DataFlow.do
@@ -124,4 +142,23 @@ sharing v k = DataFlow.do
       (v, lend) <- reborrow v
       share v & \(Ur v) -> Control.do
         v <- k v
-        Control.pure $ \end -> (v, reclaim (upcast end) lend)
+        Control.pure $ \end -> (v (upcast end), reclaim (upcast end) lend)
+
+reborrowing ::
+  Mut α a %1 ->
+  (forall β. (β <= α) => Mut β a -> BO β (End β -> r)) %1 ->
+  BO α (r, Mut α a)
+reborrowing mutα k = DataFlow.do
+  (lin, v) <- withLinearly mutα
+  scope lin \(Proxy :: Proxy β) ->
+    DataFlow.do
+      (v, lend) <- reborrow v
+      Control.do
+        v <- k v
+        Control.pure $ \end -> (v (upcast end), reclaim (upcast end) lend)
+
+reborrowing_ ::
+  Mut α a %1 ->
+  (forall β. (β <= α) => Mut β a -> BO β r) %1 ->
+  BO α (r, Mut α a)
+reborrowing_ mutα k = reborrowing mutα (\mut -> k mut Control.<&> \a _ -> a)

--- a/src/Control/Monad/Borrow/Pure/Affine/Internal.hs
+++ b/src/Control/Monad/Borrow/Pure/Affine/Internal.hs
@@ -171,6 +171,9 @@ deriving via (Maybe a) instance (Affable a) => Affable (Mon.Last a)
 
 -- * Generics
 
+{- | We need this instead of 'Generically' becuase
+it gives a different 'Consumable' instance.
+-}
 newtype GenericallyAffable a = GenericallyAffable a
 
 unGenericallyAffable :: GenericallyAffable a %1 -> a

--- a/src/Data/OnceChan/Linear.hs
+++ b/src/Data/OnceChan/Linear.hs
@@ -1,0 +1,63 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE QualifiedDo #-}
+{-# LANGUAGE RoleAnnotations #-}
+{-# LANGUAGE UnboxedTuples #-}
+{-# LANGUAGE UnliftedNewtypes #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# OPTIONS_GHC -Wno-name-shadowing #-}
+
+module Data.OnceChan.Linear (
+  Sink,
+  Source,
+  new,
+  put,
+  take,
+) where
+
+import Control.Monad.Borrow.Pure.Affine.Internal
+import Control.Monad.Borrow.Pure.Internal
+import Control.Monad.Borrow.Pure.Lifetime.Token.Internal
+import Data.OnceChan.Linear.Unlifted
+import Data.Unrestricted.Linear
+import Prelude.Linear hiding (take)
+import Unsafe.Linear qualified as Unsafe
+
+data Sink a = Sink (Sink# a)
+
+data Source a = Source (Source# a)
+
+type role Sink nominal
+
+type role Source representational
+
+new :: Linearly %1 -> (Sink a, Source a)
+{-# INLINE new #-}
+new lin = case new# lin of
+  (# sink, source #) -> (Sink sink, Source source)
+
+instance LinearOnly (Sink a) where
+  unsafeWithLinear = unsafeLinearOnly
+
+instance LinearOnly (Source a) where
+  unsafeWithLinear = unsafeLinearOnly
+
+instance Affable (Sink a) where
+  aff = Unsafe.toLinear UnsafeAff
+
+instance Consumable (Sink a) where
+  consume = Unsafe.toLinear \(Sink !_) -> ()
+
+instance Consumable (Source a) where
+  consume = Unsafe.toLinear \(Source !_) -> ()
+
+instance Affable (Source a) where
+  aff = Unsafe.toLinear UnsafeAff
+
+take :: Source a %1 -> BO α a
+{-# INLINE take #-}
+take (Source v) = evaluate $ take# v
+
+put :: Sink a %1 -> a %1 -> BO α ()
+{-# INLINE put #-}
+put (Sink v) !a = evaluate $ put# v a

--- a/src/Data/OnceChan/Linear/Unlifted.hs
+++ b/src/Data/OnceChan/Linear/Unlifted.hs
@@ -1,0 +1,56 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE RoleAnnotations #-}
+{-# LANGUAGE UnboxedTuples #-}
+{-# LANGUAGE UnliftedNewtypes #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# OPTIONS_GHC -Wno-name-shadowing #-}
+
+module Data.OnceChan.Linear.Unlifted (
+  Sink#,
+  Source#,
+  new#,
+  put#,
+  take#,
+) where
+
+import Control.Monad.Borrow.Pure.Lifetime.Token
+import Control.Monad.Borrow.Pure.Lifetime.Token.Internal
+import GHC.Exts qualified as GHC
+import Prelude.Linear
+import Unsafe.Linear qualified as Unsafe
+
+newtype Source# a = Source# (GHC.MVar# GHC.RealWorld a)
+
+newtype Sink# a = Sink# (GHC.MVar# GHC.RealWorld a)
+
+type role Source# representational
+
+type role Sink# nominal
+
+new# :: Linearly %1 -> (# Sink# a, Source# a #)
+{-# NOINLINE new# #-}
+new# = GHC.noinline $ Unsafe.toLinear $ \_ ->
+  GHC.runRW# \s ->
+    case GHC.newMVar# s of
+      (# _, !v #) -> (# Sink# v, Source# v #)
+
+take# :: Source# a %1 -> a
+{-# INLINE take# #-}
+take# = GHC.noinline $ Unsafe.toLinear \(Source# mv) ->
+  GHC.runRW# \s ->
+    case GHC.takeMVar# mv s of
+      (# _, !a #) -> a
+
+put# :: Sink# a %1 -> a %1 -> ()
+{-# NOINLINE put# #-}
+put# = GHC.noinline $ Unsafe.toLinear2 \(Sink# mv) !a ->
+  GHC.runRW# \s ->
+    case GHC.putMVar# mv a s of
+      !_ -> ()
+
+instance LinearOnly (Sink# a) where
+  unsafeWithLinear = unsafeLinearOnly
+
+instance LinearOnly (Source# a) where
+  unsafeWithLinear = unsafeLinearOnly

--- a/src/Data/Vector/Mutable/Linear/Borrow.hs
+++ b/src/Data/Vector/Mutable/Linear/Borrow.hs
@@ -273,12 +273,12 @@ qsort = go
       (Ur n, v) ->
         let i = n `quot` 2
          in Control.do
-              (pivot, v) <- sharing v \v ->
+              (pivot, v) <- sharing_ v \v ->
                 move . derefShare Control.<$> unsafeGet i v
               pivot & \(Ur pivot) -> Control.do
                 (lo, hi) <- divide pivot v 0 n
                 let b' = budget `quot` 2
-                Control.void $ parIf (b' NonLinear.> 0) (go b' lo) (go b' hi) 
+                Control.void $ parIf (b' NonLinear.> 0) (go b' lo) (go b' hi)
 
 parIf :: Bool %1 -> BO α a %1 -> BO α b %1 -> BO α (a, b)
 {-# INLINE parIf #-}
@@ -302,14 +302,14 @@ divide pivot = partUp
   where
     partUp v l u
       | l < u = Control.do
-          (e, v) <- sharing v $ Control.fmap derefShare . unsafeGet l
+          (e, v) <- sharing_ v $ Control.fmap derefShare . unsafeGet l
           if e < pivot
             then partUp v (l + 1) u
             else partDown v l (u - 1)
       | otherwise = Control.pure $ splitAtMut l v
     partDown v l u
       | l < u = Control.do
-          (e, v) <- sharing v $ Control.fmap derefShare . unsafeGet u
+          (e, v) <- sharing_ v $ Control.fmap derefShare . unsafeGet u
           if pivot < e
             then partDown v l (u - 1)
             else Control.do

--- a/test/Control/Concurrent/DivideConquer/LinearSpec.hs
+++ b/test/Control/Concurrent/DivideConquer/LinearSpec.hs
@@ -55,5 +55,5 @@ qsortDCVec v = unur $ unur $ linearly \lin -> DataFlow.do
   runBO l1
     $ borrow (VL.fromVector v l2) l3
     & \(v, lend) -> Control.do
-      Control.void $ divideAndConquer 10 (qsortDC 8) v
+      Control.void $ divideAndConquer 10 (qsortDC 16) v
       Control.pure \end -> VL.toVector (reclaim end lend)

--- a/test/Control/Concurrent/DivideConquer/LinearSpec.hs
+++ b/test/Control/Concurrent/DivideConquer/LinearSpec.hs
@@ -1,0 +1,59 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE ImpredicativeTypes #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE LinearTypes #-}
+{-# LANGUAGE QualifiedDo #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# OPTIONS_GHC -Wno-name-shadowing #-}
+
+module Control.Concurrent.DivideConquer.LinearSpec (
+  module Control.Concurrent.DivideConquer.LinearSpec,
+) where
+
+import Control.Concurrent.DivideConquer.Linear
+import Control.Functor.Linear qualified as Control
+import Control.Monad.Borrow.Pure
+import Control.Syntax.DataFlow qualified as DataFlow
+import Data.List qualified as List
+import Data.List qualified as NonLinear
+import Data.Vector qualified as V
+import Data.Vector.Mutable.Linear.Borrow qualified as VL
+import Prelude.Linear
+import Test.Falsify.Generator qualified as G
+import Test.Falsify.Predicate qualified as P
+import Test.Falsify.Range qualified as G
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.Falsify (testProperty)
+import Test.Tasty.Falsify qualified as F
+import Test.Tasty.HUnit (testCase, (@?=))
+import Prelude qualified as NonLinear
+
+test_qsort :: TestTree
+test_qsort =
+  testGroup
+    "qsort"
+    [ testCase "empty" do
+        qsortDCVec (V.empty @Int) @?= V.empty
+    , testProperty "coincides with Data.List.sort on Ints" do
+        xs <- F.gen $ G.list (G.between (1, 100)) $ G.int $ G.between (-100, 100)
+        let v = V.fromList xs
+            sorted = qsortDCVec v
+        F.collect "length" [ceiling @_ @Int (fromIntegral @_ @Double (V.length v) / 10) * 10]
+        F.collect "min" [NonLinear.minimum v `quot` 10 * 10]
+        F.collect "max" [NonLinear.maximum v `quot` 10 * 10]
+        F.collect "sorted" [V.and $ V.zipWith (NonLinear.<=) v (V.tail v)]
+        F.info $ "input: " <> show xs
+        F.assert
+          $ P.expect (V.fromList $ List.sort xs)
+          P..$ ("output", sorted)
+    ]
+
+qsortDCVec :: (Ord a, Movable a, Derefable a) => V.Vector a -> V.Vector a
+qsortDCVec v = unur $ unur $ linearly \lin -> DataFlow.do
+  (l1, l2, l3) <- dup3 lin
+  runBO l1
+    $ borrow (VL.fromVector v l2) l3
+    & \(v, lend) -> Control.do
+      Control.void $ divideAndConquer 10 (qsortDC 8) v
+      Control.pure \end -> VL.toVector (reclaim end lend)


### PR DESCRIPTION
- Implements `Control.Concurrent.DivideConquer.Linear` module that provides general work-stealing scheduler for divide-and-conquer problem (currently without post-processing)
  + This would suffice for quicksort
- Some additional data structures
  + `OnceChan`: a one-time concurrent channel with separate sink / (blocking) source interface
    * With deterministic interface, this API should be morally safe.
    * Exposed to the user
  + MQueue: closeable concurrent queue
    * Uses STM `TMQueue` under the hood
    * This API should be **unasfe**, and hence unexposed to external package (even Internal module is unavailable to endusers).
      - Reason: It allows nonrestricted cloning and hence it allows to share mutable references across the threads, hence highly impure!
    * I believe the usage in `DivideConquer` should morally be safe.
- New combinator `reborrowing` to create a sub-lifetime and temporarily lend `Mut` to it.