### PR TITLE
feat(vector): add the backend-generic unrestricted vector

### DIFF
--- a/pure-borrow.cabal
+++ b/pure-borrow.cabal
@@ -135,6 +135,8 @@ library
     Data.Ref.Linear.Borrow
     Data.Ref.Linear.Unlifted
     Data.Unique.Linear
+    Data.Vector.Generic.Mutable.Linear.Borrow.Unrestricted
+    Data.Vector.Generic.Mutable.Linear.Borrow.Unrestricted.Internal
     Data.Vector.Mutable.Growable.Linear.Borrow
     Data.Vector.Mutable.Growable.Linear.Borrow.Internal
     Data.Vector.Mutable.Linear.Borrow
@@ -166,6 +168,8 @@ test-suite pure-borrow-test
     Control.Monad.Borrow.Pure.CopyableSpec
     Control.Monad.Borrow.Pure.Lifetime.TypingCases
     Control.Monad.Borrow.Pure.LifetimeSpec
+    Data.Vector.Generic.Mutable.Linear.Borrow.Unrestricted.TypingCases
+    Data.Vector.Generic.Mutable.Linear.Borrow.UnrestrictedSpec
     Data.Vector.Mutable.Growable.Linear.BorrowSpec
     Data.Vector.Mutable.Growable.Linear.TypingCases
     Data.Vector.Mutable.Linear.BorrowSpec

--- a/src/Data/Vector/Generic/Mutable/Linear/Borrow/Unrestricted.hs
+++ b/src/Data/Vector/Generic/Mutable/Linear/Borrow/Unrestricted.hs
@@ -1,0 +1,47 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+{- |
+Linearly owned mutable vectors whose elements are unrestricted and GC-owned.
+
+The public backend parameter @v@ selects any immutable backend supported by
+@vector@'s generic interface. The owner and its mutable backing remain linear.
+
+Custom backends are a trusted extensibility boundary: their mutable-vector
+operations must obey the usual @vector@ laws, including fresh allocation and
+cloning, exact indexing, disjoint non-overlapping splits, copying thaw, and
+alias-free ownership transfer through unsafe freeze/thaw. The standard boxed,
+unboxed, and primitive backends satisfy these requirements.
+-}
+module Data.Vector.Generic.Mutable.Linear.Borrow.Unrestricted (
+  Vector,
+  empty,
+  constant,
+  fromList,
+  fromVector,
+  unsafeFromVector,
+  unsafeFromMutable,
+  toVector,
+  toList,
+  copyToVector,
+  size,
+  get,
+  unsafeGet,
+  head,
+  unsafeHead,
+  last,
+  unsafeLast,
+  copyAt,
+  copyAtMut,
+  set,
+  unsafeSet,
+  write,
+  unsafeWrite,
+  update,
+  unsafeUpdate,
+  modify,
+  swap,
+  unsafeSwap,
+  splitAt,
+) where
+
+import Data.Vector.Generic.Mutable.Linear.Borrow.Unrestricted.Internal

--- a/src/Data/Vector/Generic/Mutable/Linear/Borrow/Unrestricted/Internal.hs
+++ b/src/Data/Vector/Generic/Mutable/Linear/Borrow/Unrestricted/Internal.hs
@@ -1,0 +1,477 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE QualifiedDo #-}
+{-# LANGUAGE RoleAnnotations #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# OPTIONS_GHC -Wno-name-shadowing #-}
+{-# OPTIONS_GHC -Wno-redundant-constraints #-}
+{-# OPTIONS_HADDOCK hide #-}
+
+module Data.Vector.Generic.Mutable.Linear.Borrow.Unrestricted.Internal (
+  module Data.Vector.Generic.Mutable.Linear.Borrow.Unrestricted.Internal,
+) where
+
+import Control.Functor.Linear qualified as Control
+import Control.Monad.Borrow.Pure.BO
+import Control.Monad.Borrow.Pure.BO.Unsafe
+import Control.Monad.Borrow.Pure.Clone
+import Control.Monad.Borrow.Pure.Copyable
+import Control.Monad.Borrow.Pure.Lifetime.Token.Unsafe (
+  LinearOnly (..),
+  LinearOnlyWitness (..),
+ )
+import Data.Unrestricted.Linear qualified as Ur
+import Data.Vector.Generic qualified as G
+import Data.Vector.Generic.Mutable qualified as GM
+import Data.Vector.Mutable (RealWorld)
+import GHC.Exts qualified as GHC
+import GHC.IO (unsafePerformIO)
+import GHC.Stack (HasCallStack)
+import GHC.TypeError
+import Prelude.Linear hiding (head, last, splitAt)
+import Unsafe.Linear qualified as Unsafe
+import Prelude qualified as NonLinear
+
+-- | Linearly owned mutable vector of unrestricted elements.
+newtype Vector v a = Vector {content :: G.Mutable v RealWorld a}
+
+type role Vector nominal nominal
+
+-- | Construct a fixed-size view over a raw mutable-vector slice.
+unsafeFromMutableSlice ::
+  (G.Vector v a) =>
+  Int ->
+  Int ->
+  G.Mutable v RealWorld a %1 ->
+  Vector v a
+{-# INLINE unsafeFromMutableSlice #-}
+unsafeFromMutableSlice offset length_ =
+  Unsafe.toLinear \buffer ->
+    Vector (GM.unsafeSlice offset length_ buffer)
+
+instance LinearOnly (Vector v a) where
+  linearOnly = UnsafeLinearOnly
+  {-# INLINE linearOnly #-}
+
+instance
+  (Unsatisfiable (ShowType (Vector v a) :<>: Text " cannot be copied!")) =>
+  Copyable (Vector v a)
+  where
+  copy = unsatisfiable
+
+instance Consumable (Vector v a) where
+  consume = Unsafe.toLinear \_ -> ()
+  {-# INLINE consume #-}
+
+instance (G.Vector v a) => Clone (Vector v a) where
+  clone = Unsafe.toLinear \(UnsafeAlias (Vector vector)) ->
+    Vector Control.<$> unsafeSystemIOToBO (GM.clone vector)
+  {-# INLINE clone #-}
+
+-- | \(O(1)\). Construct an empty vector.
+empty :: (G.Vector v a) => Linearly %1 -> Vector v a
+{-# NOINLINE empty #-}
+empty =
+  GHC.noinline \linear ->
+    linear `lseq` Vector (unsafePerformIO (GM.unsafeNew 0))
+
+{- | \(O(n)\). Construct a vector containing @count@ copies of a value.
+
+As in @vector@, a negative count produces an empty vector.
+-}
+constant ::
+  (G.Vector v a) =>
+  Int ->
+  a ->
+  Linearly %1 ->
+  Vector v a
+{-# NOINLINE constant #-}
+constant =
+  GHC.noinline \count value linear ->
+    linear `lseq` Vector (unsafePerformIO (GM.replicate count value))
+
+-- | \(O(n)\). Copy an unrestricted list into a new vector.
+fromList ::
+  (G.Vector v a) =>
+  [a] ->
+  Linearly %1 ->
+  Vector v a
+{-# NOINLINE fromList #-}
+fromList =
+  GHC.noinline \values linear ->
+    linear `lseq`
+      Vector
+        (unsafePerformIO (G.thaw (G.fromList values)))
+
+-- | \(O(n)\). Copy an immutable vector into a new owner.
+fromVector ::
+  (G.Vector v a) =>
+  v a ->
+  Linearly %1 ->
+  Vector v a
+{-# NOINLINE fromVector #-}
+fromVector =
+  GHC.noinline \source linear ->
+    linear `lseq` Vector (unsafePerformIO (G.thaw source))
+
+{- | \(O(1)\). Unsafely take ownership of an immutable vector.
+
+The caller must ensure that no alias of the source vector, including an
+overlapping slice, is ever observed again.
+-}
+unsafeFromVector ::
+  (G.Vector v a) =>
+  v a %1 ->
+  Linearly %1 ->
+  Vector v a
+{-# NOINLINE unsafeFromVector #-}
+unsafeFromVector =
+  GHC.noinline $
+    Unsafe.toLinear \source linear ->
+      linear `lseq` Vector (unsafePerformIO (G.unsafeThaw source))
+
+{- | \(O(1)\). Unsafely take ownership of a mutable vector.
+
+The caller must not retain any alias or overlapping slice of the input. The
+entire adopted slice must be initialized.
+-}
+unsafeFromMutable ::
+  (G.Vector v a) =>
+  G.Mutable v state a %1 ->
+  Linearly %1 ->
+  Vector v a
+{-# INLINE unsafeFromMutable #-}
+unsafeFromMutable =
+  Unsafe.toLinear \source linear ->
+    linear `lseq` Vector (Unsafe.coerce source)
+
+-- | \(O(1)\). Consume the owner and freeze its backing storage.
+toVector ::
+  (G.Vector v a) =>
+  Vector v a %1 ->
+  Ur (v a)
+{-# NOINLINE toVector #-}
+toVector =
+  GHC.noinline $
+    Unsafe.toLinear \(Vector vector) ->
+      Ur (unsafePerformIO (G.unsafeFreeze vector))
+
+-- | \(O(n)\). Consume the owner and return its elements as a list.
+toList ::
+  (G.Vector v a) =>
+  Vector v a %1 ->
+  Ur [a]
+{-# INLINE toList #-}
+toList = Ur.lift G.toList . toVector
+
+{- | \(O(n)\). Copy a live vector into an immutable vector and thread its
+borrow.
+-}
+copyToVector ::
+  (G.Vector v a, α >= β) =>
+  Borrow bk α (Vector v a) %1 ->
+  BO β (Ur (v a), Borrow bk α (Vector v a))
+{-# INLINE copyToVector #-}
+copyToVector =
+  Unsafe.toLinear \vectorBorrow@(UnsafeAlias (Vector vector)) ->
+    unsafeSystemIOToBO do
+      snapshot <- G.freeze vector
+      NonLinear.pure (Ur snapshot, vectorBorrow)
+
+-- | \(O(1)\). Return the number of elements and thread the vector borrow.
+size ::
+  (G.Vector v a) =>
+  Borrow bk α (Vector v a) %1 ->
+  (Ur Int, Borrow bk α (Vector v a))
+{-# INLINE size #-}
+size =
+  Unsafe.toLinear \vectorBorrow@(UnsafeAlias (Vector vector)) ->
+    (Ur (GM.length vector), vectorBorrow)
+
+-- | Read the element at an index and thread the vector borrow.
+get ::
+  (HasCallStack, G.Vector v a, α >= β) =>
+  Int ->
+  Borrow bk α (Vector v a) %1 ->
+  BO β (Ur a, Borrow bk α (Vector v a))
+{-# INLINE get #-}
+get index vector =
+  case size vector of
+    (Ur length_, vector)
+      | index < 0 || index >= length_ ->
+          error
+            ( "get: index "
+                <> show index
+                <> " out of bounds for length "
+                <> show length_
+            )
+            vector
+      | otherwise -> unsafeGet index vector
+
+-- | Unchecked 'get'. The index must satisfy @0 <= index < size@.
+unsafeGet ::
+  (G.Vector v a, α >= β) =>
+  Int ->
+  Borrow bk α (Vector v a) %1 ->
+  BO β (Ur a, Borrow bk α (Vector v a))
+{-# INLINE unsafeGet #-}
+unsafeGet index =
+  Unsafe.toLinear \vectorBorrow@(UnsafeAlias (Vector vector)) ->
+    unsafeSystemIOToBO do
+      value <- GM.unsafeRead vector index
+      NonLinear.pure (Ur value, vectorBorrow)
+
+-- | Read the first element and thread the vector borrow.
+head ::
+  (HasCallStack, G.Vector v a, α >= β) =>
+  Borrow bk α (Vector v a) %1 ->
+  BO β (Ur a, Borrow bk α (Vector v a))
+{-# INLINE head #-}
+head = get 0
+
+-- | Unchecked 'head'. The vector must be non-empty.
+unsafeHead ::
+  (G.Vector v a, α >= β) =>
+  Borrow bk α (Vector v a) %1 ->
+  BO β (Ur a, Borrow bk α (Vector v a))
+{-# INLINE unsafeHead #-}
+unsafeHead = unsafeGet 0
+
+-- | Read the last element and thread the vector borrow.
+last ::
+  (HasCallStack, G.Vector v a, α >= β) =>
+  Borrow bk α (Vector v a) %1 ->
+  BO β (Ur a, Borrow bk α (Vector v a))
+{-# INLINE last #-}
+last vector =
+  case size vector of
+    (Ur length_, vector)
+      | length_ <= 0 -> error "last: empty vector" vector
+      | otherwise -> unsafeGet (length_ - 1) vector
+
+-- | Unchecked 'last'. The vector must be non-empty.
+unsafeLast ::
+  (G.Vector v a, α >= β) =>
+  Borrow bk α (Vector v a) %1 ->
+  BO β (Ur a, Borrow bk α (Vector v a))
+{-# INLINE unsafeLast #-}
+unsafeLast vector =
+  case size vector of
+    (Ur length_, vector) -> unsafeGet (length_ - 1) vector
+
+-- | Read an element through a shared borrow.
+copyAt ::
+  (HasCallStack, G.Vector v a, α >= β) =>
+  Int ->
+  Share α (Vector v a) ->
+  BO β (Ur a)
+{-# INLINE copyAt #-}
+copyAt index vector = Control.do
+  (value, vector) <- get index vector
+  Control.pure (consume vector `lseq` value)
+
+-- | Read an element and retain the mutable vector borrow.
+copyAtMut ::
+  (HasCallStack, G.Vector v a, α >= β) =>
+  Int ->
+  Mut α (Vector v a) %1 ->
+  BO β (Ur a, Mut α (Vector v a))
+{-# INLINE copyAtMut #-}
+copyAtMut = get
+
+-- | Replace an element and return the displaced value.
+set ::
+  (HasCallStack, G.Vector v a, α >= β) =>
+  Int ->
+  a ->
+  Mut α (Vector v a) %1 ->
+  BO β (Ur a, Mut α (Vector v a))
+{-# INLINE set #-}
+set index value array =
+  case size array of
+    (Ur length_, array)
+      | index < 0 || index >= length_ ->
+          error
+            ( "set: index "
+                <> show index
+                <> " out of bounds for length "
+                <> show length_
+            )
+            array
+      | otherwise -> unsafeSet index value array
+
+-- | Unchecked 'set'. The index must satisfy @0 <= index < size@.
+unsafeSet ::
+  (G.Vector v a, α >= β) =>
+  Int ->
+  a ->
+  Mut α (Vector v a) %1 ->
+  BO β (Ur a, Mut α (Vector v a))
+{-# INLINE unsafeSet #-}
+unsafeSet index value =
+  Unsafe.toLinear \array@(UnsafeAlias (Vector vector)) ->
+    unsafeSystemIOToBO do
+      oldValue <- GM.unsafeExchange vector index value
+      NonLinear.pure (Ur oldValue, array)
+
+-- | Replace an element and discard the displaced unrestricted value.
+write ::
+  (HasCallStack, G.Vector v a, α >= β) =>
+  Int ->
+  a ->
+  Mut α (Vector v a) %1 ->
+  BO β (Mut α (Vector v a))
+{-# INLINE write #-}
+write index value array =
+  case size array of
+    (Ur length_, array)
+      | index < 0 || index >= length_ ->
+          error
+            ( "write: index "
+                <> show index
+                <> " out of bounds for length "
+                <> show length_
+            )
+            array
+      | otherwise -> unsafeWrite index value array
+
+-- | Unchecked 'write'. The index must satisfy @0 <= index < size@.
+unsafeWrite ::
+  (G.Vector v a, α >= β) =>
+  Int ->
+  a ->
+  Mut α (Vector v a) %1 ->
+  BO β (Mut α (Vector v a))
+{-# INLINE unsafeWrite #-}
+unsafeWrite index value =
+  Unsafe.toLinear \array@(UnsafeAlias (Vector vector)) ->
+    unsafeSystemIOToBO do
+      GM.unsafeWrite vector index value
+      NonLinear.pure array
+
+{- | Transform an element and return an auxiliary unrestricted result.
+
+The callback receives and returns unrestricted values. The mutable vector
+borrow is unavailable until the replacement has been written. This is a
+normal-return guarantee; no owner recovery is promised after an exception.
+-}
+update ::
+  (HasCallStack, G.Vector v a, α >= β) =>
+  Int ->
+  (a -> BO β (Ur result, Ur a)) ->
+  Mut α (Vector v a) %1 ->
+  BO β (Ur result, Mut α (Vector v a))
+{-# INLINE update #-}
+update index action array =
+  case size array of
+    (Ur length_, array)
+      | index < 0 || index >= length_ ->
+          error
+            ( "update: index "
+                <> show index
+                <> " out of bounds for length "
+                <> show length_
+            )
+            array
+      | otherwise -> unsafeUpdate index action array
+
+{- | Unchecked 'update'. The index must satisfy @0 <= index < size@.
+
+The callback receives and returns unrestricted values. The mutable vector
+borrow is unavailable until the replacement has been written. This is a
+normal-return guarantee; no owner recovery is promised after an exception.
+-}
+unsafeUpdate ::
+  (G.Vector v a, α >= β) =>
+  Int ->
+  (a -> BO β (Ur result, Ur a)) ->
+  Mut α (Vector v a) %1 ->
+  BO β (Ur result, Mut α (Vector v a))
+{-# INLINE unsafeUpdate #-}
+unsafeUpdate index action =
+  Unsafe.toLinear \(UnsafeAlias array@(Vector vector)) -> Control.do
+    Ur value <-
+      unsafeSystemIOToBO do
+        value <- GM.unsafeRead vector index
+        NonLinear.pure (Ur value)
+    (result, Ur updatedValue) <- action value
+    () <- unsafeSystemIOToBO (GM.unsafeWrite vector index updatedValue)
+    Control.pure (result, UnsafeAlias array)
+
+-- | Transform an element.
+modify ::
+  (HasCallStack, G.Vector v a, α >= β) =>
+  Int ->
+  (a -> a) ->
+  Mut α (Vector v a) %1 ->
+  BO β (Mut α (Vector v a))
+{-# INLINE modify #-}
+modify index function array = Control.do
+  (Ur (), array) <-
+    update
+      index
+      (\value -> Control.pure (Ur (), Ur (function value)))
+      array
+  Control.pure array
+
+-- | Swap two elements.
+swap ::
+  (HasCallStack, G.Vector v a, α >= β) =>
+  Mut α (Vector v a) %1 ->
+  Int ->
+  Int ->
+  BO β (Mut α (Vector v a))
+{-# INLINE swap #-}
+swap array first second =
+  case size array of
+    (Ur length_, array)
+      | first
+          < 0
+          || first
+          >= length_
+          || second
+          < 0
+          || second
+          >= length_ ->
+          error
+            ( "swap: indices "
+                <> show (first, second)
+                <> " out of bounds for length "
+                <> show length_
+            )
+            array
+      | otherwise -> unsafeSwap array first second
+
+-- | Unchecked 'swap'. Both indices must satisfy @0 <= index < size@.
+unsafeSwap ::
+  (G.Vector v a, α >= β) =>
+  Mut α (Vector v a) %1 ->
+  Int ->
+  Int ->
+  BO β (Mut α (Vector v a))
+{-# INLINE unsafeSwap #-}
+unsafeSwap =
+  Unsafe.toLinear \array@(UnsafeAlias (Vector vector)) first second ->
+    unsafeSystemIOToBO do
+      GM.unsafeSwap vector first second
+      NonLinear.pure array
+
+{- | Split a borrow into two disjoint fixed ranges without copying.
+
+The index is clamped to @[0, size]@, matching @vector@'s 'GM.splitAt'.
+For a custom backend, safety requires its two returned slices not to overlap.
+-}
+splitAt ::
+  (G.Vector v a) =>
+  Int ->
+  Borrow bk α (Vector v a) %1 ->
+  ( Borrow bk α (Vector v a)
+  , Borrow bk α (Vector v a)
+  )
+{-# INLINE splitAt #-}
+splitAt index =
+  Unsafe.toLinear \(UnsafeAlias (Vector vector)) ->
+    case GM.splitAt index vector of
+      (left, right) ->
+        (UnsafeAlias (Vector left), UnsafeAlias (Vector right))

--- a/test/Data/Vector/Generic/Mutable/Linear/Borrow/Unrestricted/TypingCases.hs
+++ b/test/Data/Vector/Generic/Mutable/Linear/Borrow/Unrestricted/TypingCases.hs
@@ -1,0 +1,105 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE QualifiedDo #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# OPTIONS_GHC -O0 #-}
+{-# OPTIONS_GHC -Wno-name-shadowing #-}
+{-# OPTIONS_GHC -fdefer-type-errors -Wno-deferred-type-errors #-}
+
+module Data.Vector.Generic.Mutable.Linear.Borrow.Unrestricted.TypingCases (
+  module Data.Vector.Generic.Mutable.Linear.Borrow.Unrestricted.TypingCases,
+) where
+
+import Control.Functor.Linear qualified as Control
+import Control.Monad.Borrow.Pure.BO
+import Control.Monad.Borrow.Pure.Copyable (Copyable (copy))
+import Control.Syntax.DataFlow qualified as DataFlow
+import Data.Coerce (coerce)
+import Data.Vector qualified as V
+import Data.Vector.Generic.Mutable.Linear.Borrow.Unrestricted qualified as Vector
+import Data.Vector.Mutable.Linear.Borrow qualified as Owning
+import Prelude.Linear
+import Unsafe.Linear qualified as Unsafe
+import Prelude qualified as NonLinear
+
+newtype WrappedInt = WrappedInt Int
+
+newtype WrappedBackend a = WrappedBackend (V.Vector a)
+
+badBackendCoercion ::
+  Vector.Vector V.Vector Int %1 ->
+  Vector.Vector WrappedBackend Int
+badBackendCoercion = Unsafe.toLinear coerce
+
+badElementCoercion ::
+  Vector.Vector V.Vector WrappedInt %1 ->
+  Vector.Vector V.Vector Int
+badElementCoercion = Unsafe.toLinear coerce
+
+badOwnershipCoercion ::
+  Vector.Vector V.Vector Int %1 ->
+  Owning.Vector Int
+badOwnershipCoercion = Unsafe.toLinear coerce
+
+badElementBorrow ::
+  Mut α (Vector.Vector V.Vector Int) %1 ->
+  BO α (Mut α Int)
+badElementBorrow = Vector.get 0
+
+badDuplicate ::
+  Borrow bk α (Vector.Vector V.Vector Int) %1 ->
+  Vector.Vector V.Vector Int
+badDuplicate = copy
+
+badMutateShared ::
+  Share α (Vector.Vector V.Vector Int) ->
+  BO α (Share α (Vector.Vector V.Vector Int))
+badMutateShared =
+  Vector.modify 0 (\value -> value NonLinear.+ 1)
+
+badElementCoercionCase :: Int
+badElementCoercionCase =
+  linearly \linear ->
+    case Vector.toVector
+      ( badElementCoercion
+          (Vector.fromList @V.Vector [WrappedInt 1] linear)
+      ) of
+      Ur vector -> V.length vector
+
+badOwnershipCoercionCase :: Int
+badOwnershipCoercionCase =
+  linearly \linear ->
+    case Owning.toVector
+      (badOwnershipCoercion (Vector.fromList @V.Vector [1] linear)) of
+      Ur vector -> V.length vector
+
+badElementBorrowCase :: Int
+badElementBorrowCase =
+  linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <-
+        borrowM (Vector.fromList @V.Vector [1] ownerLinear)
+      element <- badElementBorrow vector
+      let !() = consume element
+      pureAfter
+        ( case Vector.toVector (reclaim lend) of
+            Ur frozen -> V.length frozen
+        )
+
+badMutateSharedCase :: Int
+badMutateSharedCase =
+  linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <-
+        borrowM (Vector.fromList @V.Vector [1] ownerLinear)
+      vector <-
+        sharing_ vector \shared -> Control.do
+          shared <- badMutateShared shared
+          Control.pure (consume shared)
+      let !() = consume vector
+      pureAfter
+        ( case Vector.toVector (reclaim lend) of
+            Ur frozen -> V.length frozen
+        )

--- a/test/Data/Vector/Generic/Mutable/Linear/Borrow/UnrestrictedSpec.hs
+++ b/test/Data/Vector/Generic/Mutable/Linear/Borrow/UnrestrictedSpec.hs
@@ -1,0 +1,446 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE ImpredicativeTypes #-}
+{-# LANGUAGE QualifiedDo #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# OPTIONS_GHC -Wno-name-shadowing #-}
+
+module Data.Vector.Generic.Mutable.Linear.Borrow.UnrestrictedSpec (
+  module Data.Vector.Generic.Mutable.Linear.Borrow.UnrestrictedSpec,
+) where
+
+import Control.Exception qualified as Exception
+import Control.Functor.Linear qualified as Control
+import Control.Monad.Borrow.Pure.BO
+import Control.Monad.Borrow.Pure.BO.Unsafe (Alias (UnsafeAlias))
+import Control.Monad.Borrow.Pure.Clone (Clone (clone))
+import Control.Monad.Borrow.Pure.Copyable (Copyable (copy))
+import Control.Syntax.DataFlow qualified as DataFlow
+import Data.IORef (IORef, modifyIORef', newIORef, readIORef)
+import Data.List qualified as List
+import Data.Vector qualified as V
+import Data.Vector.Generic.Mutable.Linear.Borrow.Unrestricted qualified as Vector
+import Data.Vector.Generic.Mutable.Linear.Borrow.Unrestricted.TypingCases
+import Data.Vector.Primitive qualified as P
+import Data.Vector.Unboxed qualified as U
+import GHC.IO (unsafePerformIO)
+import Prelude.Linear
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit
+import Unsafe.Linear qualified as Unsafe
+import Prelude qualified as NonLinear
+
+freezeBoxed :: Vector.Vector V.Vector Int %1 -> [Int]
+freezeBoxed vector =
+  case Vector.toVector vector of
+    Ur frozen -> V.toList frozen
+
+freezeUnboxed :: Vector.Vector U.Vector Int %1 -> [Int]
+freezeUnboxed vector =
+  case Vector.toVector vector of
+    Ur frozen -> U.toList frozen
+
+freezePrimitive :: Vector.Vector P.Vector Int %1 -> [Int]
+freezePrimitive vector =
+  case Vector.toVector vector of
+    Ur frozen -> P.toList frozen
+
+test_construction :: TestTree
+test_construction =
+  testGroup
+    "construction and backends"
+    [ testCase "boxed round trip" do
+        linearly
+          ( \linear ->
+              freezeBoxed (Vector.fromList @V.Vector [1, 2, 3] linear)
+          )
+          @?= [1, 2, 3]
+    , testCase "unboxed round trip" do
+        linearly
+          ( \linear ->
+              freezeUnboxed (Vector.fromList @U.Vector [1, 2, 3] linear)
+          )
+          @?= [1, 2, 3]
+    , testCase "primitive backend remains extensible" do
+        linearly
+          ( \linear ->
+              freezePrimitive (Vector.fromList @P.Vector [1, 2, 3] linear)
+          )
+          @?= [1, 2, 3]
+    , testCase "constant and empty" do
+        linearly
+          ( \linear ->
+              case dup linear of
+                (emptyLinear, constantLinear) ->
+                  ( freezeBoxed (Vector.empty @V.Vector @Int emptyLinear)
+                  , freezeUnboxed
+                      (Vector.constant @U.Vector 3 (7 :: Int) constantLinear)
+                  )
+          )
+          @?= ([], [7, 7, 7])
+    , testCase "fromVector copies its immutable source" do
+        let source = V.fromList [1, 2, 3]
+            result =
+              linearly \linear -> DataFlow.do
+                (ownerLinear, runLinear) <- dup linear
+                runBO runLinear Control.do
+                  (vector, lend) <-
+                    borrowM (Vector.fromVector source ownerLinear)
+                  (Ur _, vector) <- Vector.set 0 99 vector
+                  let !() = consume vector
+                  pureAfter (freezeBoxed (reclaim lend))
+        V.toList source @?= [1, 2, 3]
+        result @?= [99, 2, 3]
+    ]
+
+boxedOperations :: ((Int, Int, Int), [Int])
+boxedOperations =
+  linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <-
+        borrowM (Vector.fromList @V.Vector [1, 2, 3] ownerLinear)
+      (Ur first, vector) <- Vector.get 0 vector
+      (Ur old, vector) <- Vector.set 1 20 vector
+      (Ur auxiliary, vector) <-
+        Vector.update
+          2
+          (\value -> Control.pure (Ur (value * 2), Ur (value + 1)))
+          vector
+      vector <- Vector.modify 0 (\value -> value NonLinear.+ 10) vector
+      vector <- Vector.write 1 21 vector
+      vector <- Vector.swap vector 0 2
+      let !() = consume vector
+      pureAfter ((first, old, auxiliary), freezeBoxed (reclaim lend))
+
+sharedReads :: (Int, Int)
+sharedReads =
+  linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <-
+        borrowM (Vector.fromList @V.Vector [11, 22] ownerLinear)
+      ((first, second), vector) <-
+        sharing vector \shared -> Control.do
+          Ur first <- Vector.copyAt 0 shared
+          Ur second <- Vector.copyAt 1 shared
+          Control.pure (first, second)
+      let !() = consume vector
+      pureAfter
+        ( case Vector.toVector (reclaim lend) of
+            Ur _ -> (first, second)
+        )
+
+ordinaryElementMultiplicity :: (Int, [Int])
+ordinaryElementMultiplicity =
+  linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <-
+        borrowM (Vector.fromList @V.Vector [1, 2] ownerLinear)
+      let replacement = 7
+      (Ur displaced, vector) <- Vector.set 0 replacement vector
+      vector <- Vector.write 1 replacement vector
+      let !() = consume vector
+      pureAfter
+        ( displaced + displaced
+        , freezeBoxed (reclaim lend)
+        )
+
+test_operations :: TestTree
+test_operations =
+  testGroup
+    "unrestricted element operations"
+    [ testCase "get, set, update, modify, and swap" do
+        boxedOperations @?= ((1, 2, 6), [4, 21, 11])
+    , testCase "a shared borrow may be read repeatedly" do
+        sharedReads @?= (11, 22)
+    , testCase "inputs, callbacks, and displaced values are unrestricted" do
+        ordinaryElementMultiplicity @?= (2, [7, 7])
+    ]
+
+splitBoxed :: [Int]
+splitBoxed =
+  linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <-
+        borrowM (Vector.fromList @V.Vector [1, 2, 3, 4] ownerLinear)
+      let !(left, right) = Vector.splitAt 2 vector
+      (left, right) <-
+        parBO
+          (Vector.modify 0 (\value -> value NonLinear.+ 10) left)
+          (Vector.modify 1 (\value -> value NonLinear.+ 20) right)
+      let !() = consume (left, right)
+      pureAfter (freezeBoxed (reclaim lend))
+
+splitUnboxed :: [Int]
+splitUnboxed =
+  linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <-
+        borrowM (Vector.fromList @U.Vector [1, 2, 3, 4] ownerLinear)
+      let !(left, right) = Vector.splitAt 2 vector
+      (left, right) <-
+        parBO
+          (Vector.modify 1 (\value -> value NonLinear.+ 10) left)
+          (Vector.modify 0 (\value -> value NonLinear.+ 20) right)
+      let !() = consume (left, right)
+      pureAfter (freezeUnboxed (reclaim lend))
+
+nestedBoundarySplits :: [Int]
+nestedBoundarySplits =
+  linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <-
+        borrowM (Vector.fromList @V.Vector [1, 2, 3, 4] ownerLinear)
+      let !(emptyLeft, rest) = Vector.splitAt 0 vector
+          !(prefix, emptyRight) = Vector.splitAt 4 rest
+          !(firstTwo, latterTwo) = Vector.splitAt 2 prefix
+          !(third, fourth) = Vector.splitAt 1 latterTwo
+      firstTwo <-
+        Vector.modify 0 (\value -> value NonLinear.+ 10) firstTwo
+      third <-
+        Vector.modify 0 (\value -> value NonLinear.+ 20) third
+      fourth <-
+        Vector.modify 0 (\value -> value NonLinear.+ 30) fourth
+      let !() = consume (emptyLeft, emptyRight, firstTwo, third, fourth)
+      pureAfter (freezeBoxed (reclaim lend))
+
+sharedSplitReads :: (Int, Int)
+sharedSplitReads =
+  linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <-
+        borrowM (Vector.fromList @U.Vector [10, 20, 30, 40] ownerLinear)
+      ((Ur leftValue, Ur rightValue), vector) <-
+        sharing vector \shared -> Control.do
+          let !(left, right) = Vector.splitAt 2 shared
+          parBO
+            (Vector.copyAt 1 left)
+            (Vector.copyAt 0 right)
+      let !() = consume vector
+      pureAfter
+        ( case Vector.toVector (reclaim lend) of
+            Ur _ -> (leftValue, rightValue)
+        )
+
+test_split :: TestTree
+test_split =
+  testGroup
+    "split ownership"
+    [ testCase "boxed disjoint slices mutate in parallel" do
+        splitBoxed @?= [11, 2, 3, 24]
+    , testCase "unboxed disjoint slices mutate in parallel" do
+        splitUnboxed @?= [1, 12, 23, 4]
+    , testCase "boundary and nested splits preserve disjoint ownership" do
+        nestedBoundarySplits @?= [11, 2, 23, 34]
+    , testCase "shared split ranges can be read in parallel" do
+        sharedSplitReads @?= (20, 30)
+    ]
+
+data Tracked = Tracked
+  { capabilityCalls :: !(IORef Int)
+  , trackedValue :: !Int
+  }
+
+recordCapability :: Tracked -> Tracked
+recordCapability tracked =
+  case unsafePerformIO
+    (modifyIORef' (capabilityCalls tracked) NonLinear.succ) of
+    () -> tracked
+
+instance Consumable Tracked where
+  consume =
+    Unsafe.toLinear \tracked ->
+      recordCapability tracked `NonLinear.seq` ()
+
+instance Dupable Tracked where
+  dup2 =
+    Unsafe.toLinear \tracked ->
+      (recordCapability tracked, recordCapability tracked)
+
+instance Movable Tracked where
+  move = Unsafe.toLinear \tracked -> Ur (recordCapability tracked)
+
+instance Copyable Tracked where
+  copy =
+    Unsafe.toLinear \(UnsafeAlias tracked) ->
+      recordCapability tracked
+
+capabilityFreeLifecycle :: IORef Int -> ([Int], [Int], [Int])
+capabilityFreeLifecycle calls =
+  linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <-
+        borrowM
+          ( Vector.fromVector
+              (V.fromList [Tracked calls 1, Tracked calls 2])
+              ownerLinear
+          )
+      (cloned, vector) <- sharing vector (\shared -> clone shared)
+      (Ur snapshot, vector) <- Vector.copyToVector vector
+      (Ur first, vector) <- Vector.copyAtMut 0 vector
+      (Ur old, vector) <- Vector.set 1 (Tracked calls 3) vector
+      vector <- Vector.write 0 (Tracked calls 4) vector
+      let
+        !() = consume vector
+        clonedValues =
+          case Vector.toVector cloned of
+            Ur frozen -> NonLinear.map trackedValue (V.toList frozen)
+      pureAfter
+        ( case Vector.toVector (reclaim lend) of
+            Ur frozen ->
+              ( NonLinear.map trackedValue (V.toList snapshot)
+              , clonedValues
+              , [trackedValue first, trackedValue old]
+                  <> NonLinear.map trackedValue (V.toList frozen)
+              )
+        )
+
+test_capabilities :: TestTree
+test_capabilities =
+  testGroup
+    "capability-free elements"
+    [ testCase "all fixed operations avoid element capability callbacks" do
+        calls <- newIORef 0
+        capabilityFreeLifecycle calls
+          @?= ([1, 2], [1, 2], [1, 2, 4, 3])
+        count <- readIORef calls
+        count @?= 0
+    , testCase "a clone has independent mutable backing" do
+        cloneIndependence @?= ([1, 2], [11, 2])
+    ]
+
+cloneIndependence :: ([Int], [Int])
+cloneIndependence =
+  linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <-
+        borrowM (Vector.fromList @V.Vector [1, 2] ownerLinear)
+      (cloned, vector) <- sharing vector (\shared -> clone shared)
+      vector <-
+        Vector.modify 0 (\value -> value NonLinear.+ 10) vector
+      let
+        !() = consume vector
+        clonedValues = freezeBoxed cloned
+      pureAfter
+        ( clonedValues
+        , freezeBoxed (reclaim lend)
+        )
+
+referenceAliasValue :: IORef Int -> Int
+referenceAliasValue reference =
+  linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <-
+        borrowM (Vector.fromVector (V.singleton reference) ownerLinear)
+      (Ur observed, vector) <- Vector.get 0 vector
+      let !() = consume vector
+      pureAfter
+        ( case Vector.toVector (reclaim lend) of
+            Ur frozen ->
+              unsafePerformIO do
+                modifyIORef'
+                  observed
+                  (\value -> value NonLinear.+ 41)
+                readIORef (V.head frozen)
+        )
+
+test_aliasing :: TestTree
+test_aliasing =
+  testCase "boxed entries deliberately remain GC-owned aliases" do
+    reference <- newIORef 1
+    referenceAliasValue reference @?= 42
+    originalValue <- readIORef reference
+    originalValue @?= 42
+
+getOutOfBounds :: Int -> Int
+getOutOfBounds index =
+  linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <-
+        borrowM (Vector.fromList @V.Vector [1, 2, 3] ownerLinear)
+      (Ur value, vector) <- Vector.get index vector
+      let !() = consume vector
+      pureAfter
+        ( case Vector.toVector (reclaim lend) of
+            Ur frozen -> value + V.length frozen
+        )
+
+writeOutOfBounds :: Int -> Int
+writeOutOfBounds index =
+  linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <-
+        borrowM (Vector.fromList @V.Vector [1, 2, 3] ownerLinear)
+      vector <- Vector.write index 4 vector
+      let !() = consume vector
+      pureAfter
+        ( case Vector.toVector (reclaim lend) of
+            Ur frozen -> V.sum frozen
+        )
+
+assertErrorPrefix :: NonLinear.String -> a -> Assertion
+assertErrorPrefix expectedPrefix value = do
+  result <- Exception.try @Exception.ErrorCall (Exception.evaluate value)
+  case result of
+    Left exception ->
+      assertBool
+        ("unexpected error: " <> Exception.displayException exception)
+        (expectedPrefix `List.isPrefixOf` Exception.displayException exception)
+    Right _ ->
+      assertFailure ("expected error beginning with " <> expectedPrefix)
+
+test_bounds :: TestTree
+test_bounds =
+  testGroup
+    "bounds"
+    [ testCase "negative index" do
+        assertErrorPrefix "get: index -1 out of bounds" (getOutOfBounds (-1))
+    , testCase "upper bound" do
+        assertErrorPrefix "get: index 3 out of bounds" (getOutOfBounds 3)
+    , testCase "write checks its lower bound" do
+        assertErrorPrefix "write: index -1 out of bounds" (writeOutOfBounds (-1))
+    , testCase "write checks its upper bound" do
+        assertErrorPrefix "write: index 3 out of bounds" (writeOutOfBounds 3)
+    ]
+
+assertDeferredTypeError :: NonLinear.String -> a -> Assertion
+assertDeferredTypeError expectedFragment value = do
+  result <- Exception.try @Exception.SomeException (Exception.evaluate value)
+  case result of
+    Left exception ->
+      assertBool
+        ("unexpected deferred error: " <> Exception.displayException exception)
+        (expectedFragment `List.isInfixOf` Exception.displayException exception)
+    Right _ ->
+      assertFailure
+        ("expected deferred type error containing " <> expectedFragment)
+
+test_typing :: TestTree
+test_typing =
+  testGroup
+    "typing boundaries"
+    [ testCase "backend role is nominal" do
+        assertDeferredTypeError "Couldn't match type" badBackendCoercion
+    , testCase "element role is nominal" do
+        assertDeferredTypeError "Couldn't match type" badElementCoercionCase
+    , testCase "ownership families cannot be coerced" do
+        assertDeferredTypeError "representation" badOwnershipCoercionCase
+    , testCase "get cannot manufacture an element borrow" do
+        assertDeferredTypeError "Couldn't match" badElementBorrowCase
+    , testCase "the mutable owner cannot be copied" do
+        assertDeferredTypeError "cannot be copied!" badDuplicate
+    , testCase "shared borrows cannot mutate" do
+        assertDeferredTypeError "Couldn't match" badMutateSharedCase
+    ]


### PR DESCRIPTION
`Data.Vector.Generic.Mutable.Linear.Borrow.Unrestricted` is a
fixed-size, borrow-aware mutable vector that is polymorphic in the
`vector` backend (`Data.Vector.Generic.Mutable.MVector`), so boxed,
unboxed, storable and primitive storage share one implementation.

Its elements are GC-owned rather than linearly owned: entries bind
nonlinearly, the vector exclusively owns only its mutable backing
storage. That is the other setting of the element-ownership axis
`AGENTS.md` describes, and it is what makes the backend polymorphism
possible — an unboxed backend cannot hold linearly owned elements in the
first place. Consequences: reads return the element directly instead of
a borrow of it, `set` does not have to hand back the previous element to
keep it alive, and materialization freezes the buffer in O(1) with no
per-element move.

Borrow discipline is unchanged: `Mut`/`Share` borrows, `splitAt` into
disjoint sub-borrows, and reclamation through `Lend` all behave as they
do for the element-owning vectors.

Comes with a property suite covering both a boxed and an unboxed
instantiation, and a `TypingCases` module pinning the coercion,
lifetime and escape constraints.
Part of #14.