### PR TITLE
feat(vector): add growable unboxed vectors

### DIFF
--- a/internal-src/test-bench-common/PureBorrow/Internal/Bench/Unboxed.hs
+++ b/internal-src/test-bench-common/PureBorrow/Internal/Bench/Unboxed.hs
@@ -7,25 +7,51 @@
 module PureBorrow.Internal.Bench.Unboxed (
   defaultMain,
   benches,
-  directFixedUnboxedUpdateLoop,
-  pureBorrowFixedUnboxedUpdateLoop,
+  directFixedUnboxedKernel,
+  directFixedUnboxedMaterialization,
+  directGrowableUnboxedGrowthKernel,
+  directGrowableUnboxedMaterialization,
+  directGrowableUnboxedNoGrowthKernel,
+  owningBoxedQsortKernel,
+  pureBorrowFixedUnboxedKernel,
+  pureBorrowFixedUnboxedMaterialization,
+  pureBorrowGrowableUnboxedGrowthKernel,
+  pureBorrowGrowableUnboxedMaterialization,
+  pureBorrowGrowableUnboxedNoGrowthKernel,
+  unrestrictedBoxedFftKernel,
+  unrestrictedBoxedQsortKernel,
+  unrestrictedUnboxedFftKernel,
+  unrestrictedUnboxedQsortKernel,
 ) where
 
+import Control.Concurrent.DivideConquer.Linear qualified as DC
 import Control.Functor.Linear qualified as Control
 import Control.Monad.Borrow.Pure
-import Control.Monad.ST.Strict (ST)
+import Control.Monad.ST.Strict (ST, runST)
 import Control.Syntax.DataFlow qualified as DataFlow
+import Data.Complex (Complex (..))
+import Data.Ref.Linear qualified as Ref
+import Data.STRef (STRef, newSTRef, readSTRef, writeSTRef)
+import Data.Vector qualified as B
+import Data.Vector.Generic qualified as G
+import Data.Vector.Generic.Mutable.Linear.Borrow.Unrestricted qualified as UnrestrictedVector
+import Data.Vector.Mutable.Linear.Borrow qualified as OwningVector
 import Data.Vector.Unboxed qualified as U
 import Data.Vector.Unboxed.Mutable qualified as UM
+import Data.Vector.Unboxed.Mutable.Growable.Linear.Borrow qualified as Growable
+import Data.Vector.Unboxed.Mutable.Growable.Linear.Borrow.Internal qualified as GrowableInternal
 import Data.Vector.Unboxed.Mutable.Linear.Borrow qualified as Vector
+import Data.Vector.Unboxed.Mutable.Linear.Borrow.Internal qualified as VectorInternal
+import GHC.IO (unsafePerformIO)
 import Prelude.Linear
 import Test.Tasty.Bench hiding (defaultMain)
 import Test.Tasty.Bench qualified as Bench
+import Unsafe.Linear qualified as Unsafe
 import Prelude qualified as NonLinear
 
-directFixedUnboxedUpdateLoop :: U.Vector Int -> U.Vector Int
-{-# NOINLINE directFixedUnboxedUpdateLoop #-}
-directFixedUnboxedUpdateLoop input =
+directFixedUnboxedKernel :: U.Vector Int -> U.Vector Int
+{-# NOINLINE directFixedUnboxedKernel #-}
+directFixedUnboxedKernel input =
   U.modify (\vector -> directWorker (UM.length vector) 0 vector) input
 
 directWorker :: Int -> Int -> UM.MVector s Int -> ST s ()
@@ -37,15 +63,186 @@ directWorker !length_ !index vector
       UM.unsafeWrite vector index (value + 1)
       directWorker length_ (index + 1) vector
 
-pureBorrowFixedUnboxedUpdateLoop :: U.Vector Int -> U.Vector Int
-{-# NOINLINE pureBorrowFixedUnboxedUpdateLoop #-}
-pureBorrowFixedUnboxedUpdateLoop input =
+{- | Benchmark-only monomorphic finalization for the fixed-vector kernels.
+
+For 'Int', 'move' is observationally the identity. Bypassing the public
+materialization loop isolates the update worker; this is not an API-performance
+root.
+-}
+unsafeBenchmarkFreezeFixedInt :: Vector.Vector Int %1 -> Ur (U.Vector Int)
+{-# NOINLINE unsafeBenchmarkFreezeFixedInt #-}
+unsafeBenchmarkFreezeFixedInt =
+  Unsafe.toLinear \(VectorInternal.Vector vector) ->
+    Ur (unsafePerformIO (U.unsafeFreeze vector))
+
+directFixedUnboxedMaterialization :: U.Vector Int -> U.Vector Int
+{-# NOINLINE directFixedUnboxedMaterialization #-}
+directFixedUnboxedMaterialization input =
+  U.modify (\_ -> NonLinear.pure ()) input
+
+pureBorrowFixedUnboxedMaterialization :: U.Vector Int -> U.Vector Int
+{-# NOINLINE pureBorrowFixedUnboxedMaterialization #-}
+pureBorrowFixedUnboxedMaterialization input =
+  unur $
+    linearly \linear ->
+      Vector.toVector (Vector.fromVector input linear)
+
+pureBorrowFixedUnboxedKernel :: U.Vector Int -> U.Vector Int
+{-# NOINLINE pureBorrowFixedUnboxedKernel #-}
+pureBorrowFixedUnboxedKernel input =
   unur $ linearly \linear -> DataFlow.do
     (ownerLinear, runLinear) <- dup linear
     runBO runLinear Control.do
       (vector, lend) <- borrowM (Vector.fromVector input ownerLinear)
       pureBorrowWorker (U.length input) 0 vector
-      pureAfter (Vector.toVector (reclaim lend))
+      pureAfter (unsafeBenchmarkFreezeFixedInt (reclaim lend))
+
+directGrowableUnboxedNoGrowthKernel :: U.Vector Int -> U.Vector Int
+{-# NOINLINE directGrowableUnboxedNoGrowthKernel #-}
+directGrowableUnboxedNoGrowthKernel input =
+  U.modify
+    ( \vector -> do
+        -- The header ref mirrors the growable owner's indirection, so the
+        -- baseline pays for the same loads the measured variant does.
+        header <- newSTRef (U.length input, vector)
+        (_, content) <- readSTRef header
+        directWorker (UM.length content) 0 content
+        -- Match the growable owner's final header access.
+        (_, _) <- readSTRef header
+        NonLinear.pure ()
+    )
+    input
+
+{- | Benchmark-only monomorphic finalization for the growable-vector kernels.
+
+The reclaimed owner is consumed exactly once and only its initialized prefix is
+frozen. As with 'unsafeBenchmarkFreezeFixedInt', this isolates the kernel and
+must not be interpreted as public materialization cost.
+-}
+unsafeBenchmarkFreezeGrowableInt ::
+  Growable.GrowableVector Int %1 ->
+  Ur (U.Vector Int)
+{-# NOINLINE unsafeBenchmarkFreezeGrowableInt #-}
+unsafeBenchmarkFreezeGrowableInt =
+  Unsafe.toLinear \(GrowableInternal.GrowableVector ref) ->
+    case Ref.free ref of
+      GrowableInternal.Header logicalSize vector ->
+        Ur
+          ( unsafePerformIO
+              (U.unsafeFreeze (UM.unsafeTake logicalSize vector))
+          )
+
+directGrowableUnboxedMaterialization :: U.Vector Int -> U.Vector Int
+{-# NOINLINE directGrowableUnboxedMaterialization #-}
+directGrowableUnboxedMaterialization input =
+  U.modify
+    ( \vector -> do
+        header <- newSTRef (U.length input, vector)
+        (_, _) <- readSTRef header
+        NonLinear.pure ()
+    )
+    input
+
+pureBorrowGrowableUnboxedMaterialization :: U.Vector Int -> U.Vector Int
+{-# NOINLINE pureBorrowGrowableUnboxedMaterialization #-}
+pureBorrowGrowableUnboxedMaterialization input =
+  unur $
+    linearly \linear ->
+      Growable.toVector (Growable.fromVector input linear)
+
+pureBorrowGrowableUnboxedNoGrowthKernel :: U.Vector Int -> U.Vector Int
+{-# NOINLINE pureBorrowGrowableUnboxedNoGrowthKernel #-}
+pureBorrowGrowableUnboxedNoGrowthKernel input =
+  unur $ linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <-
+        borrowM
+          ( Growable.unsafeFromMutable
+              (unsafePerformIO (U.thaw input))
+              ownerLinear
+          )
+      vector <-
+        Growable.withContent_ vector \content ->
+          pureBorrowWorker (U.length input) 0 content
+      let !() = consume vector
+      pureAfter (unsafeBenchmarkFreezeGrowableInt (reclaim lend))
+
+directGrowableUnboxedGrowthKernel :: U.Vector Int -> (U.Vector Int, Int)
+{-# NOINLINE directGrowableUnboxedGrowthKernel #-}
+-- The result length differs from the input's, so this one cannot go through
+-- 'U.modify'; 'runST' keeps it equally safe, and the buffer never escapes.
+directGrowableUnboxedGrowthKernel input = runST do
+  initial <- UM.unsafeNew 0
+  header <- newSTRef (0, initial)
+  directGrowthWorker input 0 header
+  (_, capacityContent) <- readSTRef header
+  (logicalSize, content) <- readSTRef header
+  frozen <- U.freeze (UM.unsafeTake logicalSize content)
+  NonLinear.pure (frozen, UM.length capacityContent)
+
+directGrowthWorker ::
+  U.Vector Int ->
+  Int ->
+  STRef s (Int, UM.MVector s Int) ->
+  ST s ()
+{-# NOINLINE directGrowthWorker #-}
+directGrowthWorker input !index header
+  | index >= U.length input = NonLinear.pure ()
+  | otherwise = do
+      (logicalSize, content) <- readSTRef header
+      grown <-
+        if logicalSize < UM.length content
+          then NonLinear.pure content
+          else do
+            let !capacity = growthTarget (UM.length content) (logicalSize + 1)
+            target <- UM.unsafeNew capacity
+            UM.unsafeCopy
+              (UM.unsafeTake logicalSize target)
+              (UM.unsafeTake logicalSize content)
+            NonLinear.pure target
+      UM.unsafeWrite grown logicalSize (U.unsafeIndex input index)
+      writeSTRef header (logicalSize + 1, grown)
+      directGrowthWorker input (index + 1) header
+
+pureBorrowGrowableUnboxedGrowthKernel :: U.Vector Int -> (U.Vector Int, Int)
+{-# NOINLINE pureBorrowGrowableUnboxedGrowthKernel #-}
+pureBorrowGrowableUnboxedGrowthKernel input =
+  unur $ linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <- borrowM (Growable.empty ownerLinear)
+      vector <- pureBorrowGrowthWorker input 0 vector
+      Growable.capacity vector & \(Ur finalCapacity, vector) -> DataFlow.do
+        consume vector
+        pureAfter
+          (attachCapacity finalCapacity (unsafeBenchmarkFreezeGrowableInt (reclaim lend)))
+
+attachCapacity :: Int -> Ur (U.Vector Int) %1 -> Ur (U.Vector Int, Int)
+attachCapacity =
+  Unsafe.toLinear2 \finalCapacity (Ur frozen) ->
+    Ur (frozen, finalCapacity)
+
+pureBorrowGrowthWorker ::
+  forall α.
+  U.Vector Int ->
+  Int ->
+  Mut α (Growable.GrowableVector Int) %1 ->
+  BO α (Mut α (Growable.GrowableVector Int))
+{-# NOINLINE pureBorrowGrowthWorker #-}
+pureBorrowGrowthWorker input !index vector
+  | index >= U.length input = Control.pure vector
+  | otherwise = Control.do
+      vector <- Growable.push (U.unsafeIndex input index) vector
+      pureBorrowGrowthWorker input (index + 1) vector
+
+growthTarget :: Int -> Int -> Int
+{-# INLINE growthTarget #-}
+growthTarget oldCapacity required
+  | required <= oldCapacity = oldCapacity
+  | oldCapacity <= 0 = required `max` 1
+  | oldCapacity > maxBound `quot` 2 = required
+  | otherwise = required `max` (oldCapacity * 2)
 
 pureBorrowWorker ::
   forall α.
@@ -64,18 +261,161 @@ pureBorrowWorker !length_ !index vector
           vector
       pureBorrowWorker length_ (index + 1) vector
 
+owningBoxedQsortKernel :: B.Vector Int -> B.Vector Int
+{-# NOINLINE owningBoxedQsortKernel #-}
+owningBoxedQsortKernel input =
+  unur $ linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <-
+        borrowM (OwningVector.fromVector input ownerLinear)
+      OwningVector.qsort 0 vector
+      pureAfter (OwningVector.toVector (reclaim lend))
+
+unrestrictedQsortKernel ::
+  (G.Vector v Int) =>
+  v Int ->
+  v Int
+{-# INLINEABLE unrestrictedQsortKernel #-}
+unrestrictedQsortKernel input =
+  unur $ linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <-
+        borrowM (UnrestrictedVector.fromVector input ownerLinear)
+      DC.qsort 0 vector
+      pureAfter (UnrestrictedVector.toVector (reclaim lend))
+
+unrestrictedBoxedQsortKernel :: B.Vector Int -> B.Vector Int
+{-# NOINLINE unrestrictedBoxedQsortKernel #-}
+unrestrictedBoxedQsortKernel = unrestrictedQsortKernel
+
+unrestrictedUnboxedQsortKernel :: U.Vector Int -> U.Vector Int
+{-# NOINLINE unrestrictedUnboxedQsortKernel #-}
+unrestrictedUnboxedQsortKernel = unrestrictedQsortKernel
+
+unrestrictedFftKernel ::
+  (G.Vector v (Complex Double)) =>
+  v (Complex Double) ->
+  v (Complex Double)
+{-# INLINEABLE unrestrictedFftKernel #-}
+unrestrictedFftKernel input =
+  unur $ linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <-
+        borrowM (UnrestrictedVector.fromVector input ownerLinear)
+      Control.void $
+        DC.sequentialDivideAndConquer
+          (DC.fftDC' 128)
+          vector
+      pureAfter (UnrestrictedVector.toVector (reclaim lend))
+
+unrestrictedBoxedFftKernel ::
+  B.Vector (Complex Double) ->
+  B.Vector (Complex Double)
+{-# NOINLINE unrestrictedBoxedFftKernel #-}
+unrestrictedBoxedFftKernel = unrestrictedFftKernel
+
+unrestrictedUnboxedFftKernel ::
+  U.Vector (Complex Double) ->
+  U.Vector (Complex Double)
+{-# NOINLINE unrestrictedUnboxedFftKernel #-}
+unrestrictedUnboxedFftKernel = unrestrictedFftKernel
+
 defaultMain :: IO ()
 defaultMain = Bench.defaultMain benches
 
 benches :: [Benchmark]
 benches =
-  [ env
-      (NonLinear.pure $ U.generate length_ (`NonLinear.rem` 1024))
-      \input ->
-        bgroup
-          ("fixed-unboxed/" <> show length_)
-          [ bench "direct" $ nf directFixedUnboxedUpdateLoop input
-          , bench "pure-borrow" $ nf pureBorrowFixedUnboxedUpdateLoop input
-          ]
-  | length_ <- [1024, 1024 * 1024]
-  ]
+  NonLinear.concat
+    [ [ env
+          (NonLinear.pure $ U.generate length_ (`NonLinear.rem` 1024))
+          \input ->
+            bgroup
+              ("kernel/fixed-unboxed/" <> show length_)
+              [ bench "direct" $ nf directFixedUnboxedKernel input
+              , bench "pure-borrow" $ nf pureBorrowFixedUnboxedKernel input
+              ]
+      , env
+          (NonLinear.pure $ U.generate length_ (`NonLinear.rem` 1024))
+          \input ->
+            bgroup
+              ("kernel/growable-unboxed/no-growth/" <> show length_)
+              [ bench "direct" $ nf directGrowableUnboxedNoGrowthKernel input
+              , bench "pure-borrow" $ nf pureBorrowGrowableUnboxedNoGrowthKernel input
+              ]
+      , env
+          (NonLinear.pure $ U.generate length_ (`NonLinear.rem` 1024))
+          \input ->
+            bgroup
+              ("kernel/growable-unboxed/growth/" <> show length_)
+              [ bench "direct" $ nf directGrowableUnboxedGrowthKernel input
+              , bench "pure-borrow" $ nf pureBorrowGrowableUnboxedGrowthKernel input
+              ]
+      , env
+          (NonLinear.pure $ U.generate length_ (`NonLinear.rem` 1024))
+          \input ->
+            bgroup
+              ("public-materialization/fixed-unboxed/" <> show length_)
+              [ bench "direct" $ nf directFixedUnboxedMaterialization input
+              , bench "pure-borrow" $ nf pureBorrowFixedUnboxedMaterialization input
+              ]
+      , env
+          (NonLinear.pure $ U.generate length_ (`NonLinear.rem` 1024))
+          \input ->
+            bgroup
+              ("public-materialization/growable-unboxed/" <> show length_)
+              [ bench "direct" $ nf directGrowableUnboxedMaterialization input
+              , bench "pure-borrow" $ nf pureBorrowGrowableUnboxedMaterialization input
+              ]
+      ]
+    | length_ <- [0, 1, 1024, 1024 * 1024]
+    ]
+    <> [ env
+           ( NonLinear.pure
+               ( B.generate length_ (comparisonQsortValue length_)
+               , U.generate length_ (comparisonQsortValue length_)
+               )
+           )
+           \ ~(boxedInput, unboxedInput) ->
+             bgroup
+               ( "algorithm/qsort/storage-and-element-ownership/"
+                   <> show length_
+               )
+               [ bench "owning/boxed" $
+                   nf owningBoxedQsortKernel boxedInput
+               , bench "unrestricted/boxed" $
+                   nf unrestrictedBoxedQsortKernel boxedInput
+               , bench "unrestricted/unboxed" $
+                   nf unrestrictedUnboxedQsortKernel unboxedInput
+               ]
+       | length_ <- [8 * 1024, 32 * 1024]
+       ]
+    <> [ env
+           ( NonLinear.pure
+               ( B.generate length_ comparisonFftValue
+               , U.generate length_ comparisonFftValue
+               )
+           )
+           \ ~(boxedInput, unboxedInput) ->
+             bgroup
+               ( "algorithm/fft/storage-and-element-ownership/"
+                   <> show length_
+               )
+               [ bench "unrestricted/boxed" $
+                   nf unrestrictedBoxedFftKernel boxedInput
+               , bench "unrestricted/unboxed" $
+                   nf unrestrictedUnboxedFftKernel unboxedInput
+               ]
+       | length_ <- [64 * 1024, 1024 * 1024]
+       ]
+
+comparisonQsortValue :: Int -> Int -> Int
+comparisonQsortValue length_ index =
+  (index * 1103515245 + 12345) `NonLinear.rem` (length_ + 1)
+
+comparisonFftValue :: Int -> Complex Double
+comparisonFftValue index =
+  let position = fromIntegral index
+   in (sin (position / 17) + cos (position / 31)) :+ 0

--- a/pure-borrow.cabal
+++ b/pure-borrow.cabal
@@ -142,6 +142,8 @@ library
     Data.Vector.Mutable.Growable.Linear.Borrow.Internal
     Data.Vector.Mutable.Linear.Borrow
     Data.Vector.Mutable.Linear.Borrow.Internal
+    Data.Vector.Unboxed.Mutable.Growable.Linear.Borrow
+    Data.Vector.Unboxed.Mutable.Growable.Linear.Borrow.Internal
     Data.Vector.Unboxed.Mutable.Linear.Borrow
     Data.Vector.Unboxed.Mutable.Linear.Borrow.Internal
 
@@ -174,6 +176,8 @@ test-suite pure-borrow-test
     Data.Vector.Mutable.Growable.Linear.BorrowSpec
     Data.Vector.Mutable.Growable.Linear.TypingCases
     Data.Vector.Mutable.Linear.BorrowSpec
+    Data.Vector.Unboxed.Mutable.Growable.Linear.BorrowSpec
+    Data.Vector.Unboxed.Mutable.Growable.Linear.TypingCases
     Data.Vector.Unboxed.Mutable.Linear.BorrowSpec
     Data.Vector.Unboxed.Mutable.Linear.TypingCases
 

--- a/src/Data/Vector/Unboxed/Mutable/Growable/Linear/Borrow.hs
+++ b/src/Data/Vector/Unboxed/Mutable/Growable/Linear/Borrow.hs
@@ -1,0 +1,45 @@
+{-# LANGUAGE ImpredicativeTypes #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+
+{- |
+A growable unboxed variant of
+"Data.Vector.Mutable.Growable.Linear.Borrow".
+-}
+module Data.Vector.Unboxed.Mutable.Growable.Linear.Borrow (
+  GrowableVector,
+  empty,
+  constant,
+  fromList,
+  withCapacity,
+  fromVector,
+  unsafeFromMutable,
+  unsafeFromVector,
+  toVector,
+  toList,
+  size,
+  capacity,
+  get,
+  unsafeGet,
+  head,
+  unsafeHead,
+  last,
+  unsafeLast,
+  copyAt,
+  copyAtMut,
+  set,
+  unsafeSet,
+  update,
+  unsafeUpdate,
+  modify,
+  swap,
+  unsafeSwap,
+  reserve,
+  reserveAdditional,
+  push,
+  extend,
+  getContents,
+  withContent,
+  withContent_,
+) where
+
+import Data.Vector.Unboxed.Mutable.Growable.Linear.Borrow.Internal

--- a/src/Data/Vector/Unboxed/Mutable/Growable/Linear/Borrow/Internal.hs
+++ b/src/Data/Vector/Unboxed/Mutable/Growable/Linear/Borrow/Internal.hs
@@ -1,0 +1,790 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE ImpredicativeTypes #-}
+{-# LANGUAGE QualifiedDo #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RoleAnnotations #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# OPTIONS_GHC -Wno-name-shadowing #-}
+{-# OPTIONS_GHC -Wno-redundant-constraints #-}
+{-# OPTIONS_HADDOCK hide #-}
+
+module Data.Vector.Unboxed.Mutable.Growable.Linear.Borrow.Internal (
+  module Data.Vector.Unboxed.Mutable.Growable.Linear.Borrow.Internal,
+) where
+
+import Control.Functor.Linear qualified as Control
+import Control.Monad.Borrow.Pure.Affine (aff, pop)
+import Control.Monad.Borrow.Pure.BO
+import Control.Monad.Borrow.Pure.BO.Internal (unsafeSrunBO_)
+import Control.Monad.Borrow.Pure.BO.Unsafe
+import Control.Monad.Borrow.Pure.Copyable
+import Control.Monad.Borrow.Pure.Lifetime.Token.Unsafe (
+  LinearOnly (..),
+  LinearOnlyWitness (..),
+ )
+import Data.Ref.Linear qualified as Ref
+import Data.Ref.Linear.Borrow qualified as RefBorrow
+import Data.Unrestricted.Linear qualified as Ur
+import Data.Vector.Unboxed qualified as U
+import Data.Vector.Unboxed.Mutable qualified as UM
+import Data.Vector.Unboxed.Mutable.Linear.Borrow qualified as Fixed
+import Data.Vector.Unboxed.Mutable.Linear.Borrow.Internal qualified as Fixed.Internal
+import GHC.Exts qualified as GHC
+import GHC.IO (unsafePerformIO)
+import GHC.Stack (HasCallStack)
+import GHC.TypeError
+import Prelude.Linear hiding (getContents, head, last)
+import Unsafe.Linear qualified as Unsafe
+import Prelude qualified as NonLinear
+
+data Header a where
+  Header ::
+    {-# UNPACK #-} !Int ->
+    !(UM.IOVector a) %1 ->
+    Header a
+
+-- | Growable unboxed linear mutable vector.
+data GrowableVector a where
+  GrowableVector :: !(Ref.Ref (Header a)) %1 -> GrowableVector a
+
+type role Header nominal
+
+type role GrowableVector nominal
+
+instance LinearOnly (GrowableVector a) where
+  linearOnly = UnsafeLinearOnly
+  {-# INLINE linearOnly #-}
+
+instance
+  (Unsatisfiable (ShowType (GrowableVector a) :<>: Text " cannot be copied!")) =>
+  Copyable (GrowableVector a)
+  where
+  copy = unsatisfiable
+
+instance (U.Unbox a, Consumable a) => Consumable (GrowableVector a) where
+  consume =
+    Unsafe.toLinear \(GrowableVector ref) ->
+      case Ref.free ref of
+        Header logicalSize buffer -> consumeInitialized logicalSize buffer
+  -- Reaches 'unsafePerformIO' through 'consumeInitialized'. See the note
+  -- there: this must not be duplicated across call sites.
+  {-# NOINLINE consume #-}
+
+allocateBuffer ::
+  (U.Unbox a) =>
+  Int ->
+  Linearly %1 ->
+  UM.IOVector a
+{-# NOINLINE allocateBuffer #-}
+allocateBuffer =
+  GHC.noinline \count linear ->
+    linear `lseq` unsafePerformIO (UM.unsafeNew count)
+
+cloneBuffer ::
+  (U.Unbox a) =>
+  U.Vector a ->
+  Linearly %1 ->
+  UM.IOVector a
+{-# NOINLINE cloneBuffer #-}
+cloneBuffer =
+  GHC.noinline \source linear ->
+    linear `lseq` unsafePerformIO (U.thaw source)
+
+-- | \(O(1)\). Construct an empty vector with zero capacity.
+empty :: (U.Unbox a) => Linearly %1 -> GrowableVector a
+{-# NOINLINE empty #-}
+empty = withCapacity 0
+
+-- | \(O(n)\). Construct @n@ initialized copies of a value.
+constant ::
+  (U.Unbox a) =>
+  Int ->
+  a ->
+  Linearly %1 ->
+  GrowableVector a
+{-# NOINLINE constant #-}
+constant =
+  GHC.noinline \count value linear ->
+    fromVector (U.replicate count value) linear
+
+-- | \(O(n)\). Move a linear list into a new vector.
+fromList ::
+  (U.Unbox a) =>
+  [a] %1 ->
+  Linearly %1 ->
+  GrowableVector a
+{-# NOINLINE fromList #-}
+fromList =
+  GHC.noinline $
+    Unsafe.toLinear2 \values linear ->
+      dup linear & \(bufferLinear, refLinear) ->
+        case Fixed.fromList values bufferLinear of
+          Fixed.Internal.Vector buffer ->
+            GrowableVector
+              (Ref.new (Header (UM.length buffer) buffer) refLinear)
+
+{- | \(O(1)\). Construct an empty vector with requested capacity.
+
+The capacity must be non-negative. Spare storage is not initialized.
+-}
+withCapacity ::
+  (HasCallStack, U.Unbox a) =>
+  Int ->
+  Linearly %1 ->
+  GrowableVector a
+{-# NOINLINE withCapacity #-}
+withCapacity =
+  GHC.noinline \requested linear ->
+    if requested < 0
+      then error ("withCapacity: negative capacity " <> show requested) linear
+      else
+        dup linear & \(bufferLinear, refLinear) ->
+          GrowableVector
+            (Ref.new (Header 0 (allocateBuffer requested bufferLinear)) refLinear)
+
+-- | \(O(n)\). Copy an immutable unboxed vector into a new owner.
+fromVector ::
+  (U.Unbox a) =>
+  U.Vector a ->
+  Linearly %1 ->
+  GrowableVector a
+{-# NOINLINE fromVector #-}
+fromVector =
+  GHC.noinline \source linear ->
+    dup linear & \(bufferLinear, refLinear) ->
+      GrowableVector
+        ( Ref.new
+            (Header (U.length source) (cloneBuffer source bufferLinear))
+            refLinear
+        )
+
+{- | \(O(1)\). Take ownership of a mutable unboxed vector.
+
+The complete source slice must be initialized, and the caller must retain no
+alias or overlapping slice.
+-}
+unsafeFromMutable ::
+  (U.Unbox a) =>
+  UM.MVector state a %1 ->
+  Linearly %1 ->
+  GrowableVector a
+{-# INLINE unsafeFromMutable #-}
+unsafeFromMutable =
+  Unsafe.toLinear \source linear ->
+    GrowableVector
+      ( Ref.new
+          (Header (UM.length source) (Unsafe.coerce source))
+          linear
+      )
+
+{- | \(O(1)\). Unsafely take ownership of immutable unboxed storage.
+
+No immutable alias, including an overlapping slice, may be observed after
+this operation.
+-}
+unsafeFromVector ::
+  (U.Unbox a) =>
+  U.Vector a %1 ->
+  Linearly %1 ->
+  GrowableVector a
+{-# NOINLINE unsafeFromVector #-}
+unsafeFromVector =
+  GHC.noinline $
+    Unsafe.toLinear \source linear ->
+      GrowableVector
+        ( Ref.new
+            ( Header
+                (U.length source)
+                (unsafePerformIO (U.unsafeThaw source))
+            )
+            linear
+        )
+
+{- | \(O(n)\). Move every initialized element into GC ownership, then freeze
+that prefix.
+
+Spare capacity is not exposed.
+-}
+toVector ::
+  (U.Unbox a, Movable a) =>
+  GrowableVector a %1 ->
+  Ur (U.Vector a)
+{-# NOINLINE toVector #-}
+toVector =
+  GHC.noinline $
+    Unsafe.toLinear \(GrowableVector ref) ->
+      case Ref.free ref of
+        Header logicalSize buffer ->
+          let !frozen =
+                unsafePerformIO do
+                  moveInitialized logicalSize buffer
+                  U.unsafeFreeze (UM.unsafeTake logicalSize buffer)
+           in Ur frozen
+
+-- | \(O(n)\). Consume the owner and materialize its initialized prefix.
+toList ::
+  (U.Unbox a, Movable a) =>
+  GrowableVector a %1 ->
+  Ur [a]
+{-# INLINE toList #-}
+toList = Ur.lift U.toList . toVector
+
+moveInitialized ::
+  (U.Unbox a, Movable a) =>
+  Int ->
+  UM.IOVector a ->
+  NonLinear.IO ()
+{-# INLINE moveInitialized #-}
+moveInitialized !logicalSize buffer = go 0
+  where
+    go !index
+      | index >= logicalSize = NonLinear.pure ()
+      | otherwise = do
+          value <- UM.unsafeRead buffer index
+          case move value of
+            Ur !moved -> UM.unsafeWrite buffer index moved
+          go (index + 1)
+
+{- | Consume the initialized prefix, releasing each element exactly once.
+
+The traversal only reads the buffer, but it runs under 'unsafePerformIO'.
+That makes the binding a trusted boundary rather than an ordinary pure
+function: were it inlined, GHC could duplicate the call across use sites, or
+float it out of a scope, and each copy would consume the elements again. The
+'NOINLINE' keeps exactly one occurrence, so the exactly-once discipline the
+linear types promise is preserved in the generated code too.
+-}
+consumeInitialized ::
+  (U.Unbox a, Consumable a) =>
+  Int ->
+  UM.IOVector a %1 ->
+  ()
+{-# NOINLINE consumeInitialized #-}
+consumeInitialized =
+  Unsafe.toLinear2 \logicalSize buffer ->
+    let go !index
+          | index >= logicalSize = NonLinear.pure ()
+          | otherwise = do
+              value <- UM.unsafeRead buffer index
+              let !() = consume value
+              go (index + 1)
+     in unsafePerformIO (go 0)
+
+toRefMut ::
+  Mut α (GrowableVector a) %1 ->
+  Mut α (Ref.Ref (Header a))
+{-# INLINE toRefMut #-}
+toRefMut =
+  unsafeMapAlias
+    (Unsafe.toLinear \(GrowableVector ref) -> ref)
+
+fromRefMut ::
+  Mut α (Ref.Ref (Header a)) %1 ->
+  Mut α (GrowableVector a)
+{-# INLINE fromRefMut #-}
+fromRefMut =
+  unsafeMapAlias
+    (Unsafe.toLinear GrowableVector)
+
+withHeader ::
+  (α >= β) =>
+  (Header a %1 -> BO β (result, Header a)) %1 ->
+  Mut α (GrowableVector a) %1 ->
+  BO β (result, Mut α (GrowableVector a))
+{-# INLINE withHeader #-}
+withHeader action vector = Control.do
+  (result, ref) <- RefBorrow.update action (toRefMut vector)
+  Control.pure (result, fromRefMut ref)
+
+-- | \(O(1)\). Return logical size and thread the borrow.
+size ::
+  (U.Unbox a) =>
+  Borrow bk α (GrowableVector a) %1 ->
+  (Ur Int, Borrow bk α (GrowableVector a))
+{-# INLINE size #-}
+size =
+  Unsafe.toLinear \vector@(UnsafeAlias (GrowableVector ref)) ->
+    case Ref.unsafeReadRef ref of
+      (Header logicalSize _, duplicateRef) ->
+        pop (aff duplicateRef) `lseq` (Ur logicalSize, vector)
+
+-- | \(O(1)\). Return allocation capacity and thread the borrow.
+capacity ::
+  (U.Unbox a) =>
+  Borrow bk α (GrowableVector a) %1 ->
+  (Ur Int, Borrow bk α (GrowableVector a))
+{-# INLINE capacity #-}
+capacity =
+  Unsafe.toLinear \vector@(UnsafeAlias (GrowableVector ref)) ->
+    case Ref.unsafeReadRef ref of
+      (Header _ buffer, duplicateRef) ->
+        pop (aff duplicateRef) `lseq` (Ur (UM.length buffer), vector)
+
+-- | Borrow an initialized element at an index.
+get ::
+  (HasCallStack, U.Unbox a, α >= β) =>
+  Int ->
+  Borrow bk α (GrowableVector a) %1 ->
+  BO β (Borrow bk α a)
+{-# INLINE get #-}
+get index vector =
+  case size vector of
+    (Ur logicalSize, vector) ->
+      if index < 0 || index >= logicalSize
+        then
+          error
+            ( "get: index "
+                <> show index
+                <> " out of bounds for length "
+                <> show logicalSize
+            )
+            vector
+        else unsafeGet index vector
+
+-- | Unchecked 'get'. The index must satisfy @0 <= index < size@.
+unsafeGet ::
+  (U.Unbox a, α >= β) =>
+  Int ->
+  Borrow bk α (GrowableVector a) %1 ->
+  BO β (Borrow bk α a)
+{-# INLINE unsafeGet #-}
+unsafeGet =
+  Unsafe.toLinear2 \index (UnsafeAlias (GrowableVector ref)) ->
+    case Ref.unsafeReadRef ref of
+      (Header _ buffer, duplicateRef) ->
+        pop (aff duplicateRef) `lseq`
+          UnsafeAlias
+            Control.<$> unsafeSystemIOToBO (UM.unsafeRead buffer index)
+
+-- | Borrow the first initialized element.
+head ::
+  (HasCallStack, U.Unbox a, α >= β) =>
+  Borrow bk α (GrowableVector a) %1 ->
+  BO β (Borrow bk α a)
+{-# INLINE head #-}
+head = get 0
+
+-- | Unchecked 'head'. The vector must be non-empty.
+unsafeHead ::
+  (U.Unbox a, α >= β) =>
+  Borrow bk α (GrowableVector a) %1 ->
+  BO β (Borrow bk α a)
+{-# INLINE unsafeHead #-}
+unsafeHead = unsafeGet 0
+
+-- | Borrow the last initialized element.
+last ::
+  (HasCallStack, U.Unbox a, α >= β) =>
+  Borrow bk α (GrowableVector a) %1 ->
+  BO β (Borrow bk α a)
+{-# INLINE last #-}
+last vector =
+  case size vector of
+    (Ur logicalSize, vector) ->
+      if logicalSize <= 0
+        then error "last: empty vector" vector
+        else unsafeGet (logicalSize - 1) vector
+
+-- | Unchecked 'last'. The vector must be non-empty.
+unsafeLast ::
+  (U.Unbox a, α >= β) =>
+  Borrow bk α (GrowableVector a) %1 ->
+  BO β (Borrow bk α a)
+{-# INLINE unsafeLast #-}
+unsafeLast vector =
+  case size vector of
+    (Ur logicalSize, vector) -> unsafeGet (logicalSize - 1) vector
+
+-- | Copy an initialized element through a shared borrow.
+copyAt ::
+  (HasCallStack, U.Unbox a, Copyable a, α >= β) =>
+  Int ->
+  Share α (GrowableVector a) ->
+  BO β (Ur a)
+{-# INLINE copyAt #-}
+copyAt index vector = Control.do
+  Ur !value <- move Control.<$> get index vector
+  Control.pure $! Ur $! copy value
+
+-- | Copy an initialized element and retain the mutable borrow.
+copyAtMut ::
+  (HasCallStack, U.Unbox a, Copyable a, α >= β) =>
+  Int ->
+  Mut α (GrowableVector a) %1 ->
+  BO β (Ur a, Mut α (GrowableVector a))
+{-# INLINE copyAtMut #-}
+copyAtMut =
+  Unsafe.toLinear2 \index vector@(UnsafeAlias (GrowableVector ref)) ->
+    case Ref.unsafeReadRef ref of
+      (Header logicalSize buffer, duplicateRef) ->
+        pop (aff duplicateRef) `lseq`
+          if index < 0 || index >= logicalSize
+            then
+              error
+                ( "copyAtMut: index "
+                    <> show index
+                    <> " out of bounds for length "
+                    <> show logicalSize
+                )
+                vector
+            else unsafeSystemIOToBO do
+              !value <- UM.unsafeRead buffer index
+              let !copied = copy (UnsafeAlias value)
+              NonLinear.pure (Ur copied, vector)
+
+-- | Replace an initialized element and return the displaced value.
+set ::
+  (HasCallStack, U.Unbox a, α >= β) =>
+  Int ->
+  a %1 ->
+  Mut α (GrowableVector a) %1 ->
+  BO β (a, Mut α (GrowableVector a))
+{-# INLINE set #-}
+set index value vector =
+  case size vector of
+    (Ur logicalSize, vector) ->
+      if index < 0 || index >= logicalSize
+        then
+          error
+            ( "set: index "
+                <> show index
+                <> " out of bounds for length "
+                <> show logicalSize
+            )
+            value
+            vector
+        else unsafeSet index value vector
+
+-- | Unchecked 'set'. The index must satisfy @0 <= index < size@.
+unsafeSet ::
+  (U.Unbox a, α >= β) =>
+  Int ->
+  a %1 ->
+  Mut α (GrowableVector a) %1 ->
+  BO β (a, Mut α (GrowableVector a))
+{-# INLINE unsafeSet #-}
+unsafeSet =
+  Unsafe.toLinear3 \index !value vector@(UnsafeAlias (GrowableVector ref)) ->
+    case Ref.unsafeReadRef ref of
+      (Header _ buffer, duplicateRef) ->
+        pop (aff duplicateRef) `lseq`
+          unsafeSystemIOToBO do
+            !oldValue <- UM.unsafeExchange buffer index value
+            NonLinear.pure (oldValue, vector)
+
+-- | Linearly transform an initialized element and return an auxiliary result.
+update ::
+  (HasCallStack, U.Unbox a, α >= β) =>
+  Int ->
+  (a %1 -> BO β (result, a)) %1 ->
+  Mut α (GrowableVector a) %1 ->
+  BO β (result, Mut α (GrowableVector a))
+{-# INLINE update #-}
+update index action vector =
+  case size vector of
+    (Ur logicalSize, vector) ->
+      if index < 0 || index >= logicalSize
+        then
+          error
+            ( "update: index "
+                <> show index
+                <> " out of bounds for length "
+                <> show logicalSize
+            )
+            action
+            vector
+        else unsafeUpdate index action vector
+
+{- | Unchecked 'update'. The index must satisfy @0 <= index < size@.
+
+The callback must return exactly one replacement before the growable borrow is
+restored. No exceptional owner recovery is claimed.
+-}
+unsafeUpdate ::
+  (U.Unbox a, α >= β) =>
+  Int ->
+  (a %1 -> BO β (result, a)) %1 ->
+  Mut α (GrowableVector a) %1 ->
+  BO β (result, Mut α (GrowableVector a))
+{-# INLINE unsafeUpdate #-}
+unsafeUpdate index =
+  Unsafe.toLinear2 \action vector@(UnsafeAlias (GrowableVector ref)) ->
+    case Ref.unsafeReadRef ref of
+      (Header _ buffer, duplicateRef) ->
+        pop (aff duplicateRef) `lseq` Control.do
+          value <- unsafeSystemIOToBO (UM.unsafeRead buffer index)
+          (!result, !updatedValue) <- action value
+          () <-
+            unsafeSystemIOToBO
+              (Unsafe.toLinear3 UM.unsafeWrite buffer index updatedValue)
+          Control.pure (result, vector)
+
+-- | Linearly transform an initialized element.
+modify ::
+  (HasCallStack, U.Unbox a, α >= β) =>
+  Int ->
+  (a %1 -> a) %1 ->
+  Mut α (GrowableVector a) %1 ->
+  BO β (Mut α (GrowableVector a))
+{-# INLINE modify #-}
+modify index function vector = Control.do
+  ((), vector) <-
+    update
+      index
+      (\value -> Control.pure ((), function value))
+      vector
+  Control.pure vector
+
+-- | Swap two initialized elements.
+swap ::
+  (HasCallStack, U.Unbox a, α >= β) =>
+  Mut α (GrowableVector a) %1 ->
+  Int ->
+  Int ->
+  BO β (Mut α (GrowableVector a))
+{-# INLINE swap #-}
+swap vector first second =
+  case size vector of
+    (Ur logicalSize, vector) ->
+      if first
+        < 0
+        || first
+        >= logicalSize
+        || second
+        < 0
+        || second
+        >= logicalSize
+        then
+          error
+            ( "swap: indices "
+                <> show (first, second)
+                <> " out of bounds for length "
+                <> show logicalSize
+            )
+            vector
+        else unsafeSwap vector first second
+
+-- | Unchecked 'swap'. Both indices must satisfy @0 <= index < size@.
+unsafeSwap ::
+  (U.Unbox a, α >= β) =>
+  Mut α (GrowableVector a) %1 ->
+  Int ->
+  Int ->
+  BO β (Mut α (GrowableVector a))
+{-# INLINE unsafeSwap #-}
+unsafeSwap =
+  Unsafe.toLinear3 \vector@(UnsafeAlias (GrowableVector ref)) first second ->
+    case Ref.unsafeReadRef ref of
+      (Header _ buffer, duplicateRef) ->
+        pop (aff duplicateRef) `lseq`
+          unsafeSystemIOToBO do
+            UM.unsafeSwap buffer first second
+            NonLinear.pure vector
+
+-- | Ensure at least the requested absolute capacity.
+reserve ::
+  (HasCallStack, U.Unbox a, α >= β) =>
+  Int ->
+  Mut α (GrowableVector a) %1 ->
+  BO β (Mut α (GrowableVector a))
+{-# INLINE reserve #-}
+reserve requested vector
+  | requested < 0 =
+      error ("reserve: negative capacity " <> show requested) vector
+  | otherwise = Control.do
+      ((), vector) <-
+        withHeader
+          ( Unsafe.toLinear \(Header logicalSize buffer) -> Control.do
+              grown <- growTo logicalSize requested buffer
+              Control.pure ((), Header logicalSize grown)
+          )
+          vector
+      Control.pure vector
+
+-- | Ensure capacity for at least current size plus the requested amount.
+reserveAdditional ::
+  (HasCallStack, U.Unbox a, α >= β) =>
+  Int ->
+  Mut α (GrowableVector a) %1 ->
+  BO β (Mut α (GrowableVector a))
+{-# INLINE reserveAdditional #-}
+reserveAdditional additional vector
+  | additional < 0 =
+      error
+        ("reserveAdditional: negative additional capacity " <> show additional)
+        vector
+  | otherwise = Control.do
+      ((), vector) <-
+        withHeader
+          ( Unsafe.toLinear \(Header logicalSize buffer) ->
+              let !required =
+                    checkedAdd "reserveAdditional" logicalSize additional
+               in Control.do
+                    grown <- growTo logicalSize required buffer
+                    Control.pure ((), Header logicalSize grown)
+          )
+          vector
+      Control.pure vector
+
+-- | Append one linearly supplied element.
+push ::
+  (HasCallStack, U.Unbox a, α >= β) =>
+  a %1 ->
+  Mut α (GrowableVector a) %1 ->
+  BO β (Mut α (GrowableVector a))
+{-# INLINE push #-}
+push =
+  Unsafe.toLinear2 \ !value vector -> Control.do
+    ((), vector) <-
+      withHeader
+        ( Unsafe.toLinear \(Header logicalSize buffer) ->
+            let !required = checkedAdd "push" logicalSize 1
+                !target = growthTarget (UM.length buffer) required
+             in Control.do
+                  grown <- growTo logicalSize target buffer
+                  grown <- writeAt logicalSize value grown
+                  Control.pure ((), Header required grown)
+        )
+        vector
+    Control.pure vector
+
+-- | Append copies of all elements of an immutable unboxed vector.
+extend ::
+  (HasCallStack, U.Unbox a, α >= β) =>
+  U.Vector a ->
+  Mut α (GrowableVector a) %1 ->
+  BO β (Mut α (GrowableVector a))
+{-# INLINE extend #-}
+extend source vector = Control.do
+  ((), vector) <-
+    withHeader
+      ( Unsafe.toLinear \(Header logicalSize buffer) ->
+          let !sourceSize = U.length source
+              !required = checkedAdd "extend" logicalSize sourceSize
+              !target = growthTarget (UM.length buffer) required
+           in Control.do
+                grown <- growTo logicalSize target buffer
+                grown <- copyImmutableInto source logicalSize grown
+                Control.pure ((), Header required grown)
+      )
+      vector
+  Control.pure vector
+
+copyImmutable ::
+  (U.Unbox a) =>
+  U.Vector a ->
+  Int ->
+  UM.IOVector a ->
+  NonLinear.IO ()
+{-# INLINE copyImmutable #-}
+copyImmutable source offset target =
+  U.copy (UM.unsafeSlice offset (U.length source) target) source
+
+copyImmutableInto ::
+  (U.Unbox a) =>
+  U.Vector a ->
+  Int ->
+  UM.IOVector a %1 ->
+  BO β (UM.IOVector a)
+{-# INLINE copyImmutableInto #-}
+copyImmutableInto source offset =
+  Unsafe.toLinear \target -> unsafeSystemIOToBO do
+    copyImmutable source offset target
+    NonLinear.pure target
+
+writeAt ::
+  (U.Unbox a) =>
+  Int ->
+  a %1 ->
+  UM.IOVector a %1 ->
+  BO β (UM.IOVector a)
+{-# INLINE writeAt #-}
+writeAt =
+  Unsafe.toLinear3 \index value target -> unsafeSystemIOToBO do
+    UM.unsafeWrite target index value
+    NonLinear.pure target
+
+growTo ::
+  (U.Unbox a) =>
+  Int ->
+  Int ->
+  UM.IOVector a %1 ->
+  BO β (UM.IOVector a)
+{-# INLINE growTo #-}
+growTo =
+  Unsafe.toLinear3 \logicalSize requested buffer ->
+    let !oldCapacity = UM.length buffer
+     in if requested <= oldCapacity
+          then Control.pure buffer
+          else unsafeSystemIOToBO do
+            grown <- UM.unsafeNew requested
+            UM.unsafeCopy
+              (UM.unsafeTake logicalSize grown)
+              (UM.unsafeTake logicalSize buffer)
+            NonLinear.pure grown
+
+growthTarget :: Int -> Int -> Int
+{-# INLINE growthTarget #-}
+growthTarget oldCapacity required
+  | required <= oldCapacity = oldCapacity
+  | oldCapacity <= 0 = required `max` 1
+  | oldCapacity > maxBound `quot` 2 = required
+  | otherwise = required `max` (oldCapacity * 2)
+
+checkedAdd :: (HasCallStack) => NonLinear.String -> Int -> Int -> Int
+{-# INLINE checkedAdd #-}
+checkedAdd operation left right
+  | right > maxBound - left =
+      error (operation <> ": capacity overflow")
+  | otherwise = left + right
+
+{- | Project a growable borrow to its fixed initialized prefix.
+
+The projection preserves borrow kind and lifetime and exposes no spare
+capacity or growth operation.
+-}
+getContents ::
+  (U.Unbox a) =>
+  Borrow bk α (GrowableVector a) %1 ->
+  Borrow bk α (Fixed.Vector a)
+{-# INLINE getContents #-}
+getContents =
+  Unsafe.toLinear \(UnsafeAlias (GrowableVector ref)) ->
+    case Ref.unsafeReadRef ref of
+      (Header logicalSize buffer, duplicateRef) ->
+        pop (aff duplicateRef) `lseq`
+          UnsafeAlias
+            (Fixed.Internal.unsafeFromMutableSlice 0 logicalSize buffer)
+
+-- | Borrow the fixed initialized prefix in a rank-2 no-growth scope.
+withContent ::
+  (U.Unbox a) =>
+  Borrow bk α (GrowableVector a) %1 ->
+  ( forall β.
+    Borrow bk (β /\ α) (Fixed.Vector a) %1 ->
+    BO (β /\ α) result
+  ) %1 ->
+  BO α (result, Borrow bk α (GrowableVector a))
+{-# INLINE withContent #-}
+withContent =
+  Unsafe.toLinear2 \vector action ->
+    unsafeSrunBO_ $
+      action (getContents (Unsafe.coerce vector))
+        Control.<&> \result -> (result, vector)
+
+-- | A result-discarding variant of 'withContent'.
+withContent_ ::
+  (U.Unbox a, Consumable result) =>
+  Borrow bk α (GrowableVector a) %1 ->
+  ( forall β.
+    Borrow bk (β /\ α) (Fixed.Vector a) %1 ->
+    BO (β /\ α) result
+  ) %1 ->
+  BO α (Borrow bk α (GrowableVector a))
+{-# INLINE withContent_ #-}
+withContent_ vector action =
+  withContent vector action Control.<&> \(result, vector) ->
+    consume result `lseq` vector

--- a/test/Data/Vector/Unboxed/Mutable/Growable/Linear/BorrowSpec.hs
+++ b/test/Data/Vector/Unboxed/Mutable/Growable/Linear/BorrowSpec.hs
@@ -1,0 +1,948 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE ImpredicativeTypes #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE LinearTypes #-}
+{-# LANGUAGE QualifiedDo #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# OPTIONS_GHC -Wno-name-shadowing #-}
+
+module Data.Vector.Unboxed.Mutable.Growable.Linear.BorrowSpec (
+  module Data.Vector.Unboxed.Mutable.Growable.Linear.BorrowSpec,
+) where
+
+import Control.Exception qualified as Exception
+import Control.Functor.Linear qualified as Control
+import Control.Monad.Borrow.Pure.BO
+import Control.Monad.Borrow.Pure.BO.Unsafe (Alias (..))
+import Control.Monad.Borrow.Pure.Copyable (Copyable (copy), copyMut)
+import Control.Syntax.DataFlow qualified as DataFlow
+import Data.IORef (IORef, modifyIORef', newIORef, readIORef)
+import Data.List qualified as List
+import Data.Ref.Linear qualified as Ref
+import Data.Ref.Linear.Borrow qualified as RefBorrow
+import Data.Vector.Unboxed qualified as U
+import Data.Vector.Unboxed.Mutable qualified as UM
+import Data.Vector.Unboxed.Mutable.Growable.Linear.Borrow qualified as Growable
+import Data.Vector.Unboxed.Mutable.Growable.Linear.TypingCases
+import Data.Vector.Unboxed.Mutable.Linear.Borrow qualified as Fixed
+import GHC.IO (unsafePerformIO)
+import Prelude.Linear
+import PureBorrow.Internal.Bench.Unboxed qualified as UnboxedBench
+import Test.Falsify.Generator qualified as G
+import Test.Falsify.Predicate qualified as P
+import Test.Falsify.Property qualified as F
+import Test.Falsify.Range qualified as G
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.Falsify (testProperty)
+import Test.Tasty.HUnit
+import Unsafe.Linear qualified as Unsafe
+import Prelude qualified as NonLinear
+
+data Operation
+  = Push !Int
+  | Extend !Int !Int
+  | Reserve !Int
+  | ReserveAdditional !Int
+  | Replace !Int !Int
+  deriving (Show)
+
+decodeOperation :: Int -> Operation
+decodeOperation seed =
+  case seed `NonLinear.mod` 5 of
+    0 -> Push seed
+    1 -> Extend seed (seed + 1)
+    2 -> Reserve (NonLinear.abs seed `NonLinear.mod` 32)
+    3 -> ReserveAdditional (NonLinear.abs seed `NonLinear.mod` 16)
+    _ -> Replace seed (-seed)
+
+applyOperations ::
+  [Operation] ->
+  Mut α (Growable.GrowableVector Int) %1 ->
+  BO α (Mut α (Growable.GrowableVector Int))
+applyOperations [] vector = Control.pure vector
+applyOperations (operation : operations) vector =
+  case operation of
+    Push value -> Control.do
+      vector <- Growable.push value vector
+      applyOperations operations vector
+    Extend first second -> Control.do
+      vector <- Growable.extend (U.fromList [first, second]) vector
+      applyOperations operations vector
+    Reserve requested -> Control.do
+      vector <- Growable.reserve requested vector
+      applyOperations operations vector
+    ReserveAdditional additional -> Control.do
+      vector <- Growable.reserveAdditional additional vector
+      applyOperations operations vector
+    Replace rawIndex value ->
+      case Growable.size vector of
+        (Ur 0, vector) -> applyOperations operations vector
+        (Ur logicalSize, vector) -> Control.do
+          let !index = NonLinear.abs rawIndex `NonLinear.mod` logicalSize
+          (old, vector) <- Growable.set index value vector
+          applyOperations operations (consume old `lseq` vector)
+
+applyModel :: [Operation] -> [Int] -> [Int]
+applyModel operations initial = NonLinear.foldl step initial operations
+  where
+    step values = \case
+      Push value -> values <> [value]
+      Extend first second -> values <> [first, second]
+      Reserve _ -> values
+      ReserveAdditional _ -> values
+      Replace _ _ | NonLinear.null values -> values
+      Replace rawIndex value ->
+        let !index = NonLinear.abs rawIndex `NonLinear.mod` NonLinear.length values
+         in case NonLinear.splitAt index values of
+              (prefix, _ : suffix) -> prefix <> (value : suffix)
+              (_, []) -> values
+
+freezeList :: Growable.GrowableVector Int %1 -> [Int]
+freezeList vector =
+  case Growable.toVector vector of
+    Ur frozen -> U.toList frozen
+
+freezeLength :: Growable.GrowableVector Int %1 -> Int
+freezeLength vector =
+  case Growable.toVector vector of
+    Ur frozen -> U.length frozen
+
+runOperations :: Int -> [Operation] -> ([Int], Int, Int)
+runOperations initialCapacity operations =
+  unur $ linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <-
+        borrowM (Growable.withCapacity initialCapacity ownerLinear)
+      vector <- applyOperations operations vector
+      Growable.size vector & \(Ur logicalSize, vector) ->
+        Growable.capacity vector & \(Ur finalCapacity, vector) -> DataFlow.do
+          consume vector
+          pureAfter $
+            case Growable.toVector (reclaim lend) of
+              Ur frozen ->
+                Ur (U.toList frozen, logicalSize, finalCapacity)
+
+test_model :: TestTree
+test_model =
+  testProperty "matches a list model across growth and mutation" do
+    initialCapacity <- F.gen $ G.int $ G.between (0, 16)
+    seeds <- F.gen $ G.list (G.between (0, 100)) $ G.int $ G.between (-100, 100)
+    let !operations = NonLinear.map decodeOperation seeds
+        !(actual, logicalSize, finalCapacity) =
+          runOperations initialCapacity operations
+        !expected = applyModel operations []
+    F.assert $ P.expect expected P..$ ("contents", actual)
+    F.assert $
+      P.expect (NonLinear.length expected) P..$ ("logical size", logicalSize)
+    F.assert $
+      P.satisfies
+        ("capacity >= logical size", (NonLinear.>= logicalSize))
+        P..$ ("capacity", finalCapacity)
+
+test_construction :: TestTree
+test_construction =
+  testGroup
+    "construction"
+    [ testCase "empty has no initialized elements" do
+        linearly (\linear -> freezeList (Growable.empty linear)) @?= []
+    , testCase "constant initializes the complete logical prefix" do
+        linearly
+          (\linear -> freezeList (Growable.constant 3 (7 :: Int) linear))
+          @?= [7, 7, 7]
+    , testCase "fromList moves every element" do
+        linearly
+          (\linear -> freezeList (Growable.fromList [4, 5, 6 :: Int] linear))
+          @?= [4, 5, 6]
+    , testCase "fromVector copies every element" do
+        linearly
+          ( \linear ->
+              freezeList
+                (Growable.fromVector (U.fromList [8, 9 :: Int]) linear)
+          )
+          @?= [8, 9]
+    , testCase "unsafe mutable adoption preserves a nonzero slice offset across growth" do
+        linearly
+          ( \linear ->
+              let source =
+                    unsafePerformIO do
+                      whole <- U.thaw (U.fromList [99, 1, 2, 88 :: Int])
+                      NonLinear.pure (UM.unsafeSlice 1 2 whole)
+               in growAdopted source linear
+          )
+          @?= [1, 2, 3]
+    ]
+
+growAdopted ::
+  UM.IOVector Int %1 ->
+  Linearly %1 ->
+  [Int]
+growAdopted =
+  Unsafe.toLinear2 \source linear ->
+    unur $ DataFlow.do
+      (ownerLinear, runLinear) <- dup linear
+      runBO runLinear Control.do
+        (vector, lend) <-
+          borrowM (Growable.unsafeFromMutable source ownerLinear)
+        vector <- Growable.push 3 vector
+        let !() = consume vector
+        pureAfter $
+          case Growable.toVector (reclaim lend) of
+            Ur frozen -> Ur (U.toList frozen)
+
+mirroredSurface :: ((Int, Int, Int, Int), [Int])
+mirroredSurface =
+  linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <- borrowM (Growable.fromList [1, 2, 3] ownerLinear)
+      (Ur middle, vector) <-
+        reborrowing vector \short -> Control.do
+          element <- Growable.get 1 short
+          Control.pure (copyMut element)
+      (Ur first, vector) <-
+        reborrowing vector \short -> Control.do
+          element <- Growable.head short
+          Control.pure (copyMut element)
+      (Ur final, vector) <-
+        reborrowing vector \short -> Control.do
+          element <- Growable.last short
+          Control.pure (copyMut element)
+      (Ur copied, vector) <- Growable.copyAtMut 1 vector
+      (old, vector) <- Growable.set 1 20 vector
+      let !() = consume old
+      ((), vector) <-
+        Growable.update
+          1
+          (\ !value -> Control.pure ((), value + 1))
+          vector
+      vector <- Growable.modify 0 (+ 10) vector
+      vector <- Growable.swap vector 0 2
+      let !() = consume vector
+      pureAfter
+        ( (middle, first, final, copied)
+        , freezeList (reclaim lend)
+        )
+
+test_mirroredSurface :: TestTree
+test_mirroredSurface =
+  testCase "mirrors fixed unboxed reads and mutation" do
+    mirroredSurface @?= ((2, 1, 3, 2), [3, 21, 11])
+
+contentRoundTrip :: ((Int, Int), [Int])
+contentRoundTrip =
+  linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <-
+        borrowM (Growable.fromVector (U.fromList [10, 20, 30]) ownerLinear)
+      ((logicalSize, first), vector) <-
+        Growable.withContent vector \contents -> Control.do
+          Fixed.size contents & \(Ur logicalSize, contents) -> Control.do
+            (Ur first, contents) <- Fixed.copyAtMut 0 contents
+            contents <- Fixed.modify 1 (+ 1) contents
+            Control.pure (consume contents `lseq` (logicalSize, first))
+      vector <- Growable.push 40 vector
+      let !() = consume vector
+      pureAfter
+        ( (logicalSize, first)
+        , freezeList (reclaim lend)
+        )
+
+directMutableProjection :: (Int, [Int])
+directMutableProjection =
+  linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <- borrowM (Growable.withCapacity 8 ownerLinear)
+      vector <- Growable.extend (U.fromList [3, 4, 5]) vector
+      Fixed.size (Growable.getContents vector) & \(Ur logicalSize, contents) -> Control.do
+        contents <- Fixed.modify 0 (+ 10) contents
+        let !() = consume contents
+        pureAfter
+          ( logicalSize
+          , freezeList (reclaim lend)
+          )
+
+parallelSplitContent :: [Int]
+parallelSplitContent =
+  linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <- borrowM (Growable.fromList [1, 2, 3, 4] ownerLinear)
+      vector <- Growable.withContent_ vector \contents -> Control.do
+        let !(left, right) = Fixed.splitAt 2 contents
+        consume
+          Control.<$> parBO
+            (Fixed.modify 0 (+ 10) left)
+            (Fixed.modify 0 (+ 20) right)
+      vector <- Growable.push 5 vector
+      let !() = consume vector
+      pureAfter (freezeList (reclaim lend))
+
+sharedContentProjection :: ((Int, Int), [Int])
+sharedContentProjection =
+  linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <- borrowM (Growable.fromList [5, 6, 7] ownerLinear)
+      share vector & \(Ur sharedVector) -> Control.do
+        (first, returnedSharedVector) <-
+          Growable.withContent sharedVector \linearContents ->
+            move linearContents & \(Ur contents) -> Control.do
+              Ur first <- Fixed.copyAt 0 contents
+              Control.pure first
+        move returnedSharedVector & \(Ur sharedVector) -> Control.do
+          Ur final <- Fixed.copyAt 2 (Growable.getContents sharedVector)
+          let !() = consume sharedVector
+          pureAfter ((first, final), freezeList (reclaim lend))
+
+countedContentScope :: IORef Int -> [Int]
+countedContentScope counter =
+  linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <- borrowM (Growable.fromList [1, 2, 3] ownerLinear)
+      vector <- Growable.withContent_ vector \contents ->
+        case unsafePerformIO (modifyIORef' counter NonLinear.succ) of
+          () -> Control.pure (consume contents)
+      vector <- Growable.push 4 vector
+      let !() = consume vector
+      pureAfter (freezeList (reclaim lend))
+
+test_contentProjection :: TestTree
+test_contentProjection =
+  testGroup
+    "content projection"
+    [ testCase "exposes only initialized content and restores growth" do
+        contentRoundTrip @?= ((3, 10), [10, 21, 30, 40])
+    , testCase "direct mutable projection exposes only the initialized prefix" do
+        directMutableProjection @?= (3, [13, 4, 5])
+    , testCase "permits fixed content to split before growth resumes" do
+        parallelSplitContent @?= [11, 2, 23, 4, 5]
+    , testCase "preserves shared content access" do
+        sharedContentProjection @?= ((5, 7), [5, 6, 7])
+    , testCase "runs a content callback exactly once" do
+        counter <- newIORef 0
+        countedContentScope counter @?= [1, 2, 3, 4]
+        count <- readIORef counter
+        count @?= 1
+    ]
+
+data Tracked = Tracked !(IORef Int) !Int
+
+instance Consumable (U.DoNotUnboxLazy Tracked) where
+  consume =
+    Unsafe.toLinear \(U.DoNotUnboxLazy (Tracked counter _)) ->
+      unsafePerformIO (modifyIORef' counter NonLinear.succ)
+
+instance Consumable (U.DoNotUnboxStrict Tracked) where
+  consume =
+    Unsafe.toLinear \(U.DoNotUnboxStrict (Tracked counter _)) ->
+      unsafePerformIO (modifyIORef' counter NonLinear.succ)
+
+trackedGrowth :: IORef Int -> Int
+trackedGrowth counter =
+  linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <- borrowM (Growable.withCapacity 0 ownerLinear)
+      vector <- Growable.push (U.DoNotUnboxLazy (Tracked counter 10)) vector
+      vector <- Growable.push (U.DoNotUnboxLazy (Tracked counter 20)) vector
+      vector <- Growable.reserve 32 vector
+      vector <- Growable.push (U.DoNotUnboxLazy (Tracked counter 30)) vector
+      vector <- Growable.reserveAdditional 64 vector
+      (oldLabel, vector) <-
+        Growable.update
+          1
+          ( \(U.DoNotUnboxLazy (Tracked elementCounter label)) ->
+              case dup label of
+                (oldLabel, replacementLabel) ->
+                  Control.pure
+                    ( oldLabel
+                    , U.DoNotUnboxLazy
+                        (Tracked elementCounter (replacementLabel + 1))
+                    )
+          )
+          vector
+      let !() = consume vector
+      pureAfter (consume (reclaim lend) `lseq` oldLabel)
+
+strictTrackedGrowth :: IORef Int -> ()
+strictTrackedGrowth counter =
+  linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <- borrowM (Growable.withCapacity 0 ownerLinear)
+      vector <- Growable.push (U.DoNotUnboxStrict (Tracked counter 10)) vector
+      vector <- Growable.push (U.DoNotUnboxStrict (Tracked counter 20)) vector
+      vector <- Growable.reserve 32 vector
+      vector <- Growable.push (U.DoNotUnboxStrict (Tracked counter 30)) vector
+      vector <- Growable.reserveAdditional 64 vector
+      let !() = consume vector
+      pureAfter (consume (reclaim lend))
+
+data CopyTracked = CopyTracked !(IORef Int) !(IORef Int) !Int
+
+type UnboxedCopyTracked = U.DoNotUnboxLazy CopyTracked
+
+instance Copyable UnboxedCopyTracked where
+  copy =
+    Unsafe.toLinear
+      \(UnsafeAlias value@(U.DoNotUnboxLazy (CopyTracked copies retired _))) ->
+        case unsafePerformIO do
+          retirementCount <- readIORef retired
+          if retirementCount == 0
+            then modifyIORef' copies NonLinear.succ
+            else NonLinear.error "copy invoked after source retirement" of
+          () -> value
+
+instance Consumable UnboxedCopyTracked where
+  consume =
+    Unsafe.toLinear
+      \(U.DoNotUnboxLazy (CopyTracked _ retired _)) ->
+        unsafePerformIO (modifyIORef' retired NonLinear.succ)
+
+data MoveTracked = MoveTracked !(IORef Int) !Int !Bool
+
+type UnboxedMoveTracked = U.DoNotUnboxLazy MoveTracked
+
+instance Consumable UnboxedMoveTracked where
+  consume = Unsafe.toLinear \_ -> ()
+
+instance Dupable UnboxedMoveTracked where
+  dup2 = Unsafe.toLinear \value -> (value, value)
+
+instance Movable UnboxedMoveTracked where
+  move =
+    Unsafe.toLinear
+      \(U.DoNotUnboxLazy (MoveTracked moves value _)) ->
+        case unsafePerformIO (modifyIORef' moves NonLinear.succ) of
+          () -> Ur (U.DoNotUnboxLazy (MoveTracked moves value True))
+
+materializeMoveTracked :: IORef Int -> [(Int, Bool)]
+materializeMoveTracked moves =
+  NonLinear.map
+    ( \(U.DoNotUnboxLazy (MoveTracked _ value wasMoved)) ->
+        (value, wasMoved)
+    )
+    ( U.toList $
+        unur $
+          linearly \linear -> DataFlow.do
+            (ownerLinear, runLinear) <- dup linear
+            runBO runLinear Control.do
+              (vector, lend) <- borrowM (Growable.empty ownerLinear)
+              vector <-
+                Growable.push
+                  (U.DoNotUnboxLazy (MoveTracked moves 10 False))
+                  vector
+              vector <-
+                Growable.push
+                  (U.DoNotUnboxLazy (MoveTracked moves 20 False))
+                  vector
+              let !() = consume vector
+              pureAfter (Growable.toVector (reclaim lend))
+    )
+
+discardMaterializedMoveTracked :: IORef Int -> ()
+discardMaterializedMoveTracked moves =
+  linearly \linear ->
+    case Growable.toVector
+      ( Growable.fromVector
+          ( U.fromList
+              [ U.DoNotUnboxLazy (MoveTracked moves 10 False)
+              , U.DoNotUnboxLazy (MoveTracked moves 20 False)
+              ]
+          )
+          linear
+      ) of
+      Ur _ -> ()
+
+immutableCopyLifecycle :: IORef Int -> IORef Int -> ()
+immutableCopyLifecycle copies retired =
+  linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <-
+        borrowM
+          ( Growable.fromVector
+              ( U.fromList
+                  [ U.DoNotUnboxLazy (CopyTracked copies retired 10)
+                  , U.DoNotUnboxLazy (CopyTracked copies retired 20)
+                  ]
+              )
+              ownerLinear
+          )
+      vector <- Growable.reserve 64 vector
+      vector <-
+        Growable.extend
+          (U.singleton (U.DoNotUnboxLazy (CopyTracked copies retired 30)))
+          vector
+      vector <- Growable.reserveAdditional 64 vector
+      let !() = consume vector
+      pureAfter (consume (reclaim lend))
+
+retireCopiedResult ::
+  (Ur UnboxedCopyTracked, Mut α (Growable.GrowableVector UnboxedCopyTracked)) %1 ->
+  Growable.GrowableVector UnboxedCopyTracked %1 ->
+  Int
+retireCopiedResult =
+  Unsafe.toLinear2 \(copiedResult, borrowed) owner ->
+    consume borrowed `lseq`
+      consume owner `lseq`
+        case copiedResult of
+          Ur (U.DoNotUnboxLazy (CopyTracked _ _ value)) -> value
+
+copyAtMutAfterRetirement :: IORef Int -> IORef Int -> Int
+copyAtMutAfterRetirement copies retired =
+  linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <-
+        borrowM
+          ( Growable.fromVector
+              (U.singleton (U.DoNotUnboxLazy (CopyTracked copies retired 10)))
+              ownerLinear
+          )
+      copiedResult <- Growable.copyAtMut 0 vector
+      pureAfter (retireCopiedResult copiedResult (reclaim lend))
+
+test_copyAtMutStrictness :: TestTree
+test_copyAtMutStrictness =
+  testCase "copyAtMut completes copying before mutable recovery" do
+    copies <- newIORef 0
+    retired <- newIORef 0
+    copyAtMutAfterRetirement copies retired @?= 10
+    copyCount <- readIORef copies
+    copyCount @?= 1
+    retirementCount <- readIORef retired
+    retirementCount @?= 1
+
+gcOwnedImmutableLifecycle :: IORef Int -> ()
+gcOwnedImmutableLifecycle retired =
+  linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <-
+        borrowM
+          ( Growable.fromVector
+              (U.singleton (U.DoNotUnboxLazy (Tracked retired 10)))
+              ownerLinear
+          )
+      vector <-
+        Growable.extend
+          ( U.fromList
+              [ U.DoNotUnboxLazy (Tracked retired 20)
+              , U.DoNotUnboxLazy (Tracked retired 30)
+              ]
+          )
+          vector
+      let !() = consume vector
+      pureAfter (consume (reclaim lend))
+
+newtype LinearElement = LinearElement (Ref.Ref Int)
+
+type BoxedLinearElement = U.DoNotUnboxLazy LinearElement
+
+instance Consumable BoxedLinearElement where
+  consume =
+    Unsafe.toLinear \(U.DoNotUnboxLazy (LinearElement ref)) ->
+      consume ref
+
+asBorrowedRef ::
+  Mut α BoxedLinearElement %1 ->
+  Mut α (Ref.Ref Int)
+asBorrowedRef = upcast
+
+borrowedRefAcrossGrowth :: Int
+borrowedRefAcrossGrowth =
+  linearly \linear -> DataFlow.do
+    (refLinear, remainingLinear) <- dup linear
+    (ownerLinear, runLinear) <- dup remainingLinear
+    runBO runLinear Control.do
+      (vector, lend) <- borrowM (Growable.empty ownerLinear)
+      vector <-
+        Growable.push
+          (U.DoNotUnboxLazy (LinearElement (Ref.new 1 refLinear)))
+          vector
+      vector <- Growable.reserve 64 vector
+      ((), vector) <-
+        reborrowing vector \short -> Control.do
+          element <- Growable.get 0 short
+          ref <- RefBorrow.modify (+ 41) (asBorrowedRef element)
+          Control.pure (consume ref)
+      (observed, vector) <-
+        reborrowing vector \short -> Control.do
+          element <- Growable.get 0 short
+          RefBorrow.copyRef (asBorrowedRef element)
+      let !() = consume vector
+      pureAfter (consume (reclaim lend) `lseq` observed)
+
+test_destructiveGrowth :: TestTree
+test_destructiveGrowth =
+  testGroup
+    "destructive growth"
+    [ testCase "moves non-Copyable capabilities and retires each exactly once" do
+        counter <- newIORef 0
+        oldLabel <- Exception.evaluate (trackedGrowth counter)
+        oldLabel @?= 20
+        retired <- readIORef counter
+        retired @?= 3
+    , testCase "moves strict boxed-backed capabilities and retires each exactly once" do
+        counter <- newIORef 0
+        _ <- Exception.evaluate (strictTrackedGrowth counter)
+        retired <- readIORef counter
+        retired @?= 3
+    , testCase "preserves a nested Ref identity across reallocation" do
+        borrowedRefAcrossGrowth @?= 42
+    , testCase "ordinary constructors need no Copyable instance" do
+        counter <- newIORef 0
+        _ <-
+          Exception.evaluate $
+            linearly \linear ->
+              consume
+                ( Growable.constant
+                    2
+                    (U.DoNotUnboxLazy (Tracked counter 10))
+                    linear
+                )
+        retired <- readIORef counter
+        retired @?= 2
+    , testCase "ordinary immutable sources need no Copyable instance" do
+        counter <- newIORef 0
+        _ <- Exception.evaluate (gcOwnedImmutableLifecycle counter)
+        retired <- readIORef counter
+        retired @?= 3
+    , testCase "ordinary immutable copies do not invoke Copyable" do
+        copies <- newIORef 0
+        retired <- newIORef 0
+        _ <- Exception.evaluate (immutableCopyLifecycle copies retired)
+        copyCount <- readIORef copies
+        retiredCount <- readIORef retired
+        copyCount @?= 0
+        retiredCount @?= 3
+    , testCase "materialization invokes move for every owned element" do
+        moves <- newIORef 0
+        materializeMoveTracked moves @?= [(10, True), (20, True)]
+        moveCount <- readIORef moves
+        moveCount @?= 2
+    , testCase "discarding materialization still invokes every move" do
+        moves <- newIORef 0
+        _ <- Exception.evaluate (discardMaterializedMoveTracked moves)
+        moveCount <- readIORef moves
+        moveCount @?= 2
+    ]
+
+assertErrorPrefix :: NonLinear.String -> a -> Assertion
+assertErrorPrefix expectedPrefix value = do
+  result <- Exception.try @Exception.ErrorCall $ Exception.evaluate value
+  case result of
+    Left exception ->
+      assertBool
+        ("unexpected error: " <> Exception.displayException exception)
+        (expectedPrefix `List.isPrefixOf` Exception.displayException exception)
+    Right _ -> assertFailure ("expected error beginning with " <> expectedPrefix)
+
+copyOutOfBounds :: Int -> Int
+copyOutOfBounds index =
+  linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <-
+        borrowM (Growable.fromVector (U.fromList [10, 20, 30]) ownerLinear)
+      (Ur value, vector) <- Growable.copyAtMut index vector
+      let !() = consume vector
+      pureAfter (value + freezeLength (reclaim lend))
+
+getOutOfBounds :: Int -> Int
+getOutOfBounds index =
+  linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <- borrowM (Growable.fromList [10, 20, 30] ownerLinear)
+      (Ur value, vector) <-
+        reborrowing vector \short -> Control.do
+          element <- Growable.get index short
+          Control.pure (copyMut element)
+      let !() = consume vector
+      pureAfter (value + freezeLength (reclaim lend))
+
+setOutOfBounds :: Int -> Int
+setOutOfBounds index =
+  linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <- borrowM (Growable.fromList [10, 20, 30] ownerLinear)
+      (old, vector) <- Growable.set index 0 vector
+      let !() = consume vector
+      pureAfter (old + freezeLength (reclaim lend))
+
+updateOutOfBounds :: Int -> Int
+updateOutOfBounds index =
+  linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <- borrowM (Growable.fromList [10, 20, 30] ownerLinear)
+      ((), vector) <-
+        Growable.update
+          index
+          (\value -> Control.pure ((), value))
+          vector
+      let !() = consume vector
+      pureAfter (freezeLength (reclaim lend))
+
+swapOutOfBounds :: Int -> Int -> Int
+swapOutOfBounds first second =
+  linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <- borrowM (Growable.fromList [10, 20, 30] ownerLinear)
+      vector <- Growable.swap vector first second
+      let !() = consume vector
+      pureAfter (freezeLength (reclaim lend))
+
+emptyHead :: Int
+emptyHead =
+  linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <- borrowM (Growable.empty ownerLinear)
+      element <- Growable.head vector
+      let !(Ur value) = copyMut element
+      pureAfter (value + freezeLength (reclaim lend))
+
+emptyLast :: Int
+emptyLast =
+  linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <- borrowM (Growable.empty ownerLinear)
+      element <- Growable.last vector
+      let !(Ur value) = copyMut element
+      pureAfter (value + freezeLength (reclaim lend))
+
+reserveOutOfBounds :: Int -> Int
+reserveOutOfBounds requested =
+  linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <- borrowM (Growable.empty ownerLinear)
+      vector <- Growable.reserve requested vector
+      let !() = consume vector
+      pureAfter (freezeLength (reclaim lend))
+
+reserveAdditionalOutOfBounds :: Int -> Int
+reserveAdditionalOutOfBounds additional =
+  linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <- borrowM (Growable.empty ownerLinear)
+      vector <- Growable.reserveAdditional additional vector
+      let !() = consume vector
+      pureAfter (freezeLength (reclaim lend))
+
+capacityTransitions :: (Int, Int, Int, Int)
+capacityTransitions =
+  linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <- borrowM (Growable.withCapacity @Int 2 ownerLinear)
+      Growable.capacity vector & \(Ur initial, vector) -> Control.do
+        vector <- Growable.push 1 vector
+        Growable.capacity vector & \(Ur afterFirst, vector) -> Control.do
+          vector <- Growable.push 2 vector
+          Growable.capacity vector & \(Ur afterSecond, vector) -> Control.do
+            vector <- Growable.push 3 vector
+            Growable.capacity vector & \(Ur afterGrowth, vector) -> DataFlow.do
+              consume vector
+              pureAfter
+                ( consume (reclaim lend) `lseq`
+                    (initial, afterFirst, afterSecond, afterGrowth)
+                )
+
+test_bounds :: TestTree
+test_bounds =
+  testGroup
+    "bounds"
+    [ testCase "get rejects a negative index" do
+        assertErrorPrefix
+          "get: index -1 out of bounds for length 3"
+          (getOutOfBounds (-1))
+    , testCase "get rejects the upper bound" do
+        assertErrorPrefix
+          "get: index 3 out of bounds for length 3"
+          (getOutOfBounds 3)
+    , testCase "copyAtMut rejects a negative index" do
+        assertErrorPrefix
+          "copyAtMut: index -1 out of bounds for length 3"
+          (copyOutOfBounds (-1))
+    , testCase "copyAtMut rejects the upper bound" do
+        assertErrorPrefix
+          "copyAtMut: index 3 out of bounds for length 3"
+          (copyOutOfBounds 3)
+    , testCase "set rejects a negative index" do
+        assertErrorPrefix
+          "set: index -1 out of bounds for length 3"
+          (setOutOfBounds (-1))
+    , testCase "set rejects the upper bound" do
+        assertErrorPrefix
+          "set: index 3 out of bounds for length 3"
+          (setOutOfBounds 3)
+    , testCase "update rejects an invalid index" do
+        assertErrorPrefix
+          "update: index 3 out of bounds for length 3"
+          (updateOutOfBounds 3)
+    , testCase "swap rejects an invalid index" do
+        assertErrorPrefix
+          "swap: indices (0,3) out of bounds for length 3"
+          (swapOutOfBounds 0 3)
+    , testCase "head rejects an empty vector" do
+        assertErrorPrefix
+          "get: index 0 out of bounds for length 0"
+          emptyHead
+    , testCase "last rejects an empty vector" do
+        assertErrorPrefix
+          "last: empty vector"
+          emptyLast
+    , testCase "construction rejects negative capacity" do
+        assertErrorPrefix
+          "withCapacity: negative capacity -1"
+          (linearly \linear -> consume (Growable.withCapacity @Int (-1) linear))
+    , testCase "reserve rejects negative capacity" do
+        assertErrorPrefix
+          "reserve: negative capacity -1"
+          (reserveOutOfBounds (-1))
+    , testCase "reserveAdditional rejects a negative amount" do
+        assertErrorPrefix
+          "reserveAdditional: negative additional capacity -1"
+          (reserveAdditionalOutOfBounds (-1))
+    , testCase "push preserves exact capacity until one element exceeds it" do
+        capacityTransitions @?= (2, 2, 2, 4)
+    ]
+
+test_typingBoundaries :: TestTree
+test_typingBoundaries =
+  testGroup
+    "typing boundaries"
+    [ expectDeferredTypeError
+        "element role is nominal"
+        "Couldn't match type"
+        badElementCoercion
+    , expectDeferredTypeError
+        "growable and fixed vectors are representation-distinct"
+        "Couldn't match representation of type"
+        badGrowableToFixed
+    , expectDeferredTypeError
+        "fixed and growable vectors are representation-distinct"
+        "Couldn't match representation of type"
+        badFixedToGrowable
+    , expectDeferredTypeError
+        "growable cannot be upcast to fixed"
+        "Couldn't match representation of type"
+        badGrowableToFixedUpcast
+    , expectDeferredTypeError
+        "fixed cannot be upcast to growable"
+        "Couldn't match representation of type"
+        badFixedToGrowableUpcast
+    , expectDeferredTypeError
+        "unboxed and boxed growable vectors are representation-distinct"
+        "Couldn't match representation of type"
+        badUnboxedGrowableToBoxedGrowable
+    , expectDeferredTypeError
+        "boxed and unboxed growable vectors are representation-distinct"
+        "Couldn't match representation of type"
+        badBoxedGrowableToUnboxedGrowable
+    , expectDeferredTypeError
+        "unboxed growable cannot be upcast to boxed growable"
+        "Couldn't match representation of type"
+        badUnboxedGrowableToBoxedGrowableUpcast
+    , expectDeferredTypeError
+        "boxed growable cannot be upcast to unboxed growable"
+        "Couldn't match representation of type"
+        badBoxedGrowableToUnboxedGrowableUpcast
+    , expectDeferredTypeError
+        "borrow lifetime cannot be swapped"
+        "Couldn't match type"
+        badLifetimeSwapCase
+    , expectDeferredTypeError
+        "growable vector has no generic split"
+        "DistributesAlias Growable.GrowableVector"
+        badSplit
+    , expectDeferredTypeError
+        "growable vector cannot be copied"
+        "cannot be copied!"
+        badDuplicate
+    , expectDeferredTypeError
+        "mutable content cannot escape its scope"
+        "Couldn't match type"
+        badContentEscapeCase
+    , expectDeferredTypeError
+        "shared content cannot escape its scope"
+        "Couldn't match type"
+        badSharedContentEscapeCase
+    , expectDeferredTypeError
+        "Copyable alone does not permit growable materialization"
+        "Movable (U.DoNotUnboxLazy CopyOnly)"
+        badGrowableCopyableOnlyToVectorCase
+    , expectDeferredTypeError
+        "Copyable alone does not permit fixed materialization"
+        "Movable (U.DoNotUnboxLazy CopyOnly)"
+        badFixedCopyableOnlyToVectorCase
+    , expectDeferredTypeError
+        "Movable alone does not permit copying through a shared borrow"
+        "Copyable (U.DoNotUnboxLazy NonCopyable)"
+        badNonCopyableCopyAtCase
+    , expectDeferredTypeError
+        "Movable alone does not permit copying through a mutable borrow"
+        "Copyable (U.DoNotUnboxLazy NonCopyable)"
+        badNonCopyableCopyAtMutCase
+    ]
+  where
+    expectDeferredTypeError description expectedFragment value =
+      testCase description do
+        result <- Exception.try @Exception.SomeException (Exception.evaluate value)
+        case result of
+          Left exception ->
+            assertBool
+              ("unexpected deferred type error: " <> Exception.displayException exception)
+              (expectedFragment `List.isInfixOf` Exception.displayException exception)
+          Right _ ->
+            assertFailure
+              ("expected deferred type error containing " <> expectedFragment)
+
+test_benchmarkRoots :: TestTree
+test_benchmarkRoots =
+  testGroup
+    "benchmark roots"
+    [ testGroup
+        ("length " <> show length_)
+        [ testCase "no-growth direct and Pure Borrow roots agree" do
+            let input =
+                  U.generate length_ (\index -> index `NonLinear.rem` 17)
+            UnboxedBench.pureBorrowGrowableUnboxedNoGrowthKernel input
+              @?= UnboxedBench.directGrowableUnboxedNoGrowthKernel input
+        , testCase "forced-growth direct and Pure Borrow roots agree" do
+            let input =
+                  U.generate length_ (\index -> index `NonLinear.rem` 17)
+                direct@(_, finalCapacity) =
+                  UnboxedBench.directGrowableUnboxedGrowthKernel input
+            UnboxedBench.pureBorrowGrowableUnboxedGrowthKernel input
+              @?= direct
+            finalCapacity @?= expectedGrowthCapacity length_
+        , testCase "public-materialization roots agree" do
+            let input =
+                  U.generate length_ (\index -> index `NonLinear.rem` 17)
+            UnboxedBench.pureBorrowGrowableUnboxedMaterialization input
+              @?= UnboxedBench.directGrowableUnboxedMaterialization input
+        ]
+    | length_ <- [0, 1, 257, 1024 * 1024]
+    ]
+
+expectedGrowthCapacity :: Int -> Int
+expectedGrowthCapacity logicalSize = go 0
+  where
+    go capacity
+      | capacity >= logicalSize = capacity
+      | capacity <= 0 = go 1
+      | otherwise = go (capacity * 2)

--- a/test/Data/Vector/Unboxed/Mutable/Growable/Linear/TypingCases.hs
+++ b/test/Data/Vector/Unboxed/Mutable/Growable/Linear/TypingCases.hs
@@ -1,0 +1,205 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE ImpredicativeTypes #-}
+{-# LANGUAGE QualifiedDo #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# OPTIONS_GHC -O0 #-}
+{-# OPTIONS_GHC -Wno-name-shadowing #-}
+{-# OPTIONS_GHC -fdefer-type-errors -Wno-deferred-type-errors #-}
+
+module Data.Vector.Unboxed.Mutable.Growable.Linear.TypingCases (
+  module Data.Vector.Unboxed.Mutable.Growable.Linear.TypingCases,
+) where
+
+import Control.Functor.Linear qualified as Control
+import Control.Monad.Borrow.Pure.BO
+import Control.Monad.Borrow.Pure.Copyable (Copyable (copy))
+import Control.Syntax.DataFlow qualified as DataFlow
+import Data.Coerce (coerce)
+import Data.Vector.Mutable.Growable.Linear.Borrow qualified as BoxedGrowable
+import Data.Vector.Unboxed qualified as U
+import Data.Vector.Unboxed.Mutable.Growable.Linear.Borrow qualified as Growable
+import Data.Vector.Unboxed.Mutable.Linear.Borrow qualified as Fixed
+import Prelude.Linear
+import Unsafe.Linear qualified as Unsafe
+
+newtype WrappedInt = WrappedInt Int
+
+newtype CopyOnly = CopyOnly Int
+
+type UnboxedCopyOnly = U.DoNotUnboxLazy CopyOnly
+
+instance Copyable UnboxedCopyOnly where
+  copy = Unsafe.coerce
+
+newtype NonCopyable = NonCopyable Int
+
+type UnboxedNonCopyable = U.DoNotUnboxLazy NonCopyable
+
+instance Consumable UnboxedNonCopyable where
+  consume = Unsafe.toLinear \_ -> ()
+
+instance Dupable UnboxedNonCopyable where
+  dup2 = Unsafe.toLinear \value -> (value, value)
+
+instance Movable UnboxedNonCopyable where
+  move = Unsafe.toLinear \value -> Ur value
+
+badElementCoercion ::
+  Growable.GrowableVector WrappedInt %1 ->
+  Growable.GrowableVector Int
+badElementCoercion = Unsafe.toLinear coerce
+
+badGrowableToFixed ::
+  Growable.GrowableVector Int %1 ->
+  Fixed.Vector Int
+badGrowableToFixed = Unsafe.toLinear coerce
+
+badFixedToGrowable ::
+  Fixed.Vector Int %1 ->
+  Growable.GrowableVector Int
+badFixedToGrowable = Unsafe.toLinear coerce
+
+badGrowableToFixedUpcast ::
+  Growable.GrowableVector Int %1 ->
+  Fixed.Vector Int
+badGrowableToFixedUpcast = upcast
+
+badFixedToGrowableUpcast ::
+  Fixed.Vector Int %1 ->
+  Growable.GrowableVector Int
+badFixedToGrowableUpcast = upcast
+
+badUnboxedGrowableToBoxedGrowable ::
+  Growable.GrowableVector Int %1 ->
+  BoxedGrowable.GrowableVector Int
+badUnboxedGrowableToBoxedGrowable = Unsafe.toLinear coerce
+
+badBoxedGrowableToUnboxedGrowable ::
+  BoxedGrowable.GrowableVector Int %1 ->
+  Growable.GrowableVector Int
+badBoxedGrowableToUnboxedGrowable = Unsafe.toLinear coerce
+
+badUnboxedGrowableToBoxedGrowableUpcast ::
+  Growable.GrowableVector Int %1 ->
+  BoxedGrowable.GrowableVector Int
+badUnboxedGrowableToBoxedGrowableUpcast = upcast
+
+badBoxedGrowableToUnboxedGrowableUpcast ::
+  BoxedGrowable.GrowableVector Int %1 ->
+  Growable.GrowableVector Int
+badBoxedGrowableToUnboxedGrowableUpcast = upcast
+
+badLifetimeSwap ::
+  forall α β.
+  Mut α (Growable.GrowableVector Int) %1 ->
+  Mut β (Growable.GrowableVector Int)
+{-# NOINLINE badLifetimeSwap #-}
+badLifetimeSwap =
+  Unsafe.toLinear
+    ( coerce ::
+        Mut α (Growable.GrowableVector Int) ->
+        Mut β (Growable.GrowableVector Int)
+    )
+
+badLifetimeSwapCase :: Int
+badLifetimeSwapCase =
+  linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <- borrowM (Growable.empty ownerLinear)
+      let !() = consume (badLifetimeSwap vector)
+      pureAfter (consume (reclaim lend) `lseq` 0)
+
+badSplit ::
+  Mut α (Growable.GrowableVector Int) %1 ->
+  Growable.GrowableVector (Mut α Int)
+badSplit = split
+
+badDuplicate ::
+  Borrow bk α (Growable.GrowableVector Int) %1 ->
+  Growable.GrowableVector Int
+badDuplicate = copy
+
+badContentEscapeCase :: Int
+badContentEscapeCase =
+  linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <- borrowM (Growable.empty ownerLinear)
+      (escaped, vector) <- Growable.withContent vector Control.pure
+      let
+        !() = consume escaped
+        !() = consume vector
+      pureAfter $
+        case Growable.toVector (reclaim lend) of
+          Ur frozen -> U.length frozen
+
+badSharedContentEscapeCase :: Int
+badSharedContentEscapeCase =
+  linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <- borrowM (Growable.empty ownerLinear)
+      share vector & \(Ur sharedVector) -> Control.do
+        (escaped, sharedVector) <-
+          Growable.withContent sharedVector Control.pure
+        let
+          !() = consume escaped
+          !() = consume sharedVector
+        pureAfter $
+          case Growable.toVector (reclaim lend) of
+            Ur frozen -> U.length frozen
+
+badGrowableCopyableOnlyToVectorCase :: Int
+badGrowableCopyableOnlyToVectorCase =
+  linearly \linear ->
+    case Growable.toVector
+      ( Growable.fromVector
+          (U.singleton (U.DoNotUnboxLazy (CopyOnly 1)))
+          linear
+      ) of
+      Ur frozen -> U.length frozen
+
+badFixedCopyableOnlyToVectorCase :: Int
+badFixedCopyableOnlyToVectorCase =
+  linearly \linear ->
+    case Fixed.toVector
+      ( Fixed.fromVector
+          (U.singleton (U.DoNotUnboxLazy (CopyOnly 1)))
+          linear
+      ) of
+      Ur frozen -> U.length frozen
+
+badNonCopyableCopyAtCase :: Int
+badNonCopyableCopyAtCase =
+  linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <-
+        borrowM
+          ( Growable.fromVector
+              (U.singleton (U.DoNotUnboxLazy (NonCopyable 1)))
+              ownerLinear
+          )
+      share vector & \(Ur shared) -> Control.do
+        Ur _ <- Growable.copyAt 0 shared
+        let !() = consume shared
+        pureAfter (consume (reclaim lend) `lseq` 0)
+
+badNonCopyableCopyAtMutCase :: Int
+badNonCopyableCopyAtMutCase =
+  linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <-
+        borrowM
+          ( Growable.fromVector
+              (U.singleton (U.DoNotUnboxLazy (NonCopyable 1)))
+              ownerLinear
+          )
+      (Ur (U.DoNotUnboxLazy (NonCopyable copied)), vector) <-
+        Growable.copyAtMut 0 vector
+      let !() = consume vector
+      pureAfter (consume (reclaim lend) `lseq` copied)

--- a/test/Data/Vector/Unboxed/Mutable/Linear/BorrowSpec.hs
+++ b/test/Data/Vector/Unboxed/Mutable/Linear/BorrowSpec.hs
@@ -14,7 +14,8 @@ module Data.Vector.Unboxed.Mutable.Linear.BorrowSpec (
 import Control.Exception qualified as Exception
 import Control.Functor.Linear qualified as Control
 import Control.Monad.Borrow.Pure.BO
-import Control.Monad.Borrow.Pure.Copyable (copyMut)
+import Control.Monad.Borrow.Pure.BO.Unsafe (Alias (UnsafeAlias))
+import Control.Monad.Borrow.Pure.Copyable (Copyable (copy), copyMut)
 import Control.Syntax.DataFlow qualified as DataFlow
 import Data.IORef (IORef, modifyIORef', newIORef, readIORef)
 import Data.List qualified as List
@@ -43,6 +44,77 @@ instance Consumable (U.DoNotUnboxStrict Tracked) where
   consume =
     Unsafe.toLinear \(U.DoNotUnboxStrict (Tracked counter _)) ->
       unsafePerformIO (modifyIORef' counter NonLinear.succ)
+
+data MoveTracked = MoveTracked !(IORef Int) !Int !Bool
+
+type UnboxedMoveTracked = U.DoNotUnboxLazy MoveTracked
+
+instance Consumable UnboxedMoveTracked where
+  consume = Unsafe.toLinear \_ -> ()
+
+instance Dupable UnboxedMoveTracked where
+  dup2 = Unsafe.toLinear \value -> (value, value)
+
+instance Movable UnboxedMoveTracked where
+  move =
+    Unsafe.toLinear
+      \(U.DoNotUnboxLazy (MoveTracked moves value _)) ->
+        case unsafePerformIO (modifyIORef' moves NonLinear.succ) of
+          () -> Ur (U.DoNotUnboxLazy (MoveTracked moves value True))
+
+materializeMoveTracked :: IORef Int -> [(Int, Bool)]
+materializeMoveTracked moves =
+  linearly \linear ->
+    case Vector.toVector
+      ( Vector.fromVector
+          ( U.fromList
+              [ U.DoNotUnboxLazy (MoveTracked moves 10 False)
+              , U.DoNotUnboxLazy (MoveTracked moves 20 False)
+              ]
+          )
+          linear
+      ) of
+      Ur vector ->
+        NonLinear.map
+          ( \(U.DoNotUnboxLazy (MoveTracked _ value wasMoved)) ->
+              (value, wasMoved)
+          )
+          (U.toList vector)
+
+discardMaterializedMoveTracked :: IORef Int -> ()
+discardMaterializedMoveTracked moves =
+  linearly \linear ->
+    case Vector.toVector
+      ( Vector.fromVector
+          ( U.fromList
+              [ U.DoNotUnboxLazy (MoveTracked moves 10 False)
+              , U.DoNotUnboxLazy (MoveTracked moves 20 False)
+              ]
+          )
+          linear
+      ) of
+      Ur _ -> ()
+
+data CopyTracked = CopyTracked !(IORef Int) !(IORef Int) !Int
+
+type UnboxedCopyTracked = U.DoNotUnboxLazy CopyTracked
+
+instance Copyable UnboxedCopyTracked where
+  copy =
+    Unsafe.toLinear
+      \(UnsafeAlias value@(U.DoNotUnboxLazy (CopyTracked copies retired _))) ->
+        case unsafePerformIO do
+          retirementCount <- readIORef retired
+          if retirementCount == 0
+            then modifyIORef' copies NonLinear.succ
+            else NonLinear.error "copy invoked after source retirement" of
+          () -> value
+
+instance Consumable UnboxedCopyTracked where
+  consume =
+    Unsafe.toLinear
+      \(U.DoNotUnboxLazy (CopyTracked _ retired _)) ->
+        unsafePerformIO (modifyIORef' retired NonLinear.succ)
 
 freezeList :: Vector.Vector Int %1 -> [Int]
 freezeList array =
@@ -74,6 +146,35 @@ test_construction =
         linearly
           (\linear -> freezeList (Vector.fromVector (U.fromList [4, 5, 6]) linear))
           @?= [4, 5, 6]
+    , testCase "ordinary sources need no Copyable instance" do
+        counter <- newIORef 0
+        _ <-
+          Exception.evaluate $
+            linearly \linear ->
+              dup linear & \(constantLinear, vectorLinear) ->
+                consume
+                  ( Vector.constant
+                      2
+                      (U.DoNotUnboxLazy (Tracked counter 1))
+                      constantLinear
+                  )
+                  `lseq` consume
+                    ( Vector.fromVector
+                        (U.singleton (U.DoNotUnboxLazy (Tracked counter 2)))
+                        vectorLinear
+                    )
+        consumed <- readIORef counter
+        consumed @?= 3
+    , testCase "materialization invokes move for every owned element" do
+        moves <- newIORef 0
+        materializeMoveTracked moves @?= [(10, True), (20, True)]
+        moveCount <- readIORef moves
+        moveCount @?= 2
+    , testCase "discarding materialization still invokes every move" do
+        moves <- newIORef 0
+        _ <- Exception.evaluate (discardMaterializedMoveTracked moves)
+        moveCount <- readIORef moves
+        moveCount @?= 2
     , testCase "unsafeFromVector takes ownership of the source" do
         linearly
           ( \linear ->
@@ -142,6 +243,42 @@ test_mirroredSurface =
   testCase "supports borrowed and copied reads, replacement, update, modify, and swap" do
     mirroredSurface @?= (((3, 2, 1, 3), (2, 2, 20)), [3, 21, 11])
 
+retireCopiedResult ::
+  (Ur UnboxedCopyTracked, Mut α (Vector.Vector UnboxedCopyTracked)) %1 ->
+  Vector.Vector UnboxedCopyTracked %1 ->
+  Int
+retireCopiedResult =
+  Unsafe.toLinear2 \(copiedResult, borrowed) owner ->
+    consume borrowed `lseq`
+      consume owner `lseq`
+        case copiedResult of
+          Ur (U.DoNotUnboxLazy (CopyTracked _ _ value)) -> value
+
+copyAtMutAfterRetirement :: IORef Int -> IORef Int -> Int
+copyAtMutAfterRetirement copies retired =
+  linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <-
+        borrowM
+          ( Vector.fromList
+              [U.DoNotUnboxLazy (CopyTracked copies retired 10)]
+              ownerLinear
+          )
+      copiedResult <- Vector.copyAtMut 0 vector
+      pureAfter (retireCopiedResult copiedResult (reclaim lend))
+
+test_copyAtMutStrictness :: TestTree
+test_copyAtMutStrictness =
+  testCase "copyAtMut completes copying before mutable recovery" do
+    copies <- newIORef 0
+    retired <- newIORef 0
+    copyAtMutAfterRetirement copies retired @?= 10
+    copyCount <- readIORef copies
+    copyCount @?= 1
+    retirementCount <- readIORef retired
+    retirementCount @?= 1
+
 sharedReads :: ((Int, Int), [Int])
 sharedReads =
   linearly \linear -> DataFlow.do
@@ -169,6 +306,28 @@ snapshotThenMutate =
       let !() = consume array
       pureAfter (U.toList snapshot, freezeList (reclaim lend))
 
+trackedSnapshot :: IORef Int -> IORef Int -> [Int]
+trackedSnapshot copies retired =
+  linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (array, lend) <-
+        borrowM
+          ( Vector.fromList
+              [ U.DoNotUnboxLazy (CopyTracked copies retired 10)
+              , U.DoNotUnboxLazy (CopyTracked copies retired 20)
+              ]
+              ownerLinear
+          )
+      (Ur snapshot, array) <- Vector.copyToVector array
+      let !() = consume array
+      pureAfter
+        ( consume (reclaim lend) `lseq`
+            NonLinear.map
+              (\(U.DoNotUnboxLazy (CopyTracked _ _ value)) -> value)
+              (U.toList snapshot)
+        )
+
 test_copyToVector :: TestTree
 test_copyToVector =
   testGroup
@@ -177,6 +336,14 @@ test_copyToVector =
         snapshotThenMutate @?= ([1, 2, 3], [101, 2, 3])
     , testCase "accepts a shared borrow" do
         sharedSnapshot @?= ([1, 2, 3], [1, 2, 3])
+    , testCase "invokes copy for every element while retaining the owner" do
+        copies <- newIORef 0
+        retired <- newIORef 0
+        trackedSnapshot copies retired @?= [10, 20]
+        copyCount <- readIORef copies
+        copyCount @?= 2
+        retirementCount <- readIORef retired
+        retirementCount @?= 2
     ]
 
 sharedSnapshot :: ([Int], [Int])
@@ -524,12 +691,12 @@ test_typingBoundaries =
         "cannot be copied!"
         badDuplicate
     , expectDeferredTypeError
-        "Unbox alone does not permit copyAt"
-        "Copyable (U.DoNotUnboxLazy LinearElement)"
+        "Movable alone does not permit copyAt"
+        "Copyable (U.DoNotUnboxLazy MovableOnly)"
         badNonCopyableCopyAtCase
     , expectDeferredTypeError
-        "Unbox alone does not permit copyAtMut"
-        "Copyable (U.DoNotUnboxLazy LinearElement)"
+        "Movable alone does not permit copyAtMut"
+        "Copyable (U.DoNotUnboxLazy MovableOnly)"
         badNonCopyableCopyAtMutCase
     ]
   where
@@ -547,7 +714,20 @@ test_typingBoundaries =
 
 test_benchmarkRoots :: TestTree
 test_benchmarkRoots =
-  testCase "direct and Pure Borrow benchmark roots agree" do
-    let input = U.generate 257 (\index -> index `NonLinear.rem` 17)
-    UnboxedBench.pureBorrowFixedUnboxedUpdateLoop input
-      @?= UnboxedBench.directFixedUnboxedUpdateLoop input
+  testGroup
+    "benchmark roots"
+    [ testGroup
+        ("length " <> show length_)
+        [ testCase "fixed kernel roots agree" do
+            let input =
+                  U.generate length_ (\index -> index `NonLinear.rem` 17)
+            UnboxedBench.pureBorrowFixedUnboxedKernel input
+              @?= UnboxedBench.directFixedUnboxedKernel input
+        , testCase "fixed public-materialization roots agree" do
+            let input =
+                  U.generate length_ (\index -> index `NonLinear.rem` 17)
+            UnboxedBench.pureBorrowFixedUnboxedMaterialization input
+              @?= UnboxedBench.directFixedUnboxedMaterialization input
+        ]
+    | length_ <- [0, 1, 257, 1024 * 1024]
+    ]

--- a/test/Data/Vector/Unboxed/Mutable/Linear/TypingCases.hs
+++ b/test/Data/Vector/Unboxed/Mutable/Linear/TypingCases.hs
@@ -52,7 +52,7 @@ badSplit ::
 badSplit = split
 
 badDuplicate ::
-  Borrow borrowKind α (Unboxed.Vector Int) %1 ->
+  Borrow bk α (Unboxed.Vector Int) %1 ->
   Unboxed.Vector Int
 badDuplicate = copy
 
@@ -65,30 +65,42 @@ instance Consumable (U.DoNotUnboxLazy LinearElement) where
     Unsafe.toLinear \(U.DoNotUnboxLazy (LinearElement ref)) ->
       consume ref
 
+newtype MovableOnly = MovableOnly Int
+
+type UnboxedMovableOnly = U.DoNotUnboxLazy MovableOnly
+
+instance Consumable UnboxedMovableOnly where
+  consume = Unsafe.toLinear \_ -> ()
+
+instance Dupable UnboxedMovableOnly where
+  dup2 = Unsafe.toLinear \value -> (value, value)
+
+instance Movable UnboxedMovableOnly where
+  move = Unsafe.toLinear \value -> Ur value
+
 nonCopyableGet ::
   Mut α (Unboxed.Vector BoxedLinearElement) %1 ->
   BO α (Mut α BoxedLinearElement)
 nonCopyableGet = Unboxed.get 0
 
 badNonCopyableCopyAtMut ::
-  Mut α (Unboxed.Vector BoxedLinearElement) %1 ->
+  Mut α (Unboxed.Vector UnboxedMovableOnly) %1 ->
   BO
     α
-    ( Ur BoxedLinearElement
-    , Mut α (Unboxed.Vector BoxedLinearElement)
+    ( Ur UnboxedMovableOnly
+    , Mut α (Unboxed.Vector UnboxedMovableOnly)
     )
 badNonCopyableCopyAtMut = Unboxed.copyAtMut 0
 
 badNonCopyableCopyAtMutCase :: Int
 badNonCopyableCopyAtMutCase =
   linearly \linear -> DataFlow.do
-    (refLinear, remainingLinear) <- dup linear
-    (ownerLinear, runLinear) <- dup remainingLinear
+    (ownerLinear, runLinear) <- dup linear
     runBO runLinear Control.do
       (vector, lend) <-
         borrowM
           ( Unboxed.fromList
-              [U.DoNotUnboxLazy (LinearElement (Ref.new 1 refLinear))]
+              [U.DoNotUnboxLazy (MovableOnly 1)]
               ownerLinear
           )
       (Ur _, vector) <- Unboxed.copyAtMut 0 vector
@@ -98,13 +110,12 @@ badNonCopyableCopyAtMutCase =
 badNonCopyableCopyAtCase :: Int
 badNonCopyableCopyAtCase =
   linearly \linear -> DataFlow.do
-    (refLinear, remainingLinear) <- dup linear
-    (ownerLinear, runLinear) <- dup remainingLinear
+    (ownerLinear, runLinear) <- dup linear
     runBO runLinear Control.do
       (vector, lend) <-
         borrowM
           ( Unboxed.fromList
-              [U.DoNotUnboxLazy (LinearElement (Ref.new 1 refLinear))]
+              [U.DoNotUnboxLazy (MovableOnly 1)]
               ownerLinear
           )
       share vector & \(Ur shared) -> Control.do


### PR DESCRIPTION
`Data.Vector.Unboxed.Mutable.Growable.Linear.Borrow` completes the
vector grid: growable storage over `Unbox` elements. It follows the
boxed growable vector's structure — an owned header behind a linear
`Ref`, amortized push/pop, `getContents` projecting to the fixed vector
over the live prefix — but, like the fixed unboxed vector, its elements
are GC-owned, so materialization freezes in O(1) and reads return
elements rather than borrows of them.

`PureBorrow.Internal.Bench.Unboxed` grows the growth, no-growth and
materialization kernels for the new type, alongside the direct
`vector`-only baselines they are compared against, and the unrestricted
vector and divide-and-conquer variants. `pure-borrow-test` asserts the
pure-borrow kernels agree with their baselines, so the benchmark cannot
drift into measuring something that computes a different answer.
Its `direct…` baselines use `Data.Vector.Unboxed.modify`, and the growth
kernel — whose result length differs from its input's, so `modify` does not
apply — uses `runST` with an `STRef` header. Neither reaches for
`unsafePerformIO`, per the rule in `AGENTS.md`.
Its `Consumable` instance and `consumeInitialized` are `NOINLINE` for the
same reason as the boxed growable owner's: the element-releasing traversal
runs under `unsafePerformIO`, and inlining would let GHC duplicate or float
that call so the elements are consumed more than once.
The FFT benchmark's `owning/boxed` case is dropped along with the
element-owning `fftDC` it was built on; the remaining cases compare the
unrestricted vector on boxed against unboxed storage.
Part of #14.