### PR TITLE
refactor(borrow): index AliasKind by lifetime

### DIFF
--- a/src/Control/Concurrent/DivideConquer/Linear.hs
+++ b/src/Control/Concurrent/DivideConquer/Linear.hs
@@ -54,7 +54,6 @@ import Control.Monad.Borrow.Pure.BO.Unsafe
 import Control.Monad.Borrow.Pure.Copyable
 import Control.Monad.Borrow.Pure.Experimental.Borrows
 import Control.Monad.Borrow.Pure.Experimental.Loop (iterReborrowing_)
-import Control.Monad.Borrow.Pure.Utils (coerceLin)
 import Data.Bifunctor.Linear qualified as BiL
 import Data.Bits (bit, popCount, shiftR)
 import Data.Complex (Complex (..))
@@ -75,7 +74,6 @@ import Prelude.Linear hiding (foldMap)
 import Prelude.Linear.Generically (Generically, Generically1)
 import System.Random (RandomGen)
 import Unsafe.Linear qualified as Unsafe
-import Prelude qualified as NonLinear
 import Prelude qualified as P
 
 data DivideConquer c α t a r = DivideConquer

--- a/src/Control/Monad/Borrow/Pure.hs
+++ b/src/Control/Monad/Borrow/Pure.hs
@@ -133,7 +133,7 @@ import Control.Monad.Borrow.Pure.Clone
 import Control.Monad.Borrow.Pure.Copyable
 import Control.Optics.Linear (Traversal, traverseOf)
 import Data.Unrestricted.Linear (Consumable (..), Dupable (..), Movable (..), Ur (..), dup, dup3)
-import Prelude.Linear (($), (.))
+import Prelude.Linear ((.))
 import Prelude.Linear qualified as PL
 
 {- $setup

--- a/src/Control/Monad/Borrow/Pure/BO/Internal.hs
+++ b/src/Control/Monad/Borrow/Pure/BO/Internal.hs
@@ -16,6 +16,7 @@
 {-# LANGUAGE StandaloneKindSignatures #-}
 {-# LANGUAGE TypeData #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeFamilyDependencies #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE UnliftedNewtypes #-}
@@ -259,20 +260,20 @@ evaluateBO :: a %1 -> BO α a
 evaluateBO a = unsafeSystemIOToBO (Unsafe.toLinear SystemIO.evaluate a)
 
 -- | Alias of kind 'ak' to a resource of type 'a'.
-type Alias :: AliasKind -> Lifetime -> Type -> Type
-newtype Alias ak α a = UnsafeAlias a
+type Alias :: AliasKind -> Type -> Type
+newtype Alias ak a = UnsafeAlias a
 
-unsafeUnalias :: Alias ak α a %1 -> a
+unsafeUnalias :: Alias ak a %1 -> a
 unsafeUnalias (UnsafeAlias x) = x
 
-type role Alias nominal nominal representational
+type role Alias nominal representational
 
 -- | Alias kind.
 data AliasKind
   = -- | Borrower.
-    Borrow BorrowKind
+    Borrow BorrowKind Lifetime
   | -- | Lender.
-    Lend
+    Lend Lifetime
 
 -- | Borrower kind.
 data BorrowKind
@@ -283,11 +284,11 @@ data BorrowKind
 
 -- | Borrower of kind @bk@ that is active during the lifetime @α@.
 type Borrow :: BorrowKind -> Lifetime -> Type -> Type
-type Borrow bk = Alias ('Borrow bk)
+type Borrow bk α = Alias ('Borrow bk α)
 
 -- | Mutable borrower, which is affine and can update the data.
 type Mut :: Lifetime -> Type -> Type
-type Mut = Borrow 'Mut
+type Mut α = Borrow 'Mut α
 
 assocBorrowR ::
   Borrow bk ((α /\ β) /\ γ) a %1 ->
@@ -303,9 +304,9 @@ assocBorrowL = coerceLin
 
 assocBorrowEq ::
   forall bk α β γ a.
-  (Borrow bk ((α /\ β) /\ γ) a) :~: (Borrow bk (α /\ (β /\ γ)) a)
+  (Borrow (bk ((α /\ β) /\ γ)) a) :~: (Borrow (bk (α /\ (β /\ γ))) a)
 {-# INLINE assocBorrowEq #-}
-assocBorrowEq = Unsafe.coerce $ Refl @(Borrow bk (α /\ β /\ γ) a)
+assocBorrowEq = Unsafe.coerce $ Refl @(Borrow (bk ((α /\ β) /\ γ)) a)
 
 assocLendR ::
   Lend ((α /\ β) /\ γ) a %1 ->
@@ -326,21 +327,24 @@ assocLendEq = Unsafe.coerce $ Refl @(Lend (α /\ β /\ γ) a)
 instance (bk ~ 'Mut) => LinearOnly (Borrow bk α a) where
   linearOnly = UnsafeLinearOnly
 
-deriving via AsAffine (Borrow bk α a) instance Consumable (Borrow bk α a)
+deriving via
+  AsAffine (Alias bor a)
+  instance
+    (bor ~ ('Borrow bk α)) => Consumable (Alias bor a)
 
 -- | Shared borrower, which is unrestricted but usually can only read from the data.
 type Share :: Lifetime -> Type -> Type
-type Share = Borrow 'Share
+type Share α = Borrow 'Share α
 
-instance Affine (Borrow bk α a) where
+instance (ak ~ 'Borrow bk α) => Affine (Alias ak a) where
   aff = UnsafeAff
   {-# INLINE aff #-}
 
-instance (k ~ 'Borrow 'Share) => Dupable (Alias k α a) where
+instance (k ~ 'Borrow 'Share α) => Dupable (Alias k a) where
   dup2 = Unsafe.toLinear $ NonLinear.join (,)
   {-# INLINE dup2 #-}
 
-instance (k ~ 'Borrow 'Share) => Movable (Alias k α a) where
+instance (k ~ 'Borrow 'Share α) => Movable (Alias k a) where
   move = Unsafe.toLinear Ur
   {-# INLINE move #-}
 
@@ -355,7 +359,7 @@ instance (α >= β, a <: b) => Share α a <: Share β b where
 
 -- | Lender, which can retrieve the lifetime at the lifetime @α@.
 type Lend :: Lifetime -> Type -> Type
-type Lend = Alias 'Lend
+type Lend α = Alias ('Lend α)
 
 instance (α <= β, a <: b) => Lend α a <: Lend β b where
   subtype = UnsafeSubtype
@@ -395,16 +399,16 @@ joinLend = coerceLin
 
 -- | Distribute an alias over a functor.
 class DistributesAlias f where
-  split_ :: Alias ak α (f x) %1 -> f (Alias ak α x)
+  split_ :: Alias ak (f x) %1 -> f (Alias ak x)
   default split_ ::
     (GenericDistributesAlias f) =>
-    Alias ak α (f x) %1 -> f (Alias ak α x)
+    Alias ak (f x) %1 -> f (Alias ak x)
   split_ = genericSplit
 
 split ::
-  forall f x ak α.
+  forall f x ak.
   (DistributesAlias f) =>
-  Alias ak α (f x) %1 -> f (Alias ak α x)
+  Alias ak (f x) %1 -> f (Alias ak x)
 {-# INLINE [1] split #-}
 split = split_
 
@@ -432,11 +436,11 @@ deriving anyclass instance DistributesAlias Mon.First
 
 deriving anyclass instance DistributesAlias Mon.Last
 
-splitPair :: Alias ak α (a, b) %1 -> (Alias ak α a, Alias ak α b)
+splitPair :: Alias ak (a, b) %1 -> (Alias ak a, Alias ak b)
 {-# INLINE splitPair #-}
 splitPair = coerceLin
 
-splitEither :: Alias ak α (Either a b) %1 -> Either (Alias ak α a) (Alias ak α b)
+splitEither :: Alias ak (Either a b) %1 -> Either (Alias ak a) (Alias ak b)
 {-# INLINE splitEither #-}
 splitEither = coerceLin
 
@@ -451,16 +455,16 @@ instance (Unsatisfiable ('Text "Use splitPair instead!")) => DistributesAlias ((
 type GenericDistributesAlias f = (Generic1 f, GDistributeAlias (Rep1 f))
 
 genericSplit ::
-  forall f x ak α.
+  forall f x ak.
   (GenericDistributesAlias f) =>
-  Alias ak α (f x) %1 -> f (Alias ak α x)
+  Alias ak (f x) %1 -> f (Alias ak x)
 {-# INLINE genericSplit #-}
 genericSplit =
   to1
     . gdistributeAlias @(Rep1 f)
     . unsafeMapAlias from1
 
-unsafeMapAlias :: (a %1 -> b) %1 -> Alias ak α a %1 -> Alias ak α b
+unsafeMapAlias :: (a %1 -> b) %1 -> Alias ak a %1 -> Alias ak b
 {-# INLINE unsafeMapAlias #-}
 unsafeMapAlias f = coerceLin (\x -> let !y = f x in y)
 
@@ -469,7 +473,7 @@ instance (GenericDistributesAlias f) => DistributesAlias (Generically1 f) where
   split_ = Generically1 . genericSplit . unsafeMapAlias \(Generically1 f) -> f
 
 class GDistributeAlias f where
-  gdistributeAlias :: Alias ak α (f x) %1 -> f (Alias ak α x)
+  gdistributeAlias :: Alias ak (f x) %1 -> f (Alias ak x)
 
 instance
   ( GDistributeAlias f

--- a/src/Control/Monad/Borrow/Pure/Copyable.hs
+++ b/src/Control/Monad/Borrow/Pure/Copyable.hs
@@ -229,7 +229,7 @@ class Copyable1 f where
 
 type GenericCopyable1 f = (Copyable1 (Rep1 @Type f), Generic1 f)
 
-genericLiftCopy :: forall f bk a b α. (GenericCopyable1 f) => (Borrow bk α a %1 -> b) -> Borrow bk α (f a) %1 -> f b
+genericLiftCopy :: forall f bk α a b. (GenericCopyable1 f) => (Borrow bk α a %1 -> b) -> Borrow bk α (f a) %1 -> f b
 {-# INLINE genericLiftCopy #-}
 genericLiftCopy f (UnsafeAlias x) = to1 $ liftCopy f (UnsafeAlias $ from1 x)
 

--- a/src/Control/Monad/Borrow/Pure/Experimental/Borrows.hs
+++ b/src/Control/Monad/Borrow/Pure/Experimental/Borrows.hs
@@ -10,46 +10,125 @@
 {-# LANGUAGE PartialTypeSignatures #-}
 {-# LANGUAGE QualifiedDo #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RoleAnnotations #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeAbstractions #-}
+{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# OPTIONS_GHC -Wno-name-shadowing #-}
 {-# OPTIONS_GHC -Wno-redundant-constraints #-}
 
 {- |
-The module provides 'Borrows', which is a heterogeneous list of 'Borrow's in the same lifetime.
+The module provides 'Aliases', which is a heterogeneous list of 'Alias'es in the same lifetime.
 -}
 module Control.Monad.Borrow.Pure.Experimental.Borrows (
-  Borrows (..),
+  Aliases (..),
+  Muts,
+  Shares,
+  Borrows,
+  Lends,
+  reborrows,
+  reborrowings',
+  reborrowings,
+  reborrowings_,
 ) where
 
 import Control.Functor.Linear qualified as Control
+import Control.Monad qualified as NonLinear
 import Control.Monad.Borrow.Pure.Affine
 import Control.Monad.Borrow.Pure.Affine.Unsafe (unsafeAff)
 import Control.Monad.Borrow.Pure.BO
+import Control.Monad.Borrow.Pure.BO.Internal
 import Control.Monad.Borrow.Pure.Experimental.Reborrowable
+import Control.Syntax.DataFlow qualified as DataFlow
 import Data.Coerce.Directed.Unsafe
 import Data.Kind
 import Prelude.Linear hiding (foldMap)
+import Unsafe.Coerce (unsafeCoerce)
 import Unsafe.Linear qualified as Unsafe
 
-type Borrows :: BorrowKind -> Lifetime -> [Type] -> Type
-data Borrows bk α xs where
-  BNil :: Borrows bk α '[]
-  (:-) :: !(Borrow bk α x) %1 -> !(Borrows bk α xs) %1 -> Borrows bk α (x ': xs)
+type Aliases :: AliasKind -> [Type] -> Type
+data Aliases k xs where
+  BNil :: Aliases k '[]
+  (:-) :: !(Alias k x) %1 -> !(Aliases k xs) %1 -> Aliases k (x ': xs)
+
+type role Aliases nominal nominal
 
 infixr 5 :-
 
-instance Affine (Borrows bk α xs) where
+type Lends :: Lifetime -> [Type] -> Type
+type Lends α = Aliases ('Lend α)
+
+type Borrows :: BorrowKind -> Lifetime -> [Type] -> Type
+type Borrows bk α = Aliases ('Borrow bk α)
+
+type Muts :: Lifetime -> [Type] -> Type
+type Muts α = Borrows 'Mut α
+
+type Shares :: Lifetime -> [Type] -> Type
+type Shares α = Borrows 'Share α
+
+instance Affine (Aliases α xs) where
   aff = unsafeAff
+  {-# INLINE aff #-}
 
-deriving via AsAffine (Borrows bk α xs) instance Consumable (Borrows bk α xs)
+deriving via
+  AsAffine (Aliases k xs)
+  instance
+    (k ~ 'Borrow bk α) =>
+    Consumable (Aliases k xs)
 
-instance (β <= α) => Borrows bk α xs <: Borrows bk' β xs where
+instance (k ~ 'Borrow 'Share α) => Dupable (Aliases k xs) where
+  dup2 = Unsafe.toLinear $ NonLinear.join (,)
+  {-# INLINE dup2 #-}
+
+instance (k ~ 'Borrow 'Share α) => Movable (Aliases k xs) where
+  move = Unsafe.toLinear Ur
+  {-# INLINE move #-}
+
+instance (α >= β, xs <: ys, ys <: xs) => Muts α xs <: Muts β ys where
   subtype = UnsafeSubtype
 
-instance Reborrowable (Borrows bk) where
-  locally' = Unsafe.toLinear \bors k -> Control.do
-    (,bors) Control.<$> srunBO (k $ upcast bors)
+instance (α >= β, xs <: ys) => Shares α xs <: Shares β ys where
+  subtype = UnsafeSubtype
+
+instance (α <= β, a <: b) => Lends α a <: Lends β b where
+  subtype = UnsafeSubtype
+
+instance Reborrowable (Muts α) where
+  type LifetimeOf (Muts α) = α
+  type WithLifetime (Muts α) β = Muts β
+  locally' = reborrowings'
   {-# INLINE locally' #-}
+
+-- | A plural form of 'reborrow', which reborrows multiple borrows in the given 'Muts' at once.
+reborrows :: forall β α a. (α >= β) => Muts α a %1 -> (Muts β a, Lend β (Muts α a))
+reborrows = Unsafe.toLinear \v -> (unsafeCoerce v, unsafeCoerce v)
+
+-- | A plural form of 'reborrowing''.
+reborrowings' ::
+  Muts α a %1 ->
+  (forall β. Muts (β /\ α) a %1 -> BO (β /\ α') (After β r)) %1 ->
+  BO α' (r, Muts α a)
+{-# INLINE reborrowings' #-}
+reborrowings' v k = srunBO DataFlow.do
+  (v, lend) <- reborrows v
+  Control.do
+    v <- k v
+    Control.pure $ (,) Control.<$> v Control.<*> upcast (reclaim' lend)
+
+reborrowings ::
+  Muts α a %1 ->
+  (forall β. Muts (β /\ α) a %1 -> BO (β /\ α') r) %1 ->
+  BO α' (r, Muts α a)
+{-# INLINE reborrowings #-}
+reborrowings mutα k = reborrowings' mutα (\mut -> Control.pure Control.<$> k mut)
+
+reborrowings_ ::
+  (Consumable r) =>
+  Muts α a %1 ->
+  (forall β. Muts (β /\ α) a %1 -> BO (β /\ α') r) %1 ->
+  BO α' (Muts α a)
+{-# INLINE reborrowings_ #-}
+reborrowings_ mutα k = reborrowings mutα (Control.fmap consume . k) Control.<&> \((), a) -> a

--- a/src/Control/Monad/Borrow/Pure/Experimental/Loop.hs
+++ b/src/Control/Monad/Borrow/Pure/Experimental/Loop.hs
@@ -29,7 +29,6 @@ the iteration. Keep the loop worker @INLINE@ or @INLINABLE@ so 'Ur'-boxed reads
 can be eliminated by the optimiser.
 -}
 module Control.Monad.Borrow.Pure.Experimental.Loop (
-  Borrows (..),
   forReborrowing,
   forReborrowingOf_,
   forReborrowing_,
@@ -55,7 +54,6 @@ module Control.Monad.Borrow.Pure.Experimental.Loop (
 import Control.Functor.Linear qualified as Control
 import Control.Monad.Borrow.Pure
 import Control.Monad.Borrow.Pure.BO.Unsafe
-import Control.Monad.Borrow.Pure.Experimental.Borrows
 import Control.Monad.Borrow.Pure.Experimental.Reborrowable
 import Control.Monad.Borrow.Pure.Utils (coerceLin)
 import Data.Bifunctor.Linear qualified as Bi
@@ -76,14 +74,14 @@ inside the delimited sublifetime, reborrowing the 'Borrows' in @bors@ for that s
 -}
 forReborrowing ::
   (Data.Traversable t, Reborrowable bor) =>
-  bor α xs %1 ->
+  bor xs %1 ->
   t b %1 ->
   ( forall β.
-    bor (β /\ α) xs %1 ->
+    WithLifetime bor (β /\ LifetimeOf bor) xs %1 ->
     b %1 ->
     BO (β /\ α) c
   ) ->
-  BO α (t c, bor α xs)
+  BO α (t c, bor xs)
 {-# INLINE forReborrowing #-}
 forReborrowing bors tb k =
   flip Control.runStateT bors $
@@ -152,14 +150,14 @@ unAp (Ap m) = m
 forReborrowingOf_ ::
   (Reborrowable bor) =>
   Fold s a %1 ->
-  bor α xs %1 ->
+  bor xs %1 ->
   s %1 ->
   ( forall β.
-    bor (β /\ α) xs %1 ->
+    WithLifetime bor (β /\ LifetimeOf bor) xs %1 ->
     a %1 ->
     BO (β /\ α) ()
   ) ->
-  BO α (bor α xs)
+  BO α (bor xs)
 {-# INLINE forReborrowingOf_ #-}
 forReborrowingOf_ fld bors s k =
   flip Control.execStateT bors $
@@ -169,29 +167,29 @@ forReborrowingOf_ fld bors s k =
 
 forReborrowing_ ::
   (Foldable t, Reborrowable bor) =>
-  bor α xs %1 ->
+  bor xs %1 ->
   t a %1 ->
   ( forall β.
-    bor (β /\ α) xs %1 ->
+    WithLifetime bor (β /\ LifetimeOf bor) xs %1 ->
     a %1 ->
     BO (β /\ α) ()
   ) ->
-  BO α (bor α xs)
+  BO α (bor xs)
 {-# INLINE forReborrowing_ #-}
 forReborrowing_ = forReborrowingOf_ foldMap
 
 iforReborrowingOf_ ::
   (Reborrowable bor) =>
   IndexedFold i s a %1 ->
-  bor α xs %1 ->
+  bor xs %1 ->
   s %1 ->
   ( forall β.
-    bor (β /\ α) xs %1 ->
+    WithLifetime bor (β /\ LifetimeOf bor) xs %1 ->
     i %1 ->
     a %1 ->
     BO (β /\ α) ()
   ) ->
-  BO α (bor α xs)
+  BO α (bor xs)
 {-# INLINE iforReborrowingOf_ #-}
 iforReborrowingOf_ fld bors s k =
   flip Control.execStateT bors $
@@ -201,15 +199,15 @@ iforReborrowingOf_ fld bors s k =
 
 iforReborrowing_ ::
   (FoldableWithIndex i t, Reborrowable bor) =>
-  bor α xs %1 ->
+  bor xs %1 ->
   t a %1 ->
   ( forall β.
-    bor (β /\ α) xs %1 ->
+    WithLifetime bor (β /\ LifetimeOf bor) xs %1 ->
     i %1 ->
     a %1 ->
     BO (β /\ α) ()
   ) ->
-  BO α (bor α xs)
+  BO α (bor xs)
 {-# INLINE iforReborrowing_ #-}
 iforReborrowing_ = iforReborrowingOf_ ifoldMap
 
@@ -326,18 +324,18 @@ iterReborrowing_ ::
   forall bor α xs.
   (Reborrowable bor) =>
   Int ->
-  bor α xs %1 ->
+  bor xs %1 ->
   ( forall β.
     Int ->
-    bor (β /\ α) xs %1 ->
+    WithLifetime bor (β /\ LifetimeOf bor) xs %1 ->
     BO (β /\ α) ()
   ) ->
-  BO α (bor α xs)
+  BO α (bor xs)
 {-# INLINE iterReborrowing_ #-}
 iterReborrowing_ n bor k = go bor 0
   where
     {-# INLINE go #-}
-    go :: bor α xs %1 -> Int -> BO α (bor α xs)
+    go :: bor xs %1 -> Int -> BO α (bor xs)
     go !bor !i
       | i < n = Control.do
           bor <- locally_ bor \bor -> k i bor

--- a/src/Control/Monad/Borrow/Pure/Experimental/Reborrowable.hs
+++ b/src/Control/Monad/Borrow/Pure/Experimental/Reborrowable.hs
@@ -8,6 +8,7 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeAbstractions #-}
+{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# OPTIONS_GHC -Wno-name-shadowing #-}
 
@@ -19,9 +20,14 @@ module Control.Monad.Borrow.Pure.Experimental.Reborrowable (
 
 import Control.Functor.Linear qualified as Control
 import Control.Monad.Borrow.Pure.BO
+import Data.Kind (Constraint, Type)
 import Prelude.Linear
 
-class Reborrowable bor where
+type Reborrowable :: (k -> Type) -> Constraint
+class (bor ~ WithLifetime bor (LifetimeOf bor)) => Reborrowable bor where
+  type LifetimeOf bor :: Lifetime
+  type WithLifetime bor (α :: Lifetime) :: k -> Type
+
   {- |
   Executes an operation on a borrow in sub lifetime.
   You may need @-XImpredicativeTypes@ extension to use this function.
@@ -29,17 +35,21 @@ class Reborrowable bor where
   Generalization of 'reborrowing'' and 'sharing'' that works for both 'Mut' and 'Share' borrows.
   -}
   locally' ::
-    bor α a %1 ->
-    (forall β. bor (β /\ α) a %1 -> BO (β /\ α') (After β r)) %1 ->
-    BO α' (r, bor α a)
+    bor a %1 ->
+    (forall β. WithLifetime bor (β /\ LifetimeOf bor) a %1 -> BO (β /\ α') (After β r)) %1 ->
+    BO α' (r, bor a)
 
-instance Reborrowable Mut where
-  {-# SPECIALIZE instance Reborrowable Mut #-}
+instance Reborrowable (Mut α) where
+  type LifetimeOf (Mut α) = α
+  type WithLifetime (Mut α) β = Mut β
+  {-# SPECIALIZE instance Reborrowable (Mut α) #-}
   locally' = reborrowing'
   {-# INLINE locally' #-}
 
-instance Reborrowable Share where
-  {-# SPECIALIZE instance Reborrowable Share #-}
+instance Reborrowable (Share α) where
+  type LifetimeOf (Share α) = α
+  type WithLifetime (Share α) β = Share β
+  {-# SPECIALIZE instance Reborrowable (Share α) #-}
   locally' shr k = Control.do
     let %1 !(Ur sh) = move shr
     (,sh) Control.<$> srunBO (k (upcast sh))
@@ -47,16 +57,16 @@ instance Reborrowable Share where
 
 locally ::
   (Reborrowable bor) =>
-  bor α a %1 ->
-  (forall β. bor (β /\ α) a %1 -> BO (β /\ α') r) %1 ->
-  BO α' (r, bor α a)
+  bor a %1 ->
+  (forall β. WithLifetime bor (β /\ LifetimeOf bor) a %1 -> BO (β /\ α') r) %1 ->
+  BO α' (r, bor a)
 {-# INLINE locally #-}
 locally bor k = locally' bor \mut -> Control.pure Control.<$> k mut
 
 locally_ ::
   (Reborrowable bor, Consumable r) =>
-  bor α a %1 ->
-  (forall β. bor (β /\ α) a %1 -> BO (β /\ α') r) %1 ->
-  BO α' (bor α a)
+  bor a %1 ->
+  (forall β. WithLifetime bor (β /\ LifetimeOf bor) a %1 -> BO (β /\ α') r) %1 ->
+  BO α' (bor a)
 {-# INLINE locally_ #-}
 locally_ bor k = uncurry lseq Control.<$> locally bor k

--- a/src/Data/Coerce/Directed/Internal.hs
+++ b/src/Data/Coerce/Directed/Internal.hs
@@ -106,3 +106,9 @@ instance (GenericSubtype a b) => a <: Generically b where
 
 genericUpcast :: (GenericSubtype a b) => a %1 -> b
 genericUpcast = to . gupcast . from
+
+instance '[] <: ('[] :: [k]) where
+  subtype = UnsafeSubtype
+
+instance (a <: b, as <: bs) => (a ': as) <: (b ': bs) where
+  subtype = UnsafeSubtype

--- a/src/Data/Record/Linear/Borrow/Experimental/PatternMatch.hs
+++ b/src/Data/Record/Linear/Borrow/Experimental/PatternMatch.hs
@@ -54,7 +54,7 @@ import Control.Monad.Borrow.Pure
 import Control.Monad.Borrow.Pure.Affine (Affine (..), AsAffine (..))
 import Control.Monad.Borrow.Pure.Affine.Unsafe (unsafeAff)
 import Control.Monad.Borrow.Pure.BO
-import Control.Monad.Borrow.Pure.BO.Unsafe (unsafeMapAlias)
+import Control.Monad.Borrow.Pure.BO.Internal
 import Data.Kind (Constraint)
 import GHC.Base (TYPE, Type, proxy#)
 import GHC.OverloadedLabels (IsLabel (..))
@@ -299,7 +299,11 @@ instance
   where
   type
     SplitBorrow (l1, l2, l3, l4) bk α a =
-      (Borrow bk α (ValueOf l1), Borrow bk α (ValueOf l2), Borrow bk α (ValueOf l3), Borrow bk α (ValueOf l4))
+      ( Borrow bk α (ValueOf l1)
+      , Borrow bk α (ValueOf l2)
+      , Borrow bk α (ValueOf l3)
+      , Borrow bk α (ValueOf l4)
+      )
   splitRecord (RecLab, RecLab, RecLab, RecLab) = Unsafe.toLinear \r ->
     ( unsafeMapAlias (Unsafe.toLinear (getField @f1)) r
     , unsafeMapAlias (Unsafe.toLinear (getField @f2)) r

--- a/src/Data/Record/Linear/Borrow/Experimental/Split.hs
+++ b/src/Data/Record/Linear/Borrow/Experimental/Split.hs
@@ -45,8 +45,8 @@ module Data.Record.Linear.Borrow.Experimental.Split (
   (!#),
 ) where
 
+import Control.Monad.Borrow.Pure.BO (Lifetime)
 import Control.Monad.Borrow.Pure.BO.Internal
-import Control.Monad.Borrow.Pure.Lifetime
 import Data.Kind (Constraint)
 import GHC.Base (Multiplicity (..), TYPE, Type)
 import GHC.OverloadedLabels (IsLabel (..))
@@ -95,10 +95,10 @@ In above example, we annotate type of the divided field borows for clarity, but 
 For more complex, partial splitting of a record, see [Splitting a record borrow into pieces](#split) for more detail.
 -}
 (.#) ::
-  forall field r a k α.
-  Borrow k α r %1 ->
+  forall field r a bk α.
+  Borrow bk α r %1 ->
   RecordLabel r field a ->
-  Borrow k α a
+  Borrow bk α a
 UnsafeAlias !r .# RecLab = UnsafeAlias $! Unsafe.toLinear (getField @field @r @a) r
 
 infixl 9 .#


### PR DESCRIPTION
Moves the lifetime out of `Alias`'s own parameter list and into the
alias kind:

    -- before
    newtype Alias ak α a = UnsafeAlias a
    data AliasKind = Borrow BorrowKind | Lend

    -- after
    newtype Alias ak a = UnsafeAlias a
    data AliasKind = Borrow BorrowKind Lifetime | Lend Lifetime

`Borrow bk α`, `Mut α`, `Share α` and `Lend α` are unchanged as seen by
users — they are still the same synonyms over `Alias` — so the public
borrow API and its representation are untouched. What changes is that a
kind-polymorphic function can now abstract over a whole alias *including*
its lifetime, which is what the reborrowing machinery needs: an
instance head can constrain `ak ~ 'Borrow bk α` and recover both
components, where previously the lifetime had to be threaded separately
and could not be quantified over.

Consequences carried through in the same change, since the kind is not
separable from its users:

- `Experimental.Borrows` gains the reborrow instances this enables, and
  absorbs the machinery that had to live in `Experimental.Reborrowable`.
- `Data.Coerce.Directed` gains the directed coercions for the new shape.
- Record splitting (`Experimental.PatternMatch`, `Experimental.Split`)
  and `Experimental.Loop` follow the new signatures.
- `assocBorrowEq` is restated with an explicit `BorrowKind` kind
  signature.

Squashes four work-in-progress commits into one coherent change; the
intermediate states did not build.
Part of #14.