### PR TITLE
perf(borrow): inline BO hot paths and add the Par applicative

### DIFF
--- a/pure-borrow.cabal
+++ b/pure-borrow.cabal
@@ -142,6 +142,7 @@ test-suite pure-borrow-test
   -- cabal-gild: discover test --exclude=test/Main.hs
   other-modules:
     Control.Concurrent.DivideConquer.LinearSpec
+    Control.Monad.Borrow.Pure.BOSpec
     Control.Monad.Borrow.Pure.Lifetime.TypingCases
     Control.Monad.Borrow.Pure.LifetimeSpec
     Data.Vector.Mutable.Linear.BorrowSpec

--- a/src/Control/Concurrent/DivideConquer/Linear.hs
+++ b/src/Control/Concurrent/DivideConquer/Linear.hs
@@ -269,27 +269,6 @@ sequentialDivideAndConquer' DivideConquer {..} ini = reborrowing ini \ini -> Con
           NoConquer -> Control.pure $ consume (x, rs)
           Conquer conq -> conq c x rs
 
-newtype Par α a = Par (BO α a)
-  deriving newtype (Data.Functor, Control.Functor)
-
-runPar :: Par α a %1 -> BO α a
-runPar = coerceLin
-{-# INLINE runPar #-}
-
-instance Data.Applicative (Par α) where
-  pure = Par NonLinear.. Data.pure
-  {-# INLINE pure #-}
-  Par f <*> Par x = Par Control.do
-    (f, x) <- parBO f x
-    Control.pure $ f x
-
-instance Control.Applicative (Par α) where
-  pure = Par . Control.pure
-  {-# INLINE pure #-}
-  Par f <*> Par x = Par Control.do
-    (f, x) <- parBO f x
-    Control.pure $ f x
-
 naiveDivideAndConquer ::
   forall c α t a.
   (Data.Traversable t, Consumable (t ())) =>

--- a/src/Control/Monad/Borrow/Pure.hs
+++ b/src/Control/Monad/Borrow/Pure.hs
@@ -53,6 +53,10 @@ module Control.Monad.Borrow.Pure (
 
   -- * Parallel computation
   parBO,
+  Par (..),
+  runPar,
+  mapConcurrentlyOf,
+  forConcurrentlyOf,
 
   -- * Borrowing
   -- $borrow
@@ -97,6 +101,7 @@ module Control.Monad.Borrow.Pure (
   -- ** Utility function to manipulate borrows
   joinMut,
   joinLend,
+  subShare,
   coerceShare,
 
   -- ** Copying and Cloning
@@ -126,7 +131,10 @@ module Control.Monad.Borrow.Pure (
 import Control.Monad.Borrow.Pure.BO
 import Control.Monad.Borrow.Pure.Clone
 import Control.Monad.Borrow.Pure.Copyable
+import Control.Optics.Linear (Traversal, traverseOf)
 import Data.Unrestricted.Linear (Consumable (..), Dupable (..), Movable (..), Ur (..), dup, dup3)
+import Prelude.Linear (($), (.))
+import Prelude.Linear qualified as PL
 
 {- $setup
 >>> :set -XBlockArguments -XLinearTypes -XNoImplicitPrelude -XImpredicativeTypes -XQualifiedDo
@@ -402,6 +410,25 @@ Hence, if you see @'Borrow' bk α a@ in a function, it can be either 'Mut' or 'S
     * Use 'sharing' or 'sharing_' to share temporarily and then regain the original 'Mut'.
     * Use 'reborrowing' or 'reborrowing_' to create a shorter-lived 'Mut' and then regain the original 'Mut'.
     * Use 'reclaim' or 'reclaim'' to recover the original resource from a 'Lend' after the lifetime ends.
+
+== Performance-sensitive loops
+
+Choose the loop structure that performs the least algorithmic work first. With
+the surrounding functions properly inlined, one 'sharing' or 'reborrowing' per
+iteration is normally cheap. For an otherwise read-only loop, however, prefer
+sharing once outside the loop and shortening that shared borrow inside each
+iteration with 'subShare':
+
+@
+'share' resource \& \('Ur' shared) ->
+  ... 'subShare' shared ...
+@
+
+This avoids opening and reclaiming a sublifetime merely to read the same
+resource. Functions containing hot loops over operations that return
+@(Ur a, container)@ should themselves be @INLINE@, @INLINABLE@, or specialised.
+That lets GHC eliminate the transient tuple and 'Ur' constructors; without
+cross-module inlining those constructors can allocate on every read.
 -}
 
 {- $copy-and-clone
@@ -435,6 +462,11 @@ For possibly mutable types, you can still 'clone' them out of borrows linearly i
 
 This includes, for example, 'Data.Ref.Linear.Ref' or 'Data.Vector.Mutable.Linear.Borrow.Vector'.
 The fact that the 'clone'd value is only accessible inside 'BO' ensures that we cannot leak mutable states inside @a@ into /unrestricted/ contexts -- otherwise, we can introduce mutable values into unrestricted context via @'move' :: 'Share' α a -> 'Ur' ('Share' α a)@.
+
+In performance-sensitive loops, moving a whole structured value can be a sign
+of an avoidable deep copy, particularly for generically derived 'Movable'
+instances. Prefer operating through the borrow or returning only the required
+unrestricted fields in 'Ur' rather than moving the enclosing structure.
 -}
 
 {- $splitting
@@ -451,3 +483,17 @@ It is morally an instance method of the 'DistributesAlias' class, and you can de
 
 We also provide experimental splitting on record types in "Data.Record.Linear.Borrow.Experimental.PatternMatch" and "Data.Record.Linear.Borrow.Experimental.Split".
 -}
+
+mapConcurrentlyOf ::
+  Traversal s t a b ->
+  (a %1 -> BO α b) ->
+  s %1 ->
+  BO α t
+mapConcurrentlyOf l f = runPar . traverseOf l (Par . f)
+
+forConcurrentlyOf ::
+  Traversal s t a b ->
+  s %1 ->
+  (a %1 -> BO α b) ->
+  BO α t
+forConcurrentlyOf l = PL.flip (mapConcurrentlyOf l)

--- a/src/Control/Monad/Borrow/Pure/BO.hs
+++ b/src/Control/Monad/Borrow/Pure/BO.hs
@@ -41,6 +41,8 @@ module Control.Monad.Borrow.Pure.BO (
 
   -- * Parallel computation
   parBO,
+  Par (..),
+  runPar,
 
   -- * Borrowing
   Alias,
@@ -50,6 +52,7 @@ module Control.Monad.Borrow.Pure.BO (
   Mut,
   Share,
   Lend,
+  subShare,
   coerceShare,
   shareCoercion,
   borrowM,
@@ -111,6 +114,8 @@ import Control.Monad.Borrow.Pure.Utils (coerceLin)
 import Control.Syntax.DataFlow qualified as DataFlow
 import Data.Coerce (Coercible)
 import Data.Coerce.Directed
+import Data.Function qualified as NonLinear
+import Data.Functor.Linear qualified as Data
 import Data.Type.Coercion (Coercion (..))
 import Prelude.Linear
 
@@ -340,6 +345,16 @@ pureAfter :: ((End α) => a) %1 -> BO α (After α a)
 {-# INLINE pureAfter #-}
 pureAfter a = Control.pure (After a)
 
+{- | Shorten a shared borrow to a sublifetime.
+
+This is the inference-friendly, borrow-kind-fixed variant of 'upcast'. It is
+particularly useful when a shared borrow is captured outside a read-only loop
+and must be used inside the loop's shorter lifetime.
+-}
+subShare :: (α >= β) => Share α a -> Share β a
+{-# INLINE subShare #-}
+subShare shr = upcast shr
+
 coerceShare :: forall b α a. (Coercible a b) => Share α a %1 -> Share α b
 {-# INLINE coerceShare #-}
 coerceShare = coerceLin
@@ -378,3 +393,37 @@ srunBO bo = asksLinearlyM \lin ->
 srunBO_ :: (forall α. BO (α /\ β) a) %1 -> BO β a
 {-# INLINE srunBO_ #-}
 srunBO_ k = srunBO Control.do a <- k; Control.pure $ After a
+
+{- | A parallel comoutation applicative functor for 'BO' monad.
+All the computations chained by '<*>' or 'liftA2' will be executed in parallel.
+-}
+newtype Par α a = Par (BO α a)
+  deriving newtype (Data.Functor, Control.Functor)
+
+runPar :: Par α a %1 -> BO α a
+runPar = coerceLin
+{-# INLINE runPar #-}
+
+instance Data.Applicative (Par α) where
+  pure = Par NonLinear.. Data.pure
+  {-# INLINE pure #-}
+  Par f <*> Par x = Par Control.do
+    (f, x) <- parBO f x
+    Control.pure $ f x
+  {-# INLINE (<*>) #-}
+  liftA2 f (Par x) (Par y) = Par Control.do
+    (x, y) <- parBO x y
+    Control.pure $ f x y
+  {-# INLINE liftA2 #-}
+
+instance Control.Applicative (Par α) where
+  pure = Par . Control.pure
+  {-# INLINE pure #-}
+  Par f <*> Par x = Par Control.do
+    (f, x) <- parBO f x
+    Control.pure $ f x
+  {-# INLINE (<*>) #-}
+  liftA2 f (Par x) (Par y) = Par Control.do
+    (x, y) <- parBO x y
+    Control.pure $ f x y
+  {-# INLINE liftA2 #-}

--- a/src/Control/Monad/Borrow/Pure/BO/Internal.hs
+++ b/src/Control/Monad/Borrow/Pure/BO/Internal.hs
@@ -131,6 +131,11 @@ instance Data.Applicative (BO α) where
   (<*>) = \f g -> f Control.<*> g
   {-# INLINE (<*>) #-}
 
+  liftA2 f (BO g) (BO h) = BO \s -> case g s of
+    (# s', a #) -> case h s' of
+      (# s'', b #) -> (# s'', f a b #)
+  {-# INLINE liftA2 #-}
+
 instance Control.Applicative (BO α) where
   pure a = BO \s -> (# s, a #)
   {-# INLINE pure #-}
@@ -140,10 +145,19 @@ instance Control.Applicative (BO α) where
       (# s'', a #) -> (# s'', h a #)
   {-# INLINE (<*>) #-}
 
+  liftA2 f (BO g) (BO h) = BO \s -> case g s of
+    (# s', a #) -> case h s' of
+      (# s'', b #) -> (# s'', f a b #)
+  {-# INLINE liftA2 #-}
+
 instance Control.Monad (BO α) where
   BO fa >>= f = BO \s -> case fa s of
     (# s', a #) -> (f a) PL.& \(BO g) -> g s'
   {-# INLINE (>>=) #-}
+
+  BO fa >> BO fb = BO \s -> case fa s of
+    (# s', () #) -> fb s'
+  {-# INLINE (>>) #-}
 
 -- | Unsafely converts a 'BO' computation to linear 'L.IO'.
 unsafeBOToLinIO :: BO α a %1 -> L.IO a

--- a/src/Control/Monad/Borrow/Pure/Experimental/Loop.hs
+++ b/src/Control/Monad/Borrow/Pure/Experimental/Loop.hs
@@ -21,6 +21,12 @@
 {- |
 This module provides 'Foldable' class, and provides a way to loop through it while reborrowing existing 'Borrow's into sublifetime.
 The module also introduces 'Borrows', which is a heterogeneous list of 'Borrow's in the same lifetime.
+
+For performance-sensitive code, choose the loop's algorithmic structure before
+trying to avoid sublifetimes. If a loop only reads a stable resource, share it
+once outside the loop, capture the resulting 'Share', and use 'subShare' inside
+the iteration. Keep the loop worker @INLINE@ or @INLINABLE@ so 'Ur'-boxed reads
+can be eliminated by the optimiser.
 -}
 module Control.Monad.Borrow.Pure.Experimental.Loop (
   Borrows (..),

--- a/src/Control/Monad/Borrow/Pure/Lifetime/Token/Internal.hs
+++ b/src/Control/Monad/Borrow/Pure/Lifetime/Token/Internal.hs
@@ -106,16 +106,22 @@ instance Data.Applicative (After α) where
   {-# INLINE pure #-}
   After f <*> After r = After (f r)
   {-# INLINE (<*>) #-}
+  liftA2 f (After a) (After b) = After (f a b)
+  {-# INLINE liftA2 #-}
 
 instance Control.Applicative (After α) where
   pure a = After a
   {-# INLINE pure #-}
   After f <*> After r = After (f r)
   {-# INLINE (<*>) #-}
+  liftA2 f (After a) (After b) = After (f a b)
+  {-# INLINE liftA2 #-}
 
 instance Control.Monad (After α) where
   After r >>= k = After (unAfter (k r))
   {-# INLINE (>>=) #-}
+  After r >> After a = After (r `lseq` a)
+  {-# INLINE (>>) #-}
 
 -- | Witness that the current computation is in a linear context.
 data Linearly = UnsafeLinearly

--- a/src/Data/Ref/Linear/Borrow.hs
+++ b/src/Data/Ref/Linear/Borrow.hs
@@ -31,6 +31,14 @@ import Prelude.Linear
 import Unsafe.Linear qualified as Unsafe
 import Prelude qualified as NonLinear
 
+{- | Perform one read-modify-write traversal and return an auxiliary result.
+
+This is the canonical operation when a mutation must also report what it
+observed: for example, an insert can return the displaced old value and use it
+to detect a collision without a separate lookup. Prefer this shape over
+lookup-then-update in hot paths, since the latter silently traverses the
+underlying structure twice.
+-}
 update :: (α >= β) => (a %1 -> BO β (b, a)) %1 -> Mut α (Ref a) %1 -> BO β (b, Mut α (Ref a))
 {-# INLINE update #-}
 update f (UnsafeAlias mv) = DataFlow.do

--- a/test/Control/Monad/Borrow/Pure/BOSpec.hs
+++ b/test/Control/Monad/Borrow/Pure/BOSpec.hs
@@ -1,0 +1,34 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE LinearTypes #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module Control.Monad.Borrow.Pure.BOSpec (
+  module Control.Monad.Borrow.Pure.BOSpec,
+) where
+
+import Control.Functor.Linear qualified as Control
+import Control.Monad.Borrow.Pure
+import Data.Functor.Linear qualified as Data
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (testCase, (@?=))
+import Unsafe.Linear qualified as Unsafe
+import Prelude (Int, ($), (+))
+
+shortenShare :: (α >= β) => Share α a -> Share β a
+shortenShare = subShare
+
+addLinear :: Int %1 -> Int %1 -> Int
+addLinear = Unsafe.toLinear2 (+)
+
+test_instanceMethods :: TestTree
+test_instanceMethods =
+  testGroup
+    "BO instance methods"
+    [ testCase "linear liftA2" $
+        linearly (\lin -> runBO_ lin (Control.liftA2 addLinear (Control.pure 20) (Control.pure 22))) @?= (42 :: Int)
+    , testCase "non-linear liftA2" $
+        linearly (\lin -> runBO_ lin (Data.liftA2 addLinear (Data.pure 20) (Data.pure 22))) @?= (42 :: Int)
+    , testCase "linear sequencing" $
+        linearly (\lin -> runBO_ lin (Control.pure () Control.>> Control.pure 42)) @?= (42 :: Int)
+    ]


### PR DESCRIPTION
Two related pieces of work on the core monad.

Hot paths. `BO`'s `Applicative`/`Monad` instances now define `liftA2` and
`(>>)` directly instead of inheriting the default definitions, which
built and immediately deconstructed closures on every bind. `INLINE`
pragmas are added across `BO`, `Experimental.Loop`,
`Lifetime.Token.Internal`, `Data.Ref.Linear.Borrow` and the
divide-and-conquer skeleton so these definitions are visible across
module boundaries; without that, the transient `Ur`/tuple constructors
returned by borrow reads allocate on every iteration.

`subShare` is added as the inference-friendly, borrow-kind-fixed variant
of `upcast`: an otherwise read-only loop can now share once outside the
loop and shorten the shared borrow per iteration, instead of opening and
reclaiming a sublifetime just to read the same resource. The umbrella
module gains a tutorial section describing when to reach for it.

Par. The `Par` applicative — where `(<*>)` and `liftA2` run their
operands through `parBO` — moves out of `Control.Concurrent.
DivideConquer.Linear`, where it was private, into
`Control.Monad.Borrow.Pure.BO`, and is re-exported from the umbrella
module together with `runPar`. `mapConcurrentlyOf` and
`forConcurrentlyOf` build on it to run a linear traversal's effects in
parallel.
Part of #14.