### PR TITLE
perf(borrow): erase result-discarding borrow scopes

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -31,19 +31,28 @@ jobs:
             await script({github, context, core, glob, io, require})
 
   build:
-    name: Build and Test (${{matrix.plan.name}})
+    name: Build and Test (${{matrix.plan.name}}${{matrix.flags == '+slow' && ', slow' || ''}})
     needs: [ci-enumerate]
     continue-on-error: true
     strategy:
       matrix:
         plan: ${{fromJSON(needs.ci-enumerate.outputs.plan)}}
+        flags: ["-slow"]
+        # Also exercise the sublifetime-allocating implementations behind
+        # `+slow`. Only on the pinned GHC: the flag swaps two function bodies,
+        # nothing version-dependent, so a full GHC x flag matrix would just
+        # double CI for no extra coverage.
+        include:
+          - plan: ${{fromJSON(needs.ci-enumerate.outputs.plan)[1]}}
+            flags: "+slow"
       fail-fast: false
     env:
       cabal: "cabal --project-file=${{matrix.plan.path}}"
+      flags: ${{matrix.flags}}
       ghc: ${{matrix.plan.ghc}}
       project-file: ${{matrix.plan.path}}
-      plan: ${{matrix.plan.name}}
-      artifact-name: "artifact-${{matrix.plan.name}}"
+      plan: "${{matrix.plan.name}}${{matrix.flags == '+slow' && '-slow' || ''}}"
+      artifact-name: "artifact-${{matrix.plan.name}}${{matrix.flags == '+slow' && '-slow' || ''}}"
     runs-on: ubuntu-latest
     outputs:
       benchmarks: ${{steps.list-bins.outputs.benchs}}
@@ -81,7 +90,7 @@ jobs:
           restore-keys: ${{steps.cache-keys.outputs.dist-restore}}
       - name: cabal configure
         run: |
-          ${{env.cabal}} v2-configure --enable-tests --enable-benchmarks --enable-optimisation=2 --test-show-details=always --write-ghc-environment-files=always
+          ${{env.cabal}} v2-configure --enable-tests --enable-benchmarks --enable-optimisation=2 --test-show-details=always --write-ghc-environment-files=always --flags='${{env.flags}}'
           ${{env.cabal}} update
       - name: Build Dependencies
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,8 +153,17 @@ parallel `qsort` (budgeted `parBO`; the heavier version is `qsortDC` above).
 - **Strict warnings** (`common defaults` in `pure-borrow.cabal`): `-Wall -Wcompat
   -Wunused-packages …`. `-Wunused-packages` means a now-unused `build-depends` entry breaks
   the build — drop deps you stop using.
-- **Flags:** `examples` (demo executables + `demo-impl` lib) is the only flag; it is
-  `manual`, default `False`, and enabled locally via `cabal.project`.
+- **Flags:** both are `manual` and default `False`.
+  - `examples` — demo executables + `demo-impl` lib; enabled locally via `cabal.project`.
+  - `slow` — restores the previous, sublifetime-allocating implementations of
+    `sharing_`, `reborrowing_` and `copyAtMut`, behind
+    `-DPURE_BORROW_SLOW_SCOPES`. The two variants must stay observationally
+    equivalent: the same test suites run under both, and CI builds `+slow` on
+    the pinned GHC. Use it to A/B the erased scopes, or to check whether a
+    suspected miscompilation is attributable to them.
+    ```bash
+    cabal build all --flags=+slow && cabal test --flags=+slow
+    ```
 - CI (`.github/workflows/haskell.yml`) runs a GHC matrix (9.10.3/9.12.4/9.14.1 via
   `ci/configs/*.project`): build, all test suites, `cabal check`, Haddock-for-Hackage, and a
   fourmolu check.

--- a/bench/suite/Main.hs
+++ b/bench/suite/Main.hs
@@ -1,0 +1,5 @@
+-- The two @--ingredient@ flags rebuild 'Test.Tasty.Bench.benchIngredients':
+-- @tasty-discover@ prepends each ingredient to 'Test.Tasty.defaultIngredients'
+-- in reverse flag order, so @listingTests@ ends up first (keeping
+-- @--list-tests@ working) and the composed bench reporter second.
+{-# OPTIONS_GHC -F -pgmF tasty-discover -optF --tree-display -optF --ingredient=PureBorrow.Bench.Ingredients.benchReporter -optF --ingredient=Test.Tasty.Ingredients.Basic.listingTests #-}

--- a/bench/suite/PureBorrow/Bench/CopyAt.hs
+++ b/bench/suite/PureBorrow/Bench/CopyAt.hs
@@ -1,0 +1,176 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE QualifiedDo #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module PureBorrow.Bench.CopyAt (
+  test_copyAt,
+  composedPureBorrowCopiedReadLoop,
+  directCopiedReadLoop,
+  pureBorrowCopiedReadLoop,
+  pureBorrowUpdateLoop,
+  reborrowingUpdateLoop,
+) where
+
+import Control.Exception (evaluate)
+import Control.Functor.Linear qualified as Control
+import Control.Monad.Borrow.Pure
+import Control.Monad.ST.Strict (runST)
+import Control.Syntax.DataFlow qualified as DataFlow
+import Data.Vector qualified as V
+import Data.Vector.Mutable qualified as MV
+import Data.Vector.Mutable.Linear.Borrow qualified as VL
+import Prelude.Linear
+import Test.Tasty.Bench hiding (defaultMain)
+import Prelude qualified as NonLinear
+
+directCopiedReadLoop :: V.Vector Int -> (Int, V.Vector Int)
+{-# NOINLINE directCopiedReadLoop #-}
+directCopiedReadLoop input = runST do
+  mutable <- V.thaw input
+  total <- go mutable 0 0
+  frozen <- V.unsafeFreeze mutable
+  NonLinear.pure (total, frozen)
+  where
+    go mutable !i !total
+      | i >= MV.length mutable = NonLinear.pure total
+      | otherwise = do
+          value <- MV.read mutable i
+          go mutable (i + 1) (total + value)
+
+pureBorrowCopiedReadLoop :: V.Vector Int -> (Int, V.Vector Int)
+{-# NOINLINE pureBorrowCopiedReadLoop #-}
+pureBorrowCopiedReadLoop input = unur $ linearly \linearlyToken -> DataFlow.do
+  (runToken, vectorToken) <- dup linearlyToken
+  runBO runToken Control.do
+    (initialMutable, lend) <- borrowM (VL.fromVector input vectorToken)
+    VL.size initialMutable & \(Ur length_, sizedMutable) ->
+      go length_ 0 0 sizedMutable lend
+  where
+    go ::
+      forall α.
+      Int ->
+      Int ->
+      Int ->
+      Mut α (VL.Vector Int) %1 ->
+      Lend α (VL.Vector Int) %1 ->
+      BO α (After α (Ur (Int, V.Vector Int)))
+    go !length_ !i !total mutable lend
+      | i >= length_ =
+          consume mutable `lseq`
+            Control.pure
+              ( ( \vector -> case VL.toVector vector of
+                    Ur frozen -> Ur (total, frozen)
+                )
+                  Control.<$> reclaim' lend
+              )
+      | otherwise = Control.do
+          (Ur value, nextMutable) <- VL.copyAtMut i mutable
+          go length_ (i + 1) (total + value) nextMutable lend
+
+composedPureBorrowCopiedReadLoop :: V.Vector Int -> (Int, V.Vector Int)
+{-# NOINLINE composedPureBorrowCopiedReadLoop #-}
+composedPureBorrowCopiedReadLoop input = unur $ linearly \linearlyToken -> DataFlow.do
+  (runToken, vectorToken) <- dup linearlyToken
+  runBO runToken Control.do
+    (initialMutable, lend) <- borrowM (VL.fromVector input vectorToken)
+    VL.size initialMutable & \(Ur length_, sizedMutable) ->
+      go length_ 0 0 sizedMutable lend
+  where
+    go ::
+      forall α.
+      Int ->
+      Int ->
+      Int ->
+      Mut α (VL.Vector Int) %1 ->
+      Lend α (VL.Vector Int) %1 ->
+      BO α (After α (Ur (Int, V.Vector Int)))
+    go !length_ !i !total mutable lend
+      | i >= length_ =
+          consume mutable `lseq`
+            Control.pure
+              ( ( \vector -> case VL.toVector vector of
+                    Ur frozen -> Ur (total, frozen)
+                )
+                  Control.<$> reclaim' lend
+              )
+      | otherwise = Control.do
+          (Ur value, nextMutable) <-
+            sharing @α @α mutable \shared -> VL.copyAt i shared
+          go length_ (i + 1) (total + value) nextMutable lend
+
+pureBorrowUpdateLoop :: V.Vector Int -> V.Vector Int
+{-# NOINLINE pureBorrowUpdateLoop #-}
+pureBorrowUpdateLoop input = unur $ linearly \linearlyToken -> DataFlow.do
+  (runToken, vectorToken) <- dup linearlyToken
+  runBO runToken Control.do
+    (initialMutable, lend) <- borrowM (VL.fromVector input vectorToken)
+    VL.size initialMutable & \(Ur length_, sizedMutable) ->
+      go length_ 0 sizedMutable lend
+  where
+    go ::
+      forall α.
+      Int ->
+      Int ->
+      Mut α (VL.Vector Int) %1 ->
+      Lend α (VL.Vector Int) %1 ->
+      BO α (After α (Ur (V.Vector Int)))
+    go !length_ !i mutable lend
+      | i >= length_ =
+          consume mutable `lseq`
+            Control.pure (VL.toVector Control.<$> reclaim' lend)
+      | otherwise = Control.do
+          nextMutable <- VL.modify i (+ 1) mutable
+          go length_ (i + 1) nextMutable lend
+
+reborrowingUpdateLoop :: V.Vector Int -> V.Vector Int
+{-# NOINLINE reborrowingUpdateLoop #-}
+reborrowingUpdateLoop input = unur $ linearly \linearlyToken -> DataFlow.do
+  (runToken, vectorToken) <- dup linearlyToken
+  runBO runToken Control.do
+    (initialMutable, lend) <- borrowM (VL.fromVector input vectorToken)
+    VL.size initialMutable & \(Ur length_, sizedMutable) ->
+      go length_ 0 sizedMutable lend
+  where
+    go ::
+      forall α.
+      Int ->
+      Int ->
+      Mut α (VL.Vector Int) %1 ->
+      Lend α (VL.Vector Int) %1 ->
+      BO α (After α (Ur (V.Vector Int)))
+    go !length_ !i mutable lend
+      | i >= length_ =
+          consume mutable `lseq`
+            Control.pure (VL.toVector Control.<$> reclaim' lend)
+      | otherwise = Control.do
+          nextMutable <-
+            reborrowing_ mutable \scopedMutable -> Control.do
+              modifiedScoped <- VL.modify i (+ 1) scopedMutable
+              Control.pure (consume modifiedScoped)
+          go length_ (i + 1) nextMutable lend
+
+test_copyAt :: [Benchmark]
+test_copyAt =
+  [ bgroup
+      "copy-at"
+      [ env
+          (evaluate $ V.generate size (`NonLinear.rem` 1024))
+          \input ->
+            bgroup
+              (NonLinear.show size)
+              [ bench "direct-vector" $ nf directCopiedReadLoop input
+              , bench "pure-borrow/direct-copy" $ nf pureBorrowCopiedReadLoop input
+              , bench "pure-borrow/composed-copy" $ nf composedPureBorrowCopiedReadLoop input
+              ]
+      | size <- [4 * 1024, 64 * 1024, 1024 * 1024]
+      ]
+  , env
+      (evaluate $ V.generate (1024 * 1024) (`NonLinear.rem` 1024))
+      \input ->
+        bgroup
+          "discarding-scope/update"
+          [ bench "pure-borrow/no-scope" $ nf pureBorrowUpdateLoop input
+          , bench "reborrowing_" $ nf reborrowingUpdateLoop input
+          ]
+  ]

--- a/bench/suite/PureBorrow/Bench/Ingredients.hs
+++ b/bench/suite/PureBorrow/Bench/Ingredients.hs
@@ -1,0 +1,21 @@
+module PureBorrow.Bench.Ingredients (benchReporter) where
+
+import Test.Tasty.Bench (consoleBenchReporter, csvReporter, svgReporter)
+import Test.Tasty.Ingredients (Ingredient, composeReporters)
+
+{- | The reporting half of 'Test.Tasty.Bench.benchIngredients', as a single
+composed ingredient.
+
+Composition matters: 'Test.Tasty.defaultMainWithIngredients' runs the first
+ingredient that accepts the given options, and 'consoleBenchReporter' accepts
+every invocation. Listing the reporters separately would therefore make
+@--csv@ and @--svg@ unreachable.
+
+This is a separate ingredient rather than the whole 'benchIngredients' list so
+that it can be named by @tasty-discover@'s @--ingredient@ flag; see
+@bench/suite/Main.hs@. Discovery skips this module: @tasty-discover@ imports
+only the modules that export a discovered binding.
+-}
+benchReporter :: Ingredient
+benchReporter =
+  consoleBenchReporter `composeReporters` (csvReporter `composeReporters` svgReporter)

--- a/pure-borrow.cabal
+++ b/pure-borrow.cabal
@@ -33,6 +33,18 @@ flag examples
   default: False
   manual: True
 
+flag slow
+  description:
+    Restore the previous, sublifetime-allocating implementations of the
+    result-discarding borrow scopes (`sharing_`, `reborrowing_`) and of
+    `copyAtMut`. These open a real sublifetime with a runtime token and a
+    lender, which the default implementations statically erase. Enable to
+    A/B the two against each other, or to check whether a suspected
+    miscompilation or unsoundness is attributable to the erased scopes.
+
+  default: False
+  manual: True
+
 common defaults
   default-language: GHC2021
   default-extensions: LinearTypes
@@ -72,6 +84,9 @@ common examples
 
 library
   import: defaults
+
+  if flag(slow)
+    cpp-options: -DPURE_BORROW_SLOW_SCOPES
   build-depends:
     array,
     atomic-primops,
@@ -205,6 +220,34 @@ library bench-suites
     tasty-bench,
     vector,
     vector-algorithms,
+
+  default-language: GHC2021
+
+benchmark pure-borrow-bench
+  import: defaults
+  type: exitcode-stdio-1.0
+  main-is: Main.hs
+  hs-source-dirs: bench/suite
+  -- cabal-gild: discover bench/suite --exclude=bench/suite/Main.hs
+  other-modules:
+    PureBorrow.Bench.CopyAt
+    PureBorrow.Bench.Ingredients
+
+  ghc-options:
+    -threaded
+    -rtsopts
+    -O2
+    "-with-rtsopts=-N1 -T"
+
+  build-tool-depends:
+    tasty-discover:tasty-discover >=5.0.1
+
+  build-depends:
+    base >=4.7 && <5,
+    pure-borrow,
+    tasty,
+    tasty-bench,
+    vector,
 
   default-language: GHC2021
 

--- a/src/Control/Monad/Borrow/Pure/BO.hs
+++ b/src/Control/Monad/Borrow/Pure/BO.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE ExplicitNamespaces #-}
@@ -170,7 +171,11 @@ sharing_ ::
   (forall β. Share (β /\ α) a -> BO (β /\ α') r) %1 ->
   BO α' (Mut α a)
 {-# INLINE sharing_ #-}
+#ifdef PURE_BORROW_SLOW_SCOPES
 sharing_ v k = uncurry lseq Control.<$> sharing v k
+#else
+sharing_ = unsafeBorrowScope_
+#endif
 
 -- | Flipped infix version of 'sharing_', smoewhat analgous to '(Control.<$>)' and @(<%=)@ in @lens@ package.
 (<$=) ::
@@ -269,7 +274,11 @@ reborrowing_ ::
   (forall β. Mut (β /\ α) a %1 -> BO (β /\ α') r) %1 ->
   BO α' (Mut α a)
 {-# INLINE reborrowing_ #-}
+#ifdef PURE_BORROW_SLOW_SCOPES
 reborrowing_ mutα k = reborrowing mutα (Control.fmap consume . k) Control.<&> \((), a) -> a
+#else
+reborrowing_ = unsafeBorrowScope_
+#endif
 
 -- | Flipped infix version of 'reborrowing_', smoewhat analgous to '(Control.<$>)' and @(<%=)@ in @lens@ package.
 (<%=) ::

--- a/src/Control/Monad/Borrow/Pure/BO/Internal.hs
+++ b/src/Control/Monad/Borrow/Pure/BO/Internal.hs
@@ -56,7 +56,7 @@ import Data.Tuple (Solo (..))
 import Data.Type.Equality ((:~:) (Refl))
 import GHC.Base (TYPE)
 import GHC.Base qualified as GHC
-import GHC.Exts (State#, runRW#)
+import GHC.Exts (Multiplicity (..), State#, runRW#)
 import GHC.ST qualified as ST
 import GHC.TypeError (ErrorMessage (..))
 import Generics.Linear
@@ -303,10 +303,10 @@ assocBorrowL ::
 assocBorrowL = coerceLin
 
 assocBorrowEq ::
-  forall bk α β γ a.
-  (Borrow (bk ((α /\ β) /\ γ)) a) :~: (Borrow (bk (α /\ (β /\ γ))) a)
+  forall (bk :: BorrowKind) α β γ a.
+  Borrow bk ((α /\ β) /\ γ) a :~: Borrow bk (α /\ (β /\ γ)) a
 {-# INLINE assocBorrowEq #-}
-assocBorrowEq = Unsafe.coerce $ Refl @(Borrow (bk ((α /\ β) /\ γ)) a)
+assocBorrowEq = Unsafe.coerce $ Refl @(Borrow bk ((α /\ β) /\ γ) a)
 
 assocLendR ::
   Lend ((α /\ β) /\ γ) a %1 ->
@@ -389,6 +389,56 @@ reclaim = \(UnsafeAlias !a) -> a
 reborrow :: forall β α a. (α >= β) => Mut α a %1 -> (Mut β a, Lend β (Mut α a))
 reborrow = Unsafe.toLinear \ !mutA ->
   (Data.Coerce.coerce mutA, Data.Coerce.coerce mutA)
+
+{- |
+Run and discard the result of a continuation with a representation-identical
+borrow narrowed to a fresh sublifetime, then, on normal return, restore the
+original mutable borrow.
+
+This is the trusted non-finalizing delimiter used by the scalar public
+result-discarding combinators. The rank-2 continuation cannot return its
+private @β@ at a caller-nameable lifetime; existentially hiding it supplies no
+ambient outlives evidence. The outer 'Mut' is retained only inside this
+function while the continuation runs. The continuation result is consumed
+before the outer borrow is restored. The continuation and state token are each
+consumed exactly once. Since the lifetime indices have runtime-erased
+representations, no runtime lifetime token or lender is required.
+-}
+unsafeBorrowScope_ ::
+  forall bk α α' a r.
+  (Consumable r) =>
+  Mut α a %1 ->
+  (forall β. Borrow bk (β /\ α) a %(BorrowMultiplicity bk) -> BO (β /\ α') r) %1 ->
+  BO α' (Mut α a)
+{-# INLINE unsafeBorrowScope_ #-}
+unsafeBorrowScope_ = Unsafe.toLinear2 \mut k ->
+  unsafeSrunBO_ $
+    k (Unsafe.coerce mut) Control.<&> \r ->
+      consume r `lseq` mut
+
+type BorrowMultiplicity :: BorrowKind -> Multiplicity
+type family BorrowMultiplicity bk where
+  BorrowMultiplicity 'Mut = One
+  BorrowMultiplicity 'Share = Many
+
+{- |
+Run a rank-2 'BO' action in a statically delimited fresh sublifetime without
+constructing a runtime lifetime token.
+
+The action is typechecked parametrically for every private lifetime, so it
+cannot rely on the implementation's erased instantiation at the ambient
+lifetime or return a borrow at a caller-nameable lifetime. Existentially hiding
+the private lifetime supplies no evidence needed to use such a borrow in an
+ambient 'BO'. The state-token coercion executes the action exactly once. This
+is the non-finalizing analogue of 'srunBO'; it cannot eliminate 'After' or
+provide 'End' evidence.
+-}
+unsafeSrunBO_ ::
+  forall β a.
+  (forall α. BO (α /\ β) a) %1 ->
+  BO β a
+{-# INLINE unsafeSrunBO_ #-}
+unsafeSrunBO_ action = unsafeCastBO (action @β)
 
 -- | Collapse a borrower to a mutable borrower.
 joinMut :: Borrow bk α (Mut β a) %1 -> Borrow bk (α /\ β) a

--- a/src/Data/Vector/Mutable/Linear/Borrow.hs
+++ b/src/Data/Vector/Mutable/Linear/Borrow.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE ImpredicativeTypes #-}
 {-# LANGUAGE LambdaCase #-}
@@ -330,7 +331,21 @@ copyAt :: (Copyable a, α >= β) => Int -> Share α (Vector a) -> BO β (Ur a)
 copyAt i v = Control.do Ur !s <- move Control.<$> get i v; Control.pure $! Ur $! copy s
 
 copyAtMut :: forall a α β. (Copyable a, α >= β) => Int -> Mut α (Vector a) %1 -> BO β (Ur a, Mut α (Vector a))
+{-# INLINE copyAtMut #-}
+#ifdef PURE_BORROW_SLOW_SCOPES
 copyAtMut i v = upcast $ sharing @_ @α v $ copyAt i
+#else
+copyAtMut = Unsafe.toLinear2 \i mut@(UnsafeAlias (Vector v)) ->
+  let !len = MV.length v
+   in if i < 0 || i >= len
+        then error ("get: index " <> show i <> " out of bound: " <> show len) mut
+        else unsafeSystemIOToBO do
+          !a <- MV.unsafeRead v i
+          -- The raw read temporarily aliases the element retained by the
+          -- vector. 'copy' consumes that alias and returns only an authorized
+          -- unrestricted copy; the mutable vector borrow stays exclusive.
+          NonLinear.pure (Ur $! copy (UnsafeAlias a), mut)
+#endif
 
 -- | Applies an in-place mutation on 'V.MVector' from @vector@ package.
 unsafeInplace ::

--- a/test/Control/Monad/Borrow/Pure/BOSpec.hs
+++ b/test/Control/Monad/Borrow/Pure/BOSpec.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE LinearTypes #-}
 {-# LANGUAGE NoImplicitPrelude #-}
@@ -9,11 +10,18 @@ module Control.Monad.Borrow.Pure.BOSpec (
 
 import Control.Functor.Linear qualified as Control
 import Control.Monad.Borrow.Pure
+import Control.Monad.Borrow.Pure.BO qualified as BO
 import Data.Functor.Linear qualified as Data
+import Data.Type.Equality ((:~:))
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (testCase, (@?=))
 import Unsafe.Linear qualified as Unsafe
 import Prelude (Int, ($), (+))
+
+assocBorrowEqTypingCase ::
+  forall (bk :: BO.BorrowKind) α β γ a.
+  BO.Borrow bk ((α /\ β) /\ γ) a :~: BO.Borrow bk (α /\ (β /\ γ)) a
+assocBorrowEqTypingCase = BO.assocBorrowEq @bk @α @β @γ @a
 
 shortenShare :: (α >= β) => Share α a -> Share β a
 shortenShare = subShare

--- a/test/Data/Vector/Mutable/Linear/BorrowSpec.hs
+++ b/test/Data/Vector/Mutable/Linear/BorrowSpec.hs
@@ -11,6 +11,7 @@ module Data.Vector.Mutable.Linear.BorrowSpec (
   module Data.Vector.Mutable.Linear.BorrowSpec,
 ) where
 
+import Control.Exception qualified as Exception
 import Control.Functor.Linear qualified as Control
 import Control.Monad.Borrow.Pure.BO
 import Control.Monad.Borrow.Pure.Copyable
@@ -28,6 +29,38 @@ import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.Falsify (testProperty)
 import Test.Tasty.HUnit
 import Prelude qualified as NonLinear
+
+copyAtMutValue :: Int -> [Int] -> (Int, [Int])
+copyAtMutValue i xs = linearly \lin -> DataFlow.do
+  (lin, lin') <- dup lin
+  vec <- VL.fromList xs lin
+  runBO lin' Control.do
+    (mvec, lend) <- borrowM vec
+    (Ur x, mvec) <- VL.copyAtMut i mvec
+    let !() = consume mvec
+    pureAfter (x, unur $ VL.toList (reclaim lend))
+
+assertCopyAtMutBoundsError :: Int -> Assertion
+assertCopyAtMutBoundsError i = do
+  result <- Exception.try @Exception.ErrorCall $ Exception.evaluate $ copyAtMutValue i [10, 20, 30]
+  case result of
+    Left exception ->
+      assertBool
+        ("unexpected error: " <> Exception.displayException exception)
+        (("get: index " <> show i <> " out of bound: 3") `List.isPrefixOf` Exception.displayException exception)
+    Right value -> assertFailure ("expected bounds error, got " <> show value)
+
+test_copyAtMut :: TestTree
+test_copyAtMut =
+  testGroup
+    "copyAtMut"
+    [ testCase "copies the selected element and preserves the vector" do
+        copyAtMutValue 1 [10, 20, 30] @?= (20, [10, 20, 30])
+    , testCase "rejects a negative index" do
+        assertCopyAtMutBoundsError (-1)
+    , testCase "rejects an index at the upper bound" do
+        assertCopyAtMutBoundsError 3
+    ]
 
 qsortVec :: (Ord a, Copyable a) => V.Vector a -> V.Vector a
 qsortVec v = unur $ linearly \lin -> DataFlow.do
@@ -167,3 +200,24 @@ test_example3 :: TestTree
 test_example3 =
   testCase "example3" do
     example3 @?= (12, [12, 1, 7])
+
+discardingScopes :: (Int, [Int])
+discardingScopes = linearly \lin -> DataFlow.do
+  (lin, lin') <- dup lin
+  vec <- VL.fromList [10, 20, 30] lin
+  runBO lin' Control.do
+    (mvec, lend) <- borrowM vec
+    mvec <- reborrowing_ mvec \mvec -> Control.do
+      mvec <- sharing_ mvec \shared ->
+        consume Control.<$> parBO (VL.copyAt 0 shared) (VL.copyAt 1 shared)
+      mvec <- VL.modify 0 (+ 1) mvec
+      Control.pure $ consume mvec
+    mvec <- VL.modify 2 (+ 2) mvec
+    let !(Ur svec) = share mvec
+    Ur n <- VL.copyAt 0 svec
+    pureAfter $ (n, unur $ VL.toList (reclaim lend))
+
+test_discardingScopes :: TestTree
+test_discardingScopes =
+  testCase "result-discarding scopes restore the outer mutable borrow" do
+    discardingScopes @?= (11, [11, 20, 32])


### PR DESCRIPTION
`sharing_` and `reborrowing_` open a sublifetime, run the continuation,
discard its result and hand back the original `Mut`. Built on top of the
result-returning `sharing`/`reborrowing`, that costs a real lifetime
token and a lender per call even though nothing can escape.

`unsafeBorrowScope_` replaces both. The continuation is rank-2 in its
private lifetime `β`, so it can neither return a borrow at a
caller-nameable lifetime nor obtain outlives evidence for one; since
lifetime indices are runtime-erased, the delimiter needs no token and no
lender at all. `unsafeSrunBO_` is the non-finalizing analogue of
`srunBO` it is built from, and `BorrowMultiplicity` selects the
continuation's multiplicity so one definition serves both the affine
`Mut` and the unrestricted `Share` case. Both carry the proof obligation
in their Haddock.

`copyAtMut` no longer routes through `sharing`: it reads the element
directly through the mutable borrow and hands the raw alias to `copy`,
which returns an authorized unrestricted copy while the vector borrow
stays exclusive.

Also corrects the type annotation on `assocBorrowEq`, which named
`α /\ β /\ γ` where it meant `(α /\ β) /\ γ`. The coercion was unsafe
either way so no behaviour changed, but the stated equality was not the
one being witnessed.

The previous implementations stay reachable behind a new manual cabal
flag, `slow` (default `False`), which defines
`-DPURE_BORROW_SLOW_SCOPES` and restores the sublifetime-allocating
definitions of all three functions. The erased scopes rest on a proof
obligation rather than on the type system alone, so keeping the trusted
implementation one flag away means a suspected miscompilation or
unsoundness can be attributed or ruled out without reverting anything —
and it makes the two directly A/B-able under the benchmark below.

The two variants must stay observationally equivalent, so CI builds and
runs the full test suites under both: the existing GHC matrix covers
`-slow`, and one added job covers `+slow` on the pinned GHC. The flag
swaps two function bodies and nothing version-dependent, so a full
GHC x flag product would double CI without adding coverage.

Adds `pure-borrow-bench`, a `-N1 -T` tasty-discover benchmark executable
under `bench/suite`, with `copy-at` as its first member: it measures the
copy paths above against a raw `vector` baseline, and `reborrowing_`
against a no-scope loop. `PureBorrow.Bench.Ingredients` recomposes
tasty-bench's reporters so `--csv`/`--svg` stay reachable through
tasty-discover's `--ingredient` flag.
Part of #14.