### PR TITLE
feat(vector): add generic growable and multiplicity-polymorphic vectors

### DIFF
--- a/pure-borrow.cabal
+++ b/pure-borrow.cabal
@@ -136,6 +136,10 @@ library
     Data.Ref.Linear.Borrow
     Data.Ref.Linear.Unlifted
     Data.Unique.Linear
+    Data.Vector.Generic.Mutable.Growable.Linear.Borrow.Unrestricted
+    Data.Vector.Generic.Mutable.Growable.Linear.Borrow.Unrestricted.Internal
+    Data.Vector.Generic.Mutable.Linear.Borrow.Experimental.Multiplicity
+    Data.Vector.Generic.Mutable.Linear.Borrow.Experimental.Multiplicity.Internal
     Data.Vector.Generic.Mutable.Linear.Borrow.Unrestricted
     Data.Vector.Generic.Mutable.Linear.Borrow.Unrestricted.Internal
     Data.Vector.Mutable.Growable.Linear.Borrow
@@ -171,6 +175,10 @@ test-suite pure-borrow-test
     Control.Monad.Borrow.Pure.CopyableSpec
     Control.Monad.Borrow.Pure.Lifetime.TypingCases
     Control.Monad.Borrow.Pure.LifetimeSpec
+    Data.Vector.Generic.Mutable.Growable.Linear.Borrow.Unrestricted.TypingCases
+    Data.Vector.Generic.Mutable.Growable.Linear.Borrow.UnrestrictedSpec
+    Data.Vector.Generic.Mutable.Linear.Borrow.Experimental.Multiplicity.TypingCases
+    Data.Vector.Generic.Mutable.Linear.Borrow.Experimental.MultiplicitySpec
     Data.Vector.Generic.Mutable.Linear.Borrow.Unrestricted.TypingCases
     Data.Vector.Generic.Mutable.Linear.Borrow.UnrestrictedSpec
     Data.Vector.Mutable.Growable.Linear.BorrowSpec
@@ -211,6 +219,7 @@ test-suite pure-borrow-inspection
   -- cabal-gild: discover test-inspection --exclude=test-inspection/Main.hs
   other-modules:
     PureBorrow.Inspection.Fft
+    PureBorrow.Inspection.GenericGrowableUnrestricted
     PureBorrow.Inspection.QSort
 
   ghc-options:

--- a/src/Data/Vector/Generic/Mutable/Growable/Linear/Borrow/Unrestricted.hs
+++ b/src/Data/Vector/Generic/Mutable/Growable/Linear/Borrow/Unrestricted.hs
@@ -1,0 +1,79 @@
+{-# LANGUAGE ImpredicativeTypes #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+
+{- |
+Growable, linearly owned mutable vectors with unrestricted, GC-owned elements
+and a backend selected through @vector@'s generic interface.
+
+A 'GrowableVector' keeps its replaceable backing buffer behind a stable mutable
+header. Consequently, 'reserve', 'push', and 'extend' preserve the identity
+reclaimed by an existing @Lend@. The backend parameter @v@ may be any immutable
+backend supported by 'Data.Vector.Generic.Vector'.
+
+'getContents' projects a mutable or shared growable borrow to the corresponding
+fixed-size unrestricted vector borrow over exactly the initialized prefix.
+'withContent' provides the same projection in a rank-2 no-growth scope and
+restores the growable borrow afterward. Growth remains unavailable until every
+fixed content borrow has ended.
+
+The owner and mutable backing are linear, but entries are not element-owned.
+Constructing, growing, cloning, discarding, and materializing a vector therefore
+do not invoke @Consumable@, @Movable@, @Copyable@, or @Dupable@ operations on
+elements. 'toVector' freezes the initialized prefix in \(O(1)\).
+
+The growable owner deliberately has no splitting operation because independent
+replaceable headers over overlapping storage would invalidate borrows after
+growth. Split only a fixed view inside 'withContent'.
+
+Growth provides a normal-return ownership guarantee. Allocation and copying
+complete before the logical size is published; an owner is not promised to be
+recoverable after an exception escapes a @BO@ computation.
+
+Custom backends are a trusted extensibility boundary. Their mutable operations
+must obey the usual @vector@ laws, including fresh allocation, exact lengths,
+non-overlapping storage, copying thaw and freeze, and alias-free ownership
+transfer through unsafe freeze and thaw.
+-}
+module Data.Vector.Generic.Mutable.Growable.Linear.Borrow.Unrestricted (
+  GrowableVector,
+  empty,
+  constant,
+  fromList,
+  withCapacity,
+  fromVector,
+  unsafeFromMutable,
+  unsafeFromVector,
+  toVector,
+  toList,
+  copyToVector,
+  size,
+  capacity,
+  get,
+  unsafeGet,
+  head,
+  unsafeHead,
+  last,
+  unsafeLast,
+  copyAt,
+  unsafeCopyAt,
+  copyAtMut,
+  unsafeCopyAtMut,
+  set,
+  unsafeSet,
+  write,
+  unsafeWrite,
+  update,
+  unsafeUpdate,
+  modify,
+  swap,
+  unsafeSwap,
+  reserve,
+  reserveAdditional,
+  push,
+  extend,
+  getContents,
+  withContent,
+  withContent_,
+) where
+
+import Data.Vector.Generic.Mutable.Growable.Linear.Borrow.Unrestricted.Internal

--- a/src/Data/Vector/Generic/Mutable/Growable/Linear/Borrow/Unrestricted/Internal.hs
+++ b/src/Data/Vector/Generic/Mutable/Growable/Linear/Borrow/Unrestricted/Internal.hs
@@ -1,0 +1,854 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE ImpredicativeTypes #-}
+{-# LANGUAGE QualifiedDo #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RoleAnnotations #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# OPTIONS_GHC -Wno-name-shadowing #-}
+{-# OPTIONS_GHC -Wno-redundant-constraints #-}
+{-# OPTIONS_HADDOCK hide #-}
+
+module Data.Vector.Generic.Mutable.Growable.Linear.Borrow.Unrestricted.Internal (
+  module Data.Vector.Generic.Mutable.Growable.Linear.Borrow.Unrestricted.Internal,
+) where
+
+import Control.Functor.Linear qualified as Control
+import Control.Monad.Borrow.Pure.Affine (aff, pop)
+import Control.Monad.Borrow.Pure.BO
+import Control.Monad.Borrow.Pure.BO.Internal (unsafeSrunBO_)
+import Control.Monad.Borrow.Pure.BO.Unsafe
+import Control.Monad.Borrow.Pure.Clone
+import Control.Monad.Borrow.Pure.Copyable
+import Control.Monad.Borrow.Pure.Lifetime.Token.Unsafe (
+  LinearOnly (..),
+  LinearOnlyWitness (..),
+ )
+import Data.Ref.Linear qualified as Ref
+import Data.Ref.Linear.Borrow qualified as RefBorrow
+import Data.Unrestricted.Linear qualified as Ur
+import Data.Vector.Generic qualified as G
+import Data.Vector.Generic.Mutable qualified as GM
+import Data.Vector.Generic.Mutable.Linear.Borrow.Unrestricted qualified as Fixed
+import Data.Vector.Generic.Mutable.Linear.Borrow.Unrestricted.Internal qualified as Fixed.Internal
+import Data.Vector.Mutable (RealWorld)
+import GHC.Exts qualified as GHC
+import GHC.IO (unsafePerformIO)
+import GHC.Stack (HasCallStack)
+import GHC.TypeError
+import Prelude.Linear hiding (getContents, head, last)
+import Unsafe.Linear qualified as Unsafe
+import Prelude qualified as NonLinear
+
+data Header v a where
+  Header ::
+    {-# UNPACK #-} !Int ->
+    !(G.Mutable v RealWorld a) %1 ->
+    Header v a
+
+-- | A growable vector with a stable header and replaceable generic backing.
+data GrowableVector v a where
+  GrowableVector ::
+    !(Ref.Ref (Header v a)) %1 ->
+    GrowableVector v a
+
+type role Header nominal nominal
+
+type role GrowableVector nominal nominal
+
+instance LinearOnly (GrowableVector v a) where
+  linearOnly = UnsafeLinearOnly
+  {-# INLINE linearOnly #-}
+
+instance
+  ( Unsatisfiable
+      (ShowType (GrowableVector v a) :<>: Text " cannot be copied!")
+  ) =>
+  Copyable (GrowableVector v a)
+  where
+  copy = unsatisfiable
+
+instance Consumable (GrowableVector v a) where
+  consume = Unsafe.toLinear \_ -> ()
+  {-# INLINE consume #-}
+
+instance (G.Vector v a) => Clone (GrowableVector v a) where
+  clone =
+    Unsafe.toLinear \(UnsafeAlias (GrowableVector ref)) ->
+      case Ref.unsafeReadRef ref of
+        (Header logicalSize buffer, duplicateRef) ->
+          pop (aff duplicateRef) `lseq` Control.do
+            cloned <-
+              unsafeSystemIOToBO do
+                target <- GM.unsafeNew (GM.length buffer)
+                GM.unsafeCopy
+                  (GM.unsafeTake logicalSize target)
+                  (GM.unsafeTake logicalSize buffer)
+                NonLinear.pure target
+            linear <- askLinearly
+            Control.pure
+              (GrowableVector (Ref.new (Header logicalSize cloned) linear))
+  {-# INLINE clone #-}
+
+allocateBuffer ::
+  (G.Vector v a) =>
+  Int ->
+  Linearly %1 ->
+  G.Mutable v RealWorld a
+{-# NOINLINE allocateBuffer #-}
+allocateBuffer =
+  GHC.noinline \count linear ->
+    linear `lseq` unsafePerformIO (GM.unsafeNew count)
+
+cloneBuffer ::
+  (G.Vector v a) =>
+  v a ->
+  Linearly %1 ->
+  G.Mutable v RealWorld a
+{-# NOINLINE cloneBuffer #-}
+cloneBuffer =
+  GHC.noinline \source linear ->
+    linear `lseq` unsafePerformIO (G.thaw source)
+
+-- | \(O(1)\). Construct an empty vector with zero capacity.
+empty :: (G.Vector v a) => Linearly %1 -> GrowableVector v a
+{-# NOINLINE empty #-}
+empty = withCapacity 0
+
+{- | \(O(n)\). Construct @count@ initialized copies of a value.
+
+As in @vector@, a negative count produces an empty vector.
+-}
+constant ::
+  (G.Vector v a) =>
+  Int ->
+  a ->
+  Linearly %1 ->
+  GrowableVector v a
+{-# NOINLINE constant #-}
+constant =
+  GHC.noinline \count value linear ->
+    fromVector (G.replicate count value) linear
+
+-- | \(O(n)\). Copy an unrestricted list into a new vector.
+fromList ::
+  (G.Vector v a) =>
+  [a] ->
+  Linearly %1 ->
+  GrowableVector v a
+{-# NOINLINE fromList #-}
+fromList =
+  GHC.noinline \values linear ->
+    fromVector (G.fromList values) linear
+
+{- | \(O(1)\). Construct an empty vector with the requested capacity.
+
+The capacity must be non-negative. Spare storage is not considered initialized.
+-}
+withCapacity ::
+  (HasCallStack, G.Vector v a) =>
+  Int ->
+  Linearly %1 ->
+  GrowableVector v a
+{-# NOINLINE withCapacity #-}
+withCapacity =
+  GHC.noinline \requested linear ->
+    if requested < 0
+      then error ("withCapacity: negative capacity " <> show requested) linear
+      else
+        dup linear & \(bufferLinear, refLinear) ->
+          GrowableVector
+            ( Ref.new
+                (Header 0 (allocateBuffer requested bufferLinear))
+                refLinear
+            )
+
+-- | \(O(n)\). Copy an immutable vector into a new growable owner.
+fromVector ::
+  (G.Vector v a) =>
+  v a ->
+  Linearly %1 ->
+  GrowableVector v a
+{-# NOINLINE fromVector #-}
+fromVector =
+  GHC.noinline \source linear ->
+    dup linear & \(bufferLinear, refLinear) ->
+      GrowableVector
+        ( Ref.new
+            (Header (G.length source) (cloneBuffer source bufferLinear))
+            refLinear
+        )
+
+{- | \(O(1)\). Take ownership of a mutable vector without copying.
+
+The complete source slice is treated as initialized. The caller must not retain
+any alias that can access its allocation.
+-}
+unsafeFromMutable ::
+  (G.Vector v a) =>
+  G.Mutable v state a %1 ->
+  Linearly %1 ->
+  GrowableVector v a
+{-# INLINE unsafeFromMutable #-}
+unsafeFromMutable =
+  Unsafe.toLinear \source linear ->
+    GrowableVector
+      ( Ref.new
+          (Header (GM.length source) (Unsafe.coerce source))
+          linear
+      )
+
+{- | \(O(1)\). Unsafely take ownership of an immutable vector's storage.
+
+The complete source is initialized. No immutable alias may be observed after
+this operation because subsequent growth and mutation reuse its storage.
+-}
+unsafeFromVector ::
+  (G.Vector v a) =>
+  v a %1 ->
+  Linearly %1 ->
+  GrowableVector v a
+{-# NOINLINE unsafeFromVector #-}
+unsafeFromVector =
+  GHC.noinline $
+    Unsafe.toLinear \source linear ->
+      GrowableVector
+        ( Ref.new
+            ( Header
+                (G.length source)
+                (unsafePerformIO (G.unsafeThaw source))
+            )
+            linear
+        )
+
+{- | \(O(1)\). Consume the owner and freeze exactly its initialized prefix.
+
+No element crosses an ownership boundary: entries were GC-owned already. Spare
+capacity is neither exposed nor copied.
+-}
+toVector ::
+  (G.Vector v a) =>
+  GrowableVector v a %1 ->
+  Ur (v a)
+{-# NOINLINE toVector #-}
+toVector =
+  GHC.noinline $
+    Unsafe.toLinear \(GrowableVector ref) ->
+      case Ref.free ref of
+        Header logicalSize buffer ->
+          Ur
+            ( unsafePerformIO
+                (G.unsafeFreeze (GM.unsafeTake logicalSize buffer))
+            )
+
+-- | \(O(n)\). Consume the owner and return its initialized prefix as a list.
+toList ::
+  (G.Vector v a) =>
+  GrowableVector v a %1 ->
+  Ur [a]
+{-# INLINE toList #-}
+toList = Ur.lift G.toList . toVector
+
+{- | \(O(n)\). Copy the initialized prefix into an immutable vector and thread
+the live growable borrow.
+-}
+copyToVector ::
+  (G.Vector v a, α >= β) =>
+  Borrow bk α (GrowableVector v a) %1 ->
+  BO β (Ur (v a), Borrow bk α (GrowableVector v a))
+{-# INLINE copyToVector #-}
+copyToVector =
+  Unsafe.toLinear \vector@(UnsafeAlias (GrowableVector ref)) ->
+    case Ref.unsafeReadRef ref of
+      (Header logicalSize buffer, duplicateRef) ->
+        pop (aff duplicateRef) `lseq`
+          unsafeSystemIOToBO do
+            snapshot <- G.freeze (GM.unsafeTake logicalSize buffer)
+            NonLinear.pure (Ur snapshot, vector)
+
+toRefMut ::
+  Mut α (GrowableVector v a) %1 ->
+  Mut α (Ref.Ref (Header v a))
+{-# INLINE toRefMut #-}
+toRefMut =
+  unsafeMapAlias
+    (Unsafe.toLinear \(GrowableVector ref) -> ref)
+
+fromRefMut ::
+  Mut α (Ref.Ref (Header v a)) %1 ->
+  Mut α (GrowableVector v a)
+{-# INLINE fromRefMut #-}
+fromRefMut =
+  unsafeMapAlias
+    (Unsafe.toLinear GrowableVector)
+
+withHeader ::
+  (α >= β) =>
+  (Header v a %1 -> BO β (result, Header v a)) %1 ->
+  Mut α (GrowableVector v a) %1 ->
+  BO β (result, Mut α (GrowableVector v a))
+{-# INLINE withHeader #-}
+withHeader action vector = Control.do
+  (result, ref) <- RefBorrow.update action (toRefMut vector)
+  Control.pure (result, fromRefMut ref)
+
+-- | \(O(1)\). Return the number of initialized elements and thread the borrow.
+size ::
+  Borrow bk α (GrowableVector v a) %1 ->
+  (Ur Int, Borrow bk α (GrowableVector v a))
+{-# INLINE size #-}
+size =
+  Unsafe.toLinear \vector@(UnsafeAlias (GrowableVector ref)) ->
+    case Ref.unsafeReadRef ref of
+      (Header logicalSize _, duplicateRef) ->
+        pop (aff duplicateRef) `lseq` (Ur logicalSize, vector)
+
+-- | \(O(1)\). Return the backing allocation size and thread the borrow.
+capacity ::
+  (G.Vector v a) =>
+  Borrow bk α (GrowableVector v a) %1 ->
+  (Ur Int, Borrow bk α (GrowableVector v a))
+{-# INLINE capacity #-}
+capacity =
+  Unsafe.toLinear \vector@(UnsafeAlias (GrowableVector ref)) ->
+    case Ref.unsafeReadRef ref of
+      (Header _ buffer, duplicateRef) ->
+        pop (aff duplicateRef) `lseq` (Ur (GM.length buffer), vector)
+
+-- | Read an initialized element and thread the growable borrow.
+get ::
+  (HasCallStack, G.Vector v a, α >= β) =>
+  Int ->
+  Borrow bk α (GrowableVector v a) %1 ->
+  BO β (Ur a, Borrow bk α (GrowableVector v a))
+{-# INLINE get #-}
+get index vector =
+  case size vector of
+    (Ur logicalSize, vector) ->
+      if index < 0 || index >= logicalSize
+        then
+          error
+            ( "get: index "
+                <> show index
+                <> " out of bounds for length "
+                <> show logicalSize
+            )
+            vector
+        else unsafeGet index vector
+
+-- | Unchecked 'get'. The index must satisfy @0 <= index < size@.
+unsafeGet ::
+  (G.Vector v a, α >= β) =>
+  Int ->
+  Borrow bk α (GrowableVector v a) %1 ->
+  BO β (Ur a, Borrow bk α (GrowableVector v a))
+{-# INLINE unsafeGet #-}
+unsafeGet index =
+  Unsafe.toLinear \vector@(UnsafeAlias (GrowableVector ref)) ->
+    case Ref.unsafeReadRef ref of
+      (Header _ buffer, duplicateRef) ->
+        pop (aff duplicateRef) `lseq`
+          unsafeSystemIOToBO do
+            value <- GM.unsafeRead buffer index
+            NonLinear.pure (Ur value, vector)
+
+-- | Read the first initialized element.
+head ::
+  (HasCallStack, G.Vector v a, α >= β) =>
+  Borrow bk α (GrowableVector v a) %1 ->
+  BO β (Ur a, Borrow bk α (GrowableVector v a))
+{-# INLINE head #-}
+head = get 0
+
+-- | Unchecked 'head'. The vector must be non-empty.
+unsafeHead ::
+  (G.Vector v a, α >= β) =>
+  Borrow bk α (GrowableVector v a) %1 ->
+  BO β (Ur a, Borrow bk α (GrowableVector v a))
+{-# INLINE unsafeHead #-}
+unsafeHead = unsafeGet 0
+
+-- | Read the last initialized element.
+last ::
+  (HasCallStack, G.Vector v a, α >= β) =>
+  Borrow bk α (GrowableVector v a) %1 ->
+  BO β (Ur a, Borrow bk α (GrowableVector v a))
+{-# INLINE last #-}
+last vector =
+  case size vector of
+    (Ur logicalSize, vector) ->
+      if logicalSize <= 0
+        then error "last: empty vector" vector
+        else unsafeGet (logicalSize - 1) vector
+
+-- | Unchecked 'last'. The vector must be non-empty.
+unsafeLast ::
+  (G.Vector v a, α >= β) =>
+  Borrow bk α (GrowableVector v a) %1 ->
+  BO β (Ur a, Borrow bk α (GrowableVector v a))
+{-# INLINE unsafeLast #-}
+unsafeLast vector =
+  case size vector of
+    (Ur logicalSize, vector) -> unsafeGet (logicalSize - 1) vector
+
+-- | Read an initialized element through a shared borrow.
+copyAt ::
+  (HasCallStack, G.Vector v a, α >= β) =>
+  Int ->
+  Share α (GrowableVector v a) ->
+  BO β (Ur a)
+{-# INLINE copyAt #-}
+copyAt index vector = Control.do
+  (value, vector) <- get index vector
+  Control.pure (consume vector `lseq` value)
+
+-- | Unchecked 'copyAt'. The index must satisfy @0 <= index < size@.
+unsafeCopyAt ::
+  (G.Vector v a, α >= β) =>
+  Int ->
+  Share α (GrowableVector v a) ->
+  BO β (Ur a)
+{-# INLINE unsafeCopyAt #-}
+unsafeCopyAt index vector = Control.do
+  (value, vector) <- unsafeGet index vector
+  Control.pure (consume vector `lseq` value)
+
+-- | Read an initialized element and retain the mutable growable borrow.
+copyAtMut ::
+  (HasCallStack, G.Vector v a, α >= β) =>
+  Int ->
+  Mut α (GrowableVector v a) %1 ->
+  BO β (Ur a, Mut α (GrowableVector v a))
+{-# INLINE copyAtMut #-}
+copyAtMut = get
+
+-- | Unchecked 'copyAtMut'. The index must satisfy @0 <= index < size@.
+unsafeCopyAtMut ::
+  (G.Vector v a, α >= β) =>
+  Int ->
+  Mut α (GrowableVector v a) %1 ->
+  BO β (Ur a, Mut α (GrowableVector v a))
+{-# INLINE unsafeCopyAtMut #-}
+unsafeCopyAtMut = unsafeGet
+
+-- | Replace an initialized element and return the displaced value.
+set ::
+  (HasCallStack, G.Vector v a, α >= β) =>
+  Int ->
+  a ->
+  Mut α (GrowableVector v a) %1 ->
+  BO β (Ur a, Mut α (GrowableVector v a))
+{-# INLINE set #-}
+set index value vector =
+  case size vector of
+    (Ur logicalSize, vector) ->
+      if index < 0 || index >= logicalSize
+        then
+          error
+            ( "set: index "
+                <> show index
+                <> " out of bounds for length "
+                <> show logicalSize
+            )
+            vector
+        else unsafeSet index value vector
+
+-- | Unchecked 'set'. The index must satisfy @0 <= index < size@.
+unsafeSet ::
+  (G.Vector v a, α >= β) =>
+  Int ->
+  a ->
+  Mut α (GrowableVector v a) %1 ->
+  BO β (Ur a, Mut α (GrowableVector v a))
+{-# INLINE unsafeSet #-}
+unsafeSet index value =
+  Unsafe.toLinear \vector@(UnsafeAlias (GrowableVector ref)) ->
+    case Ref.unsafeReadRef ref of
+      (Header _ buffer, duplicateRef) ->
+        pop (aff duplicateRef) `lseq`
+          unsafeSystemIOToBO do
+            oldValue <- GM.unsafeExchange buffer index value
+            NonLinear.pure (Ur oldValue, vector)
+
+-- | Replace an initialized element and discard the displaced GC-owned value.
+write ::
+  (HasCallStack, G.Vector v a, α >= β) =>
+  Int ->
+  a ->
+  Mut α (GrowableVector v a) %1 ->
+  BO β (Mut α (GrowableVector v a))
+{-# INLINE write #-}
+write index value vector =
+  case size vector of
+    (Ur logicalSize, vector) ->
+      if index < 0 || index >= logicalSize
+        then
+          error
+            ( "write: index "
+                <> show index
+                <> " out of bounds for length "
+                <> show logicalSize
+            )
+            vector
+        else unsafeWrite index value vector
+
+-- | Unchecked 'write'. The index must satisfy @0 <= index < size@.
+unsafeWrite ::
+  (G.Vector v a, α >= β) =>
+  Int ->
+  a ->
+  Mut α (GrowableVector v a) %1 ->
+  BO β (Mut α (GrowableVector v a))
+{-# INLINE unsafeWrite #-}
+unsafeWrite index value =
+  Unsafe.toLinear \vector@(UnsafeAlias (GrowableVector ref)) ->
+    case Ref.unsafeReadRef ref of
+      (Header _ buffer, duplicateRef) ->
+        pop (aff duplicateRef) `lseq`
+          unsafeSystemIOToBO do
+            GM.unsafeWrite buffer index value
+            NonLinear.pure vector
+
+-- | Transform an initialized element and return an unrestricted result.
+update ::
+  (HasCallStack, G.Vector v a, α >= β) =>
+  Int ->
+  (a -> BO β (Ur result, Ur a)) ->
+  Mut α (GrowableVector v a) %1 ->
+  BO β (Ur result, Mut α (GrowableVector v a))
+{-# INLINE update #-}
+update index action vector =
+  case size vector of
+    (Ur logicalSize, vector) ->
+      if index < 0 || index >= logicalSize
+        then
+          error
+            ( "update: index "
+                <> show index
+                <> " out of bounds for length "
+                <> show logicalSize
+            )
+            vector
+        else unsafeUpdate index action vector
+
+-- | Unchecked 'update'. The index must satisfy @0 <= index < size@.
+unsafeUpdate ::
+  (G.Vector v a, α >= β) =>
+  Int ->
+  (a -> BO β (Ur result, Ur a)) ->
+  Mut α (GrowableVector v a) %1 ->
+  BO β (Ur result, Mut α (GrowableVector v a))
+{-# INLINE unsafeUpdate #-}
+unsafeUpdate index action =
+  Unsafe.toLinear \vector@(UnsafeAlias (GrowableVector ref)) ->
+    case Ref.unsafeReadRef ref of
+      (Header _ buffer, duplicateRef) ->
+        pop (aff duplicateRef) `lseq` Control.do
+          Ur value <-
+            unsafeSystemIOToBO do
+              value <- GM.unsafeRead buffer index
+              NonLinear.pure (Ur value)
+          (result, Ur updatedValue) <- action value
+          () <- unsafeSystemIOToBO (GM.unsafeWrite buffer index updatedValue)
+          Control.pure (result, vector)
+
+-- | Transform an initialized element.
+modify ::
+  (HasCallStack, G.Vector v a, α >= β) =>
+  Int ->
+  (a -> a) ->
+  Mut α (GrowableVector v a) %1 ->
+  BO β (Mut α (GrowableVector v a))
+{-# INLINE modify #-}
+modify index function vector = Control.do
+  (Ur (), vector) <-
+    update
+      index
+      (\value -> Control.pure (Ur (), Ur (function value)))
+      vector
+  Control.pure vector
+
+-- | Swap two initialized elements.
+swap ::
+  (HasCallStack, G.Vector v a, α >= β) =>
+  Mut α (GrowableVector v a) %1 ->
+  Int ->
+  Int ->
+  BO β (Mut α (GrowableVector v a))
+{-# INLINE swap #-}
+swap vector first second =
+  case size vector of
+    (Ur logicalSize, vector) ->
+      if first
+        < 0
+        || first
+        >= logicalSize
+        || second
+        < 0
+        || second
+        >= logicalSize
+        then
+          error
+            ( "swap: indices "
+                <> show (first, second)
+                <> " out of bounds for length "
+                <> show logicalSize
+            )
+            vector
+        else unsafeSwap vector first second
+
+-- | Unchecked 'swap'. Both indices must satisfy @0 <= index < size@.
+unsafeSwap ::
+  (G.Vector v a, α >= β) =>
+  Mut α (GrowableVector v a) %1 ->
+  Int ->
+  Int ->
+  BO β (Mut α (GrowableVector v a))
+{-# INLINE unsafeSwap #-}
+unsafeSwap =
+  Unsafe.toLinear \vector@(UnsafeAlias (GrowableVector ref)) first second ->
+    case Ref.unsafeReadRef ref of
+      (Header _ buffer, duplicateRef) ->
+        pop (aff duplicateRef) `lseq`
+          unsafeSystemIOToBO do
+            GM.unsafeSwap buffer first second
+            NonLinear.pure vector
+
+{- | Ensure at least the requested absolute capacity.
+
+The request must be non-negative. Logical size and initialized contents do not
+change.
+-}
+reserve ::
+  (HasCallStack, G.Vector v a, α >= β) =>
+  Int ->
+  Mut α (GrowableVector v a) %1 ->
+  BO β (Mut α (GrowableVector v a))
+{-# INLINE reserve #-}
+reserve requested vector
+  | requested < 0 =
+      error ("reserve: negative capacity " <> show requested) vector
+  | otherwise = Control.do
+      ((), vector) <-
+        withHeader
+          ( Unsafe.toLinear \(Header logicalSize buffer) -> Control.do
+              grown <- growTo logicalSize requested buffer
+              Control.pure ((), Header logicalSize grown)
+          )
+          vector
+      Control.pure vector
+
+{- | Ensure capacity for at least the current size plus the requested amount.
+
+The additional amount must be non-negative.
+-}
+reserveAdditional ::
+  (HasCallStack, G.Vector v a, α >= β) =>
+  Int ->
+  Mut α (GrowableVector v a) %1 ->
+  BO β (Mut α (GrowableVector v a))
+{-# INLINE reserveAdditional #-}
+reserveAdditional additional vector
+  | additional < 0 =
+      error
+        ("reserveAdditional: negative additional capacity " <> show additional)
+        vector
+  | otherwise = Control.do
+      ((), vector) <-
+        withHeader
+          ( Unsafe.toLinear \(Header logicalSize buffer) ->
+              let !required =
+                    checkedAdd "reserveAdditional" logicalSize additional
+               in Control.do
+                    grown <- growTo logicalSize required buffer
+                    Control.pure ((), Header logicalSize grown)
+          )
+          vector
+      Control.pure vector
+
+-- | Append one unrestricted element to the initialized prefix.
+push ::
+  (HasCallStack, G.Vector v a, α >= β) =>
+  a ->
+  Mut α (GrowableVector v a) %1 ->
+  BO β (Mut α (GrowableVector v a))
+{-# INLINE push #-}
+push value vector = Control.do
+  ((), vector) <-
+    withHeader
+      ( Unsafe.toLinear \(Header logicalSize buffer) ->
+          let !required = checkedAdd "push" logicalSize 1
+              !target = growthTarget (GM.length buffer) required
+           in Control.do
+                grown <- growTo logicalSize target buffer
+                grown <- writeAt logicalSize value grown
+                Control.pure ((), Header required grown)
+      )
+      vector
+  Control.pure vector
+
+-- | Append all elements of an immutable vector.
+extend ::
+  (HasCallStack, G.Vector v a, α >= β) =>
+  v a ->
+  Mut α (GrowableVector v a) %1 ->
+  BO β (Mut α (GrowableVector v a))
+{-# INLINE extend #-}
+extend source vector = Control.do
+  ((), vector) <-
+    withHeader
+      ( Unsafe.toLinear \(Header logicalSize buffer) ->
+          let !sourceSize = G.length source
+              !required = checkedAdd "extend" logicalSize sourceSize
+              !target = growthTarget (GM.length buffer) required
+           in Control.do
+                grown <- growTo logicalSize target buffer
+                grown <- copyImmutableInto source logicalSize grown
+                Control.pure ((), Header required grown)
+      )
+      vector
+  Control.pure vector
+
+copyImmutable ::
+  (G.Vector v a) =>
+  v a ->
+  Int ->
+  G.Mutable v RealWorld a ->
+  NonLinear.IO ()
+{-# INLINE copyImmutable #-}
+copyImmutable source offset target =
+  G.copy
+    (GM.unsafeSlice offset (G.length source) target)
+    source
+
+copyImmutableInto ::
+  (G.Vector v a) =>
+  v a ->
+  Int ->
+  G.Mutable v RealWorld a %1 ->
+  BO β (G.Mutable v RealWorld a)
+{-# INLINE copyImmutableInto #-}
+copyImmutableInto source offset =
+  Unsafe.toLinear \target -> unsafeSystemIOToBO do
+    copyImmutable source offset target
+    NonLinear.pure target
+
+writeAt ::
+  (G.Vector v a) =>
+  Int ->
+  a ->
+  G.Mutable v RealWorld a %1 ->
+  BO β (G.Mutable v RealWorld a)
+{-# INLINE writeAt #-}
+writeAt index value =
+  Unsafe.toLinear \target -> unsafeSystemIOToBO do
+    GM.unsafeWrite target index value
+    NonLinear.pure target
+
+growTo ::
+  (G.Vector v a) =>
+  Int ->
+  Int ->
+  G.Mutable v RealWorld a %1 ->
+  BO β (G.Mutable v RealWorld a)
+{-# INLINE growTo #-}
+growTo =
+  Unsafe.toLinear3 \logicalSize requested buffer ->
+    let !oldCapacity = GM.length buffer
+     in if requested <= oldCapacity
+          then Control.pure buffer
+          else unsafeSystemIOToBO do
+            grown <- GM.unsafeNew requested
+            GM.unsafeCopy
+              (GM.unsafeTake logicalSize grown)
+              (GM.unsafeTake logicalSize buffer)
+            NonLinear.pure grown
+
+growthTarget :: Int -> Int -> Int
+{-# INLINE growthTarget #-}
+growthTarget oldCapacity required
+  | required <= oldCapacity = oldCapacity
+  | oldCapacity <= 0 = required `max` 1
+  | oldCapacity > maxBound `quot` 2 = required
+  | otherwise = required `max` (oldCapacity * 2)
+
+checkedAdd :: (HasCallStack) => NonLinear.String -> Int -> Int -> Int
+{-# INLINE checkedAdd #-}
+checkedAdd operation left right
+  | right > maxBound - left =
+      error (operation <> ": capacity overflow")
+  | otherwise = left + right
+
+{- | Project a growable borrow to the fixed initialized prefix.
+
+The result preserves the borrow kind and lifetime and exposes neither spare
+capacity nor growth. A mutable result may be split with the fixed unrestricted
+vector API. The growable borrow becomes recoverable only after all resulting
+fixed borrows have ended.
+-}
+getContents ::
+  (G.Vector v a) =>
+  Borrow bk α (GrowableVector v a) %1 ->
+  Borrow bk α (Fixed.Vector v a)
+{-# INLINE getContents #-}
+getContents =
+  Unsafe.toLinear \(UnsafeAlias (GrowableVector ref)) ->
+    -- SAFETY: unsafeReadRef exposes the current header while returning the same
+    -- borrowed Ref handle. Discarding that returned handle does not free the
+    -- authoritative header retained by an enclosing lender. The input
+    -- growable occurrence is consumed by this projection and cannot be used
+    -- for reserve or growth. The result preserves its borrow kind and lifetime
+    -- and exposes exactly the initialized prefix, so mutable access cannot
+    -- coexist with growth and shared access remains read-only. The fixed safe
+    -- API can split this slice but cannot resize it, reveal spare capacity, or
+    -- consume/freeze the growable backing owner. Nominal backend and element
+    -- roles prevent selecting operations for a different representation.
+    case Ref.unsafeReadRef ref of
+      (Header logicalSize buffer, duplicateRef) ->
+        pop (aff duplicateRef) `lseq`
+          UnsafeAlias
+            (Fixed.Internal.unsafeFromMutableSlice 0 logicalSize buffer)
+
+{- | Borrow the fixed initialized prefix in a rank-2 no-growth scope.
+
+The callback receives one linear occurrence for either borrow kind. Shared
+callers may use 'move' to regain unrestricted use. A mutable growable borrow is
+restored only after the callback result is produced and the fixed view ends.
+-}
+withContent ::
+  (G.Vector v a) =>
+  Borrow bk α (GrowableVector v a) %1 ->
+  ( forall β.
+    Borrow bk (β /\ α) (Fixed.Vector v a) %1 ->
+    BO (β /\ α) result
+  ) %1 ->
+  BO α (result, Borrow bk α (GrowableVector v a))
+{-# INLINE withContent #-}
+withContent =
+  Unsafe.toLinear2 \vector action ->
+    -- SAFETY: the coercion changes only the phantom lifetime of this one
+    -- retained borrow occurrence. unsafeSrunBO_ chooses a fresh rigid
+    -- sublifetime and invokes action exactly once. Linearity keeps vector
+    -- inaccessible until action has consumed every fixed slice and returned;
+    -- the result type cannot mention the fresh lifetime. Only then is the
+    -- original growable occurrence restored. This is a normal-return
+    -- guarantee; the module promises no owner recovery after an exception.
+    unsafeSrunBO_ $
+      action (getContents (Unsafe.coerce vector))
+        Control.<&> \result -> (result, vector)
+
+-- | A result-discarding variant of 'withContent'.
+withContent_ ::
+  (G.Vector v a, Consumable result) =>
+  Borrow bk α (GrowableVector v a) %1 ->
+  ( forall β.
+    Borrow bk (β /\ α) (Fixed.Vector v a) %1 ->
+    BO (β /\ α) result
+  ) %1 ->
+  BO α (Borrow bk α (GrowableVector v a))
+{-# INLINE withContent_ #-}
+withContent_ vector action =
+  withContent vector action Control.<&> \(result, vector) ->
+    consume result `lseq` vector

--- a/src/Data/Vector/Generic/Mutable/Linear/Borrow/Experimental/Multiplicity.hs
+++ b/src/Data/Vector/Generic/Mutable/Linear/Borrow/Experimental/Multiplicity.hs
@@ -1,0 +1,58 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+{- |
+__Experimental.__ This API is unstable and may change without preserving
+compatibility.
+
+Linearly owned mutable vectors whose element ownership is selected by a
+multiplicity parameter.
+
+The public backend parameter @v@ selects any immutable backend supported by
+@vector@'s generic interface. The owner and its mutable backing remain linear.
+
+Custom backends are a trusted extensibility boundary: their mutable-vector
+operations must obey the usual @vector@ laws, including fresh allocation and
+cloning, exact indexing, disjoint non-overlapping splits, copying thaw, and
+alias-free ownership transfer through unsafe freeze/thaw. The standard boxed,
+unboxed, and primitive backends satisfy these requirements.
+-}
+module Data.Vector.Generic.Mutable.Linear.Borrow.Experimental.Multiplicity (
+  Vector,
+  KnownMultiplicity,
+  GetResult,
+  UpdateAction,
+  Bound,
+  PossiblyConsumable,
+  PossiblyMovable,
+  PossiblyCopyable,
+  empty,
+  constant,
+  fromList,
+  fromVector,
+  unsafeFromVector,
+  unsafeFromMutable,
+  toVector,
+  toList,
+  copyToVector,
+  size,
+  get,
+  unsafeGet,
+  head,
+  unsafeHead,
+  last,
+  unsafeLast,
+  copyAt,
+  copyAtMut,
+  set,
+  unsafeSet,
+  write,
+  unsafeWrite,
+  update,
+  unsafeUpdate,
+  modify,
+  swap,
+  unsafeSwap,
+  splitAt,
+) where
+
+import Data.Vector.Generic.Mutable.Linear.Borrow.Experimental.Multiplicity.Internal

--- a/src/Data/Vector/Generic/Mutable/Linear/Borrow/Experimental/Multiplicity/Internal.hs
+++ b/src/Data/Vector/Generic/Mutable/Linear/Borrow/Experimental/Multiplicity/Internal.hs
@@ -1,0 +1,710 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE QualifiedDo #-}
+{-# LANGUAGE RoleAnnotations #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeFamilyDependencies #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# OPTIONS_GHC -Wno-name-shadowing #-}
+{-# OPTIONS_GHC -Wno-redundant-constraints #-}
+{-# OPTIONS_HADDOCK hide #-}
+
+module Data.Vector.Generic.Mutable.Linear.Borrow.Experimental.Multiplicity.Internal (
+  module Data.Vector.Generic.Mutable.Linear.Borrow.Experimental.Multiplicity.Internal,
+) where
+
+import Control.Functor.Linear qualified as Control
+import Control.Monad.Borrow.Pure.BO
+import Control.Monad.Borrow.Pure.BO.Unsafe
+import Control.Monad.Borrow.Pure.Clone
+import Control.Monad.Borrow.Pure.Copyable
+import Control.Monad.Borrow.Pure.Lifetime.Token.Unsafe (
+  LinearOnly (..),
+  LinearOnlyWitness (..),
+ )
+import Data.Kind (Constraint, Type)
+import Data.Vector.Generic qualified as G
+import Data.Vector.Generic.Mutable qualified as GM
+import Data.Vector.Mutable (RealWorld)
+import GHC.Exts (Multiplicity (..))
+import GHC.Exts qualified as GHC
+import GHC.IO (unsafePerformIO)
+import GHC.Stack (HasCallStack)
+import GHC.TypeError
+import Prelude.Linear hiding (head, last, splitAt)
+import Unsafe.Linear qualified as Unsafe
+import Prelude qualified as NonLinear
+
+-- | Linearly owned mutable vector with mode-indexed element ownership.
+type Vector :: GHC.Multiplicity -> (Type -> Type) -> Type -> Type
+newtype Vector p v a = Vector {content :: G.Mutable v RealWorld a}
+
+-- | Linear mutable vector, owning the elements exclusively.
+type OwningVector = Vector One
+
+-- | Linear mutable vector, but the elements are bound unrestricted.
+type UrVector = Vector Many
+
+type role Vector nominal nominal nominal
+
+-- | A linearly owned result for 'One', or a GC-owned result for 'Many'.
+type Bound :: Multiplicity -> Type -> Type
+type family Bound p a = result where
+  Bound One a = a
+  Bound Many a = Ur a
+
+-- | 'Consumable' when the multiplicity is 'One', and always satisfied when the multiplicity is 'Many'.
+type PossiblyConsumable :: Multiplicity -> Type -> Constraint
+type family PossiblyConsumable p a where
+  PossiblyConsumable One a = (Consumable a)
+  PossiblyConsumable Many a = ()
+
+-- | 'Movable' when the multiplicity is 'One', and always satisfied when the multiplicity is 'Many'.
+type PossiblyMovable :: Multiplicity -> Type -> Constraint
+type family PossiblyMovable p a where
+  PossiblyMovable One a = (Movable a)
+  PossiblyMovable Many a = ()
+
+-- | 'Copyable' when the multiplicity is 'One', and always satisfied when the multiplicity is 'Many'.
+type PossiblyCopyable :: Multiplicity -> Type -> Constraint
+type family PossiblyCopyable p a where
+  PossiblyCopyable One a = (Copyable a)
+  PossiblyCopyable Many a = ()
+
+-- | Result of reading an element while respecting the vector's element ownership.
+type GetResult :: Multiplicity -> BorrowKind -> Lifetime -> (Type -> Type) -> Type -> Type
+type family GetResult p bk α v a where
+  GetResult One bk α v a = Borrow bk α a
+  GetResult Many bk α v a =
+    (Ur a, Borrow bk α (Vector Many v a))
+
+-- | Mode-indexed element update callback.
+type UpdateAction :: Multiplicity -> Lifetime -> Type -> Type -> Type
+type UpdateAction p β result a =
+  a %p -> BO β (Bound p result, Bound p a)
+
+-- | Construct a fixed-size view over a raw mutable-vector slice.
+unsafeFromMutableSlice ::
+  (G.Vector v a) =>
+  Int ->
+  Int ->
+  G.Mutable v RealWorld a %1 ->
+  Vector p v a
+{-# INLINE unsafeFromMutableSlice #-}
+unsafeFromMutableSlice offset length_ =
+  Unsafe.toLinear \buffer ->
+    Vector (GM.unsafeSlice offset length_ buffer)
+
+instance LinearOnly (Vector p v a) where
+  linearOnly = UnsafeLinearOnly
+  {-# INLINE linearOnly #-}
+
+instance
+  (Unsatisfiable (ShowType (Vector p v a) :<>: Text " cannot be copied!")) =>
+  Copyable (Vector p v a)
+  where
+  copy = unsatisfiable
+
+instance (G.Vector v a) => Consumable (Vector Many v a) where
+  consume = Unsafe.toLinear \_ -> ()
+  {-# INLINE consume #-}
+
+instance (G.Vector v a, Consumable a) => Consumable (Vector One v a) where
+  consume =
+    Unsafe.toLinear \(Vector vector) ->
+      unsafePerformIO (consumeElements 0 (GM.length vector) vector)
+  -- Only the 'One' instance releases elements, and it does so under
+  -- 'unsafePerformIO'. Inlining would let GHC duplicate that call across use
+  -- sites, or float it out of a scope, and each copy would consume the
+  -- elements again; 'NOINLINE' keeps exactly one occurrence. The 'Many'
+  -- instance above owns nothing and stays 'INLINE'.
+  {-# NOINLINE consume #-}
+
+consumeElements ::
+  (G.Vector v a, Consumable a) =>
+  Int ->
+  Int ->
+  G.Mutable v RealWorld a ->
+  IO ()
+{-# INLINE consumeElements #-}
+consumeElements !index !length_ vector
+  | index >= length_ = NonLinear.pure ()
+  | otherwise = do
+      value <- GM.unsafeRead vector index
+      let !() = consume value
+      consumeElements (index + 1) length_ vector
+
+instance (G.Vector v a) => Clone (Vector Many v a) where
+  clone = Unsafe.toLinear \(UnsafeAlias (Vector vector)) ->
+    Vector Control.<$> unsafeSystemIOToBO (GM.clone vector)
+  {-# INLINE clone #-}
+
+instance (G.Vector v a, Dupable a) => Clone (Vector One v a) where
+  clone = Unsafe.toLinear \(UnsafeAlias (Vector source)) ->
+    Vector Control.<$> unsafeSystemIOToBO do
+      let !length_ = GM.length source
+      target <- GM.unsafeNew length_
+      let go !index
+            | index >= length_ = NonLinear.pure ()
+            | otherwise = do
+                value <- GM.unsafeRead source index
+                let (!_, !clonedValue) = dup value
+                GM.unsafeWrite target index clonedValue
+                go (index + 1)
+      go 0
+      NonLinear.pure target
+  {-# INLINE clone #-}
+
+-- | \(O(1)\). Construct an empty vector.
+empty :: (G.Vector v a) => Linearly %1 -> Vector p v a
+{-# NOINLINE empty #-}
+empty =
+  GHC.noinline \linear ->
+    linear `lseq` Vector (unsafePerformIO (GM.unsafeNew 0))
+
+{- | \(O(n)\). Construct a vector containing @count@ copies of a value.
+
+As in @vector@, a negative count produces an empty vector.
+-}
+constant ::
+  (G.Vector v a) =>
+  Int ->
+  a ->
+  Linearly %1 ->
+  Vector Many v a
+{-# NOINLINE constant #-}
+constant =
+  GHC.noinline \count value linear ->
+    linear `lseq` Vector (unsafePerformIO (GM.replicate count value))
+
+-- | \(O(n)\). Materialize a list whose binding multiplicity matches the mode.
+fromList ::
+  (G.Vector v a) =>
+  [a] %p ->
+  Linearly %1 ->
+  Vector p v a
+{-# NOINLINE fromList #-}
+fromList =
+  GHC.noinline $ Unsafe.toLinear \values linear ->
+    linear `lseq`
+      Vector
+        (unsafePerformIO (G.thaw (G.fromList values)))
+
+-- | \(O(n)\). Copy an immutable vector into a new owner.
+fromVector ::
+  (G.Vector v a) =>
+  v a ->
+  Linearly %1 ->
+  Vector Many v a
+{-# NOINLINE fromVector #-}
+fromVector =
+  GHC.noinline \source linear ->
+    linear `lseq` Vector (unsafePerformIO (G.thaw source))
+
+{- | \(O(1)\). Unsafely take ownership of an immutable vector.
+
+The caller must ensure that no alias of the source vector, including an
+overlapping slice, is ever observed again.
+-}
+unsafeFromVector ::
+  (G.Vector v a) =>
+  v a %1 ->
+  Linearly %1 ->
+  Vector p v a
+{-# NOINLINE unsafeFromVector #-}
+unsafeFromVector =
+  GHC.noinline $
+    Unsafe.toLinear \source linear ->
+      linear `lseq` Vector (unsafePerformIO (G.unsafeThaw source))
+
+{- | \(O(1)\). Unsafely take ownership of a mutable vector.
+
+The caller must not retain any alias or overlapping slice of the input. The
+entire adopted slice must be initialized.
+-}
+unsafeFromMutable ::
+  (G.Vector v a) =>
+  G.Mutable v state a %1 ->
+  Linearly %1 ->
+  Vector p v a
+{-# INLINE unsafeFromMutable #-}
+unsafeFromMutable =
+  Unsafe.toLinear \source linear ->
+    linear `lseq` Vector (Unsafe.coerce source)
+
+type KnownMultiplicity :: Multiplicity -> Constraint
+
+-- | Internal evidence selecting the ownership-sensitive implementation.
+class KnownMultiplicity p where
+  mMove :: a %1 -> Bound p a
+
+  -- | \(O(1)\). Consume the owner and freeze its backing storage.
+  toVector :: (G.Vector v a, PossiblyMovable p a) => Vector p v a %1 -> Ur (v a)
+
+  mCopy :: forall a. (PossiblyCopyable p a) => a -> Bound p a
+
+  mUnbind :: Bound p a %1 -> a
+
+  copyVector ::
+    (G.Vector v a, PossiblyCopyable p a) =>
+    v a ->
+    Ur (v a)
+
+  mUnsafeWrite ::
+    forall v a α β.
+    (G.Vector v a, α >= β, PossiblyConsumable p a) =>
+    Int ->
+    a %p ->
+    Mut α (Vector p v a) %1 ->
+    BO β (Mut α (Vector p v a))
+
+  mUnsafeGet ::
+    forall bk α β v a.
+    (G.Vector v a, α >= β) =>
+    Int ->
+    Borrow bk α (Vector p v a) %1 ->
+    BO β (GetResult p bk α v a)
+
+instance KnownMultiplicity Many where
+  {-# SPECIALIZE instance KnownMultiplicity Many #-}
+  mMove = Unsafe.toLinear Ur
+  {-# INLINE mMove #-}
+
+  toVector = Unsafe.toLinear \v -> Ur $ unsafeToVector v
+  {-# INLINE toVector #-}
+
+  mCopy = Unsafe.toLinear Ur
+  {-# INLINE mCopy #-}
+
+  mUnbind = \(Ur value) -> value
+  {-# INLINE mUnbind #-}
+
+  copyVector = Unsafe.toLinear Ur
+  {-# INLINE copyVector #-}
+
+  mUnsafeWrite =
+    Unsafe.toLinear3 \index value array@(UnsafeAlias (Vector vector)) ->
+      unsafeSystemIOToBO do
+        GM.unsafeWrite vector index value
+        NonLinear.pure array
+  {-# INLINE mUnsafeWrite #-}
+
+  mUnsafeGet index =
+    Unsafe.toLinear \vectorBorrow@(UnsafeAlias (Vector vector)) ->
+      unsafeSystemIOToBO do
+        value <- GM.unsafeRead vector index
+        NonLinear.pure (Ur value, vectorBorrow)
+  {-# INLINE mUnsafeGet #-}
+
+instance KnownMultiplicity One where
+  {-# SPECIALIZE instance KnownMultiplicity One #-}
+  mMove = id
+  {-# INLINE mMove #-}
+  toVector = Unsafe.toLinear \(v :: Vector One v a) ->
+    G.mapM (Unsafe.toLinear move) (unsafeToVector v)
+  {-# INLINE toVector #-}
+
+  mCopy = \value -> copy (UnsafeAlias value)
+  {-# INLINE mCopy #-}
+
+  mUnbind = id
+  {-# INLINE mUnbind #-}
+
+  copyVector =
+    G.mapM \value ->
+      Ur $! copy (UnsafeAlias value)
+  {-# INLINE copyVector #-}
+
+  mUnsafeWrite =
+    Unsafe.toLinear3 \index value array@(UnsafeAlias (Vector vector)) ->
+      unsafeSystemIOToBO do
+        oldValue <- GM.unsafeExchange vector index value
+        let !() = consume oldValue
+        NonLinear.pure array
+  {-# INLINE mUnsafeWrite #-}
+
+  mUnsafeGet index =
+    Unsafe.toLinear \(UnsafeAlias (Vector vector)) ->
+      UnsafeAlias Control.<$> unsafeSystemIOToBO (GM.unsafeRead vector index)
+  {-# INLINE mUnsafeGet #-}
+
+unsafeToVector ::
+  (G.Vector v a) =>
+  Vector p v a %1 ->
+  v a
+{-# NOINLINE unsafeToVector #-}
+unsafeToVector =
+  GHC.noinline $
+    Unsafe.toLinear \(Vector vector) ->
+      unsafePerformIO (G.unsafeFreeze vector)
+
+unsafeToList :: (G.Vector v a) => Vector p v a %1 -> [a]
+{-# NOINLINE unsafeToList #-}
+unsafeToList = GHC.noinline $
+  Unsafe.toLinear \(Vector vector) ->
+    G.toList $! unsafePerformIO (G.unsafeFreeze vector)
+
+-- | \(O(n)\). Consume the owner and materialize its elements as a list.
+toList :: (KnownMultiplicity p, G.Vector v a) => Vector p v a %1 -> Bound p [a]
+{-# INLINE toList #-}
+{-# SPECIALIZE INLINE toList :: (G.Vector v a) => Vector Many v a %1 -> Ur [a] #-}
+{-# SPECIALIZE INLINE toList :: (G.Vector v a) => Vector One v a %1 -> [a] #-}
+toList (v :: Vector p v a) = mMove @p (unsafeToList v)
+
+{- | \(O(n)\). Copy a live vector into an immutable vector and thread its
+borrow.
+-}
+copyToVector ::
+  ( G.Vector v a
+  , α >= β
+  , KnownMultiplicity p
+  , PossiblyCopyable p a
+  ) =>
+  Borrow bk α (Vector p v a) %1 ->
+  BO β (Ur (v a), Borrow bk α (Vector p v a))
+{-# INLINE copyToVector #-}
+copyToVector =
+  Unsafe.toLinear \vectorBorrow@(UnsafeAlias (Vector vector) :: Borrow bk α (Vector p v a)) ->
+    unsafeSystemIOToBO do
+      snapshot <- G.freeze vector
+      case copyVector @p snapshot of
+        Ur !copied -> NonLinear.pure (Ur copied, vectorBorrow)
+
+-- | \(O(1)\). Return the number of elements and thread the vector borrow.
+size ::
+  (G.Vector v a) =>
+  Borrow bk α (Vector p v a) %1 ->
+  (Ur Int, Borrow bk α (Vector p v a))
+{-# INLINE size #-}
+size =
+  Unsafe.toLinear \vectorBorrow@(UnsafeAlias (Vector vector)) ->
+    (Ur (GM.length vector), vectorBorrow)
+
+-- | Read the element at an index and thread the vector borrow.
+get ::
+  (HasCallStack, G.Vector v a, α >= β, KnownMultiplicity p) =>
+  Int ->
+  Borrow bk α (Vector p v a) %1 ->
+  BO β (GetResult p bk α v a)
+{-# INLINE get #-}
+get index vector =
+  case size vector of
+    (Ur length_, vector)
+      | index < 0 || index >= length_ ->
+          error
+            ( "get: index "
+                <> show index
+                <> " out of bounds for length "
+                <> show length_
+            )
+            vector
+      | otherwise -> unsafeGet index vector
+
+-- | Unchecked 'get'. The index must satisfy @0 <= index < size@.
+unsafeGet ::
+  forall p v a α β bk.
+  (G.Vector v a, α >= β, KnownMultiplicity p) =>
+  Int ->
+  Borrow bk α (Vector p v a) %1 ->
+  BO β (GetResult p bk α v a)
+{-# INLINE unsafeGet #-}
+unsafeGet = mUnsafeGet @p
+
+-- | Read the first element and thread the vector borrow.
+head ::
+  (HasCallStack, G.Vector v a, α >= β, KnownMultiplicity p) =>
+  Borrow bk α (Vector p v a) %1 ->
+  BO β (GetResult p bk α v a)
+{-# INLINE head #-}
+head = get 0
+
+-- | Unchecked 'head'. The vector must be non-empty.
+unsafeHead ::
+  (G.Vector v a, α >= β, KnownMultiplicity p) =>
+  Borrow bk α (Vector p v a) %1 ->
+  BO β (GetResult p bk α v a)
+{-# INLINE unsafeHead #-}
+unsafeHead = unsafeGet 0
+
+-- | Read the last element and thread the vector borrow.
+last ::
+  (HasCallStack, G.Vector v a, α >= β, KnownMultiplicity p) =>
+  Borrow bk α (Vector p v a) %1 ->
+  BO β (GetResult p bk α v a)
+{-# INLINE last #-}
+last vector =
+  case size vector of
+    (Ur length_, vector)
+      | length_ <= 0 -> error "last: empty vector" vector
+      | otherwise -> unsafeGet (length_ - 1) vector
+
+-- | Unchecked 'last'. The vector must be non-empty.
+unsafeLast ::
+  (G.Vector v a, α >= β, KnownMultiplicity p) =>
+  Borrow bk α (Vector p v a) %1 ->
+  BO β (GetResult p bk α v a)
+{-# INLINE unsafeLast #-}
+unsafeLast vector =
+  case size vector of
+    (Ur length_, vector) -> unsafeGet (length_ - 1) vector
+
+-- | Read an element through a shared borrow.
+copyAt ::
+  ( HasCallStack
+  , G.Vector v a
+  , α >= β
+  , KnownMultiplicity p
+  , PossiblyCopyable p a
+  ) =>
+  Int ->
+  Share α (Vector p v a) ->
+  BO β (Bound p a)
+{-# INLINE copyAt #-}
+copyAt =
+  Unsafe.toLinear2 \index vector@(UnsafeAlias (Vector buffer) :: Share α (Vector p v a)) ->
+    let !length_ = GM.length buffer
+     in if index < 0 || index >= length_
+          then
+            error
+              ( "get: index "
+                  <> show index
+                  <> " out of bounds for length "
+                  <> show length_
+              )
+              vector
+          else unsafeSystemIOToBO do
+            !value <- GM.unsafeRead buffer index
+            let !copied = mCopy @p value
+            NonLinear.pure copied
+
+-- | Read an element and retain the mutable vector borrow.
+copyAtMut ::
+  ( HasCallStack
+  , G.Vector v a
+  , α >= β
+  , KnownMultiplicity p
+  , PossiblyCopyable p a
+  ) =>
+  Int ->
+  Mut α (Vector p v a) %1 ->
+  BO β (Bound p a, Mut α (Vector p v a))
+{-# INLINE copyAtMut #-}
+copyAtMut = Unsafe.toLinear2 \i mut@(UnsafeAlias (Vector v) :: Mut α (Vector p v a)) ->
+  let !len = GM.length v
+   in if i < 0 || i >= len
+        then error ("get: index " <> show i <> " out of bound: " <> show len) mut
+        else unsafeSystemIOToBO do
+          !a <- GM.unsafeRead v i
+          let !copied = mCopy @p a
+          NonLinear.pure (copied, mut)
+
+-- | Replace an element and return the displaced value.
+set ::
+  (HasCallStack, G.Vector v a, α >= β, KnownMultiplicity p) =>
+  Int ->
+  a %p ->
+  Mut α (Vector p v a) %1 ->
+  BO β (Bound p a, Mut α (Vector p v a))
+{-# INLINE set #-}
+set index value array =
+  case size array of
+    (Ur length_, array)
+      | index < 0 || index >= length_ ->
+          error
+            ( "set: index "
+                <> show index
+                <> " out of bounds for length "
+                <> show length_
+            )
+            array
+            value
+      | otherwise -> unsafeSet index value array
+
+-- | Unchecked 'set'. The index must satisfy @0 <= index < size@.
+unsafeSet ::
+  forall p v a α β.
+  (G.Vector v a, α >= β, KnownMultiplicity p) =>
+  Int ->
+  a %p ->
+  Mut α (Vector p v a) %1 ->
+  BO β (Bound p a, Mut α (Vector p v a))
+{-# INLINE unsafeSet #-}
+unsafeSet =
+  Unsafe.toLinear3 \index !value array@(UnsafeAlias (Vector vector) :: Mut α (Vector p v a)) ->
+    unsafeSystemIOToBO do
+      oldValue <- GM.unsafeExchange vector index value
+      NonLinear.pure (mMove @p oldValue, array)
+
+-- | Replace an element and consume the displaced value.
+write ::
+  ( HasCallStack
+  , G.Vector v a
+  , α >= β
+  , KnownMultiplicity p
+  , PossiblyConsumable p a
+  ) =>
+  Int ->
+  a %p ->
+  Mut α (Vector p v a) %1 ->
+  BO β (Mut α (Vector p v a))
+{-# INLINE write #-}
+write index value array =
+  case size array of
+    (Ur length_, array)
+      | index < 0 || index >= length_ ->
+          error
+            ( "write: index "
+                <> show index
+                <> " out of bounds for length "
+                <> show length_
+            )
+            array
+            value
+      | otherwise -> unsafeWrite index value array
+
+-- | Unchecked 'write'. The index must satisfy @0 <= index < size@.
+unsafeWrite ::
+  forall p v a α β.
+  ( G.Vector v a
+  , α >= β
+  , KnownMultiplicity p
+  , PossiblyConsumable p a
+  ) =>
+  Int ->
+  a %p ->
+  Mut α (Vector p v a) %1 ->
+  BO β (Mut α (Vector p v a))
+{-# INLINE unsafeWrite #-}
+unsafeWrite = mUnsafeWrite @p
+
+{- | Transform an element and return an auxiliary result.
+
+For an owning vector, the callback and element are linear. For an unrestricted
+vector, both are unrestricted and the callback returns 'Ur'-wrapped results.
+The mutable vector borrow is unavailable until the replacement has been
+written. This is a normal-return guarantee; no owner recovery is promised
+after an exception.
+-}
+update ::
+  forall p v a α β result.
+  (HasCallStack, G.Vector v a, α >= β, KnownMultiplicity p) =>
+  Int ->
+  UpdateAction p β result a %p ->
+  Mut α (Vector p v a) %1 ->
+  BO β (Bound p result, Mut α (Vector p v a))
+{-# INLINE update #-}
+update index action array =
+  case size array of
+    (Ur length_, array)
+      | index < 0 || index >= length_ ->
+          error
+            ( "update: index "
+                <> show index
+                <> " out of bounds for length "
+                <> show length_
+            )
+            array
+            action
+      | otherwise ->
+          unsafeUpdate @p @v @a @α @β @result index action array
+
+{- | Unchecked 'update'. The index must satisfy @0 <= index < size@.
+
+The ownership guarantees are the same as for 'update'.
+-}
+unsafeUpdate ::
+  forall p v a α β result.
+  (G.Vector v a, α >= β, KnownMultiplicity p) =>
+  Int ->
+  UpdateAction p β result a %p ->
+  Mut α (Vector p v a) %1 ->
+  BO β (Bound p result, Mut α (Vector p v a))
+{-# INLINE unsafeUpdate #-}
+unsafeUpdate index action =
+  Unsafe.toLinear \(UnsafeAlias array@(Vector vector)) -> Control.do
+    value <- unsafeSystemIOToBO (GM.unsafeRead vector index)
+    (result, updatedValue) <- Unsafe.toLinear action value
+    let !unboundValue = mUnbind @p updatedValue
+    () <-
+      unsafeSystemIOToBO
+        (Unsafe.toLinear3 GM.unsafeWrite vector index unboundValue)
+    Control.pure (result, UnsafeAlias array)
+
+-- | Transform an element.
+modify ::
+  forall p v a α β.
+  (HasCallStack, G.Vector v a, α >= β, KnownMultiplicity p) =>
+  Int ->
+  (a %p -> a) %p ->
+  Mut α (Vector p v a) %1 ->
+  BO β (Mut α (Vector p v a))
+{-# INLINE modify #-}
+modify index function array = Control.do
+  (unit, array) <-
+    update @p @v @a @α @β @()
+      index
+      ( Unsafe.toLinear \value ->
+          Control.pure
+            ( mMove @p ()
+            , mMove @p (Unsafe.toLinear function value)
+            )
+      )
+      array
+  case mUnbind @p unit of
+    () -> Control.pure array
+
+-- | Swap two elements.
+swap ::
+  (HasCallStack, G.Vector v a, α >= β) =>
+  Mut α (Vector p v a) %1 ->
+  Int ->
+  Int ->
+  BO β (Mut α (Vector p v a))
+{-# INLINE swap #-}
+swap array first second =
+  case size array of
+    (Ur length_, array)
+      | first < 0 || first >= length_ || second < 0 || second >= length_ ->
+          error
+            ( "swap: indices "
+                <> show (first, second)
+                <> " out of bounds for length "
+                <> show length_
+            )
+            array
+      | otherwise -> unsafeSwap array first second
+
+-- | Unchecked 'swap'. Both indices must satisfy @0 <= index < size@.
+unsafeSwap ::
+  (G.Vector v a, α >= β) =>
+  Mut α (Vector p v a) %1 ->
+  Int ->
+  Int ->
+  BO β (Mut α (Vector p v a))
+{-# INLINE unsafeSwap #-}
+unsafeSwap =
+  Unsafe.toLinear \array@(UnsafeAlias (Vector vector)) first second ->
+    unsafeSystemIOToBO do
+      GM.unsafeSwap vector first second
+      NonLinear.pure array
+
+{- | Split a borrow into two disjoint fixed ranges without copying.
+
+The index is clamped to @[0, size]@, matching @vector@'s 'GM.splitAt'.
+For a custom backend, safety requires its two returned slices not to overlap.
+-}
+splitAt ::
+  (G.Vector v a) =>
+  Int ->
+  Borrow bk α (Vector p v a) %1 ->
+  ( Borrow bk α (Vector p v a)
+  , Borrow bk α (Vector p v a)
+  )
+{-# INLINE splitAt #-}
+splitAt index =
+  Unsafe.toLinear \(UnsafeAlias (Vector vector)) ->
+    case GM.splitAt index vector of
+      (left, right) ->
+        (UnsafeAlias (Vector left), UnsafeAlias (Vector right))

--- a/test-inspection/Main.hs
+++ b/test-inspection/Main.hs
@@ -1,6 +1,7 @@
 module Main (main) where
 
 import PureBorrow.Inspection.Fft qualified as Fft
+import PureBorrow.Inspection.GenericGrowableUnrestricted qualified as GenericGrowableUnrestricted
 import PureBorrow.Inspection.QSort qualified as QSort
 import Test.Tasty (defaultMain, testGroup)
 
@@ -10,5 +11,6 @@ main =
     testGroup
       "optimized Core"
       [ Fft.tests
+      , GenericGrowableUnrestricted.tests
       , QSort.tests
       ]

--- a/test-inspection/PureBorrow/Inspection/GenericGrowableUnrestricted.hs
+++ b/test-inspection/PureBorrow/Inspection/GenericGrowableUnrestricted.hs
@@ -1,0 +1,68 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# OPTIONS_GHC -O2 #-}
+
+module PureBorrow.Inspection.GenericGrowableUnrestricted (
+  tests,
+  boxedPush,
+  unboxedPush,
+) where
+
+import Control.Monad.Borrow.Pure.BO (BO, Mut)
+import Data.Vector qualified as Boxed
+import Data.Vector.Generic.Mutable.Growable.Linear.Borrow.Unrestricted qualified as Growable
+import Data.Vector.Mutable qualified as BoxedMutable
+import Data.Vector.Unboxed qualified as Unboxed
+import GHC.Base (IP)
+import Prelude.Linear
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.Inspection
+
+boxedPush ::
+  Int ->
+  Mut α (Growable.GrowableVector Boxed.Vector Int) %1 ->
+  BO α (Mut α (Growable.GrowableVector Boxed.Vector Int))
+{-# NOINLINE boxedPush #-}
+boxedPush = Growable.push
+
+unboxedPush ::
+  Int ->
+  Mut α (Growable.GrowableVector Unboxed.Vector Int) %1 ->
+  BO α (Mut α (Growable.GrowableVector Unboxed.Vector Int))
+{-# NOINLINE unboxedPush #-}
+unboxedPush = Growable.push
+
+tests :: TestTree
+tests =
+  testGroup
+    "generic growable unrestricted vector"
+    [ $( inspectTest
+           ( (hasNoTypeClassesExcept 'boxedPush [''IP])
+               { testName =
+                   Just "boxed push retains only CallStack dictionaries"
+               }
+           )
+       )
+    , $( inspectTest
+           ( (hasNoTypeClassesExcept 'unboxedPush [''IP])
+               { testName =
+                   Just "unboxed push retains only CallStack dictionaries"
+               }
+           )
+       )
+    , $( inspectTest
+           ( (hasNoType 'boxedPush ''Unboxed.MVector)
+               { testName =
+                   Just "boxed push has no unboxed backing"
+               }
+           )
+       )
+    , $( inspectTest
+           ( (hasNoType 'unboxedPush ''BoxedMutable.MVector)
+               { testName =
+                   Just "unboxed push has no boxed backing"
+               }
+           )
+       )
+    ]

--- a/test/Data/Vector/Generic/Mutable/Growable/Linear/Borrow/Unrestricted/TypingCases.hs
+++ b/test/Data/Vector/Generic/Mutable/Growable/Linear/Borrow/Unrestricted/TypingCases.hs
@@ -1,0 +1,229 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE ImpredicativeTypes #-}
+{-# LANGUAGE QualifiedDo #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# OPTIONS_GHC -O0 #-}
+{-# OPTIONS_GHC -Wno-name-shadowing #-}
+{-# OPTIONS_GHC -fdefer-type-errors -Wno-deferred-type-errors #-}
+
+module Data.Vector.Generic.Mutable.Growable.Linear.Borrow.Unrestricted.TypingCases (
+  module Data.Vector.Generic.Mutable.Growable.Linear.Borrow.Unrestricted.TypingCases,
+) where
+
+import Control.Functor.Linear qualified as Control
+import Control.Monad.Borrow.Pure.BO
+import Control.Monad.Borrow.Pure.Copyable (Copyable (copy))
+import Control.Syntax.DataFlow qualified as DataFlow
+import Data.Coerce (coerce)
+import Data.Vector qualified as V
+import Data.Vector.Generic.Mutable.Growable.Linear.Borrow.Unrestricted qualified as Growable
+import Data.Vector.Generic.Mutable.Linear.Borrow.Unrestricted qualified as Fixed
+import Data.Vector.Mutable.Growable.Linear.Borrow qualified as Owning
+import Prelude.Linear
+import Unsafe.Linear qualified as Unsafe
+import Prelude qualified as NonLinear
+
+newtype WrappedInt = WrappedInt Int
+
+newtype WrappedBackend a = WrappedBackend (V.Vector a)
+
+badBackendCoercion ::
+  Growable.GrowableVector V.Vector Int %1 ->
+  Growable.GrowableVector WrappedBackend Int
+badBackendCoercion = Unsafe.toLinear coerce
+
+badElementCoercion ::
+  Growable.GrowableVector V.Vector WrappedInt %1 ->
+  Growable.GrowableVector V.Vector Int
+badElementCoercion = Unsafe.toLinear coerce
+
+badOwnershipCoercion ::
+  Growable.GrowableVector V.Vector Int %1 ->
+  Owning.GrowableVector Int
+badOwnershipCoercion = Unsafe.toLinear coerce
+
+badGrowableToFixed ::
+  Growable.GrowableVector V.Vector Int %1 ->
+  Fixed.Vector V.Vector Int
+badGrowableToFixed = Unsafe.toLinear coerce
+
+badFixedToGrowable ::
+  Fixed.Vector V.Vector Int %1 ->
+  Growable.GrowableVector V.Vector Int
+badFixedToGrowable = Unsafe.toLinear coerce
+
+badGrowableToFixedUpcast ::
+  Growable.GrowableVector V.Vector Int %1 ->
+  Fixed.Vector V.Vector Int
+badGrowableToFixedUpcast = upcast
+
+badFixedToGrowableUpcast ::
+  Fixed.Vector V.Vector Int %1 ->
+  Growable.GrowableVector V.Vector Int
+badFixedToGrowableUpcast = upcast
+
+badLifetimeSwap ::
+  forall α β.
+  Mut α (Growable.GrowableVector V.Vector Int) %1 ->
+  Mut β (Growable.GrowableVector V.Vector Int)
+{-# NOINLINE badLifetimeSwap #-}
+badLifetimeSwap =
+  Unsafe.toLinear
+    ( coerce ::
+        Mut α (Growable.GrowableVector V.Vector Int) ->
+        Mut β (Growable.GrowableVector V.Vector Int)
+    )
+
+badLifetimeSwapCase :: Int
+badLifetimeSwapCase =
+  linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <-
+        borrowM (Growable.empty @V.Vector @Int ownerLinear)
+      let !() = consume (badLifetimeSwap vector)
+      pureAfter
+        ( case Growable.toVector (reclaim lend) of
+            Ur frozen -> V.length frozen
+        )
+
+badSplit ::
+  Mut α (Growable.GrowableVector V.Vector Int) %1 ->
+  Growable.GrowableVector V.Vector (Mut α Int)
+badSplit = split
+
+badOwnerToContentCoercion ::
+  Mut α (Growable.GrowableVector V.Vector Int) %1 ->
+  Mut α (Fixed.Vector V.Vector Int)
+badOwnerToContentCoercion = Unsafe.toLinear coerce
+
+badElementBorrow ::
+  Mut α (Growable.GrowableVector V.Vector Int) %1 ->
+  BO α (Mut α Int)
+badElementBorrow = Growable.get 0
+
+badDuplicate ::
+  Borrow bk α (Growable.GrowableVector V.Vector Int) %1 ->
+  Growable.GrowableVector V.Vector Int
+badDuplicate = copy
+
+badMutateShared ::
+  Share α (Growable.GrowableVector V.Vector Int) ->
+  BO α (Share α (Growable.GrowableVector V.Vector Int))
+badMutateShared =
+  Growable.modify 0 (\value -> value NonLinear.+ 1)
+
+badGrowShared ::
+  Share α (Growable.GrowableVector V.Vector Int) ->
+  BO α (Share α (Growable.GrowableVector V.Vector Int))
+badGrowShared = Growable.reserve 10
+
+badElementCoercionCase :: Int
+badElementCoercionCase =
+  linearly \linear ->
+    case Growable.toVector
+      ( badElementCoercion
+          (Growable.fromList @V.Vector [WrappedInt 1] linear)
+      ) of
+      Ur vector -> V.length vector
+
+badOwnershipCoercionCase :: Int
+badOwnershipCoercionCase =
+  linearly \linear ->
+    case Owning.toVector
+      (badOwnershipCoercion (Growable.fromList @V.Vector [1] linear)) of
+      Ur vector -> V.length vector
+
+badElementBorrowCase :: Int
+badElementBorrowCase =
+  linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <-
+        borrowM (Growable.fromList @V.Vector [1] ownerLinear)
+      element <- badElementBorrow vector
+      let !() = consume element
+      pureAfter
+        ( case Growable.toVector (reclaim lend) of
+            Ur frozen -> V.length frozen
+        )
+
+badMutateSharedCase :: Int
+badMutateSharedCase =
+  linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <-
+        borrowM (Growable.fromList @V.Vector [1] ownerLinear)
+      vector <-
+        sharing_ vector \shared -> Control.do
+          shared <- badMutateShared shared
+          Control.pure (consume shared)
+      let !() = consume vector
+      pureAfter
+        ( case Growable.toVector (reclaim lend) of
+            Ur frozen -> V.length frozen
+        )
+
+badGrowSharedCase :: Int
+badGrowSharedCase =
+  linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <-
+        borrowM (Growable.fromList @V.Vector [1] ownerLinear)
+      vector <-
+        sharing_ vector \shared -> Control.do
+          shared <- badGrowShared shared
+          Control.pure (consume shared)
+      let !() = consume vector
+      pureAfter
+        ( case Growable.toVector (reclaim lend) of
+            Ur frozen -> V.length frozen
+        )
+
+badContentEscapeCase :: Int
+badContentEscapeCase =
+  linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <-
+        borrowM (Growable.empty @V.Vector @Int ownerLinear)
+      (escaped, vector) <- Growable.withContent vector Control.pure
+      let
+        !() = consume escaped
+        !() = consume vector
+      pureAfter
+        ( case Growable.toVector (reclaim lend) of
+            Ur frozen -> V.length frozen
+        )
+
+badSharedContentEscapeCase :: Int
+badSharedContentEscapeCase =
+  linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <-
+        borrowM (Growable.empty @V.Vector @Int ownerLinear)
+      share vector & \(Ur sharedVector) -> Control.do
+        (escaped, sharedVector) <-
+          Growable.withContent sharedVector Control.pure
+        let
+          !() = consume escaped
+          !() = consume sharedVector
+        pureAfter
+          ( case Growable.toVector (reclaim lend) of
+              Ur frozen -> V.length frozen
+          )
+
+preserveMutContent ::
+  Mut α (Growable.GrowableVector V.Vector Int) %1 ->
+  Mut α (Fixed.Vector V.Vector Int)
+preserveMutContent = Growable.getContents
+
+preserveShareContent ::
+  Share α (Growable.GrowableVector V.Vector Int) %1 ->
+  Share α (Fixed.Vector V.Vector Int)
+preserveShareContent = Growable.getContents

--- a/test/Data/Vector/Generic/Mutable/Growable/Linear/Borrow/UnrestrictedSpec.hs
+++ b/test/Data/Vector/Generic/Mutable/Growable/Linear/Borrow/UnrestrictedSpec.hs
@@ -1,0 +1,614 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE ImpredicativeTypes #-}
+{-# LANGUAGE QualifiedDo #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# OPTIONS_GHC -Wno-name-shadowing #-}
+
+module Data.Vector.Generic.Mutable.Growable.Linear.Borrow.UnrestrictedSpec (
+  module Data.Vector.Generic.Mutable.Growable.Linear.Borrow.UnrestrictedSpec,
+) where
+
+import Control.Exception qualified as Exception
+import Control.Functor.Linear qualified as Control
+import Control.Monad.Borrow.Pure.BO
+import Control.Monad.Borrow.Pure.BO.Unsafe (Alias (UnsafeAlias))
+import Control.Monad.Borrow.Pure.Clone (Clone (clone))
+import Control.Monad.Borrow.Pure.Copyable (Copyable (copy))
+import Control.Syntax.DataFlow qualified as DataFlow
+import Data.IORef (IORef, modifyIORef', newIORef, readIORef)
+import Data.List qualified as List
+import Data.Vector qualified as V
+import Data.Vector.Generic.Mutable.Growable.Linear.Borrow.Unrestricted qualified as Growable
+import Data.Vector.Generic.Mutable.Growable.Linear.Borrow.Unrestricted.TypingCases
+import Data.Vector.Generic.Mutable.Linear.Borrow.Unrestricted qualified as Fixed
+import Data.Vector.Primitive qualified as P
+import Data.Vector.Unboxed qualified as U
+import GHC.IO (unsafePerformIO)
+import Prelude.Linear
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit
+import Unsafe.Linear qualified as Unsafe
+import Prelude qualified as NonLinear
+
+freezeBoxed :: Growable.GrowableVector V.Vector Int %1 -> [Int]
+freezeBoxed vector =
+  case Growable.toVector vector of
+    Ur frozen -> V.toList frozen
+
+freezeUnboxed :: Growable.GrowableVector U.Vector Int %1 -> [Int]
+freezeUnboxed vector =
+  case Growable.toVector vector of
+    Ur frozen -> U.toList frozen
+
+freezePrimitive :: Growable.GrowableVector P.Vector Int %1 -> [Int]
+freezePrimitive vector =
+  case Growable.toVector vector of
+    Ur frozen -> P.toList frozen
+
+boxedGrowth :: ((Int, Int), [Int])
+boxedGrowth =
+  linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <-
+        borrowM (Growable.empty @V.Vector @Int ownerLinear)
+      vector <- Growable.push 1 vector
+      vector <- Growable.extend (V.fromList [2, 3]) vector
+      vector <- Growable.reserve 10 vector
+      (Ur logicalSize, vector) <- Control.pure (Growable.size vector)
+      (Ur allocated, vector) <- Control.pure (Growable.capacity vector)
+      let !() = consume vector
+      pureAfter
+        ( (logicalSize, allocated)
+        , freezeBoxed (reclaim lend)
+        )
+
+unboxedGrowth :: [Int]
+unboxedGrowth =
+  linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <-
+        borrowM
+          (Growable.fromList @U.Vector [1, 2] ownerLinear)
+      vector <- Growable.push 3 vector
+      vector <- Growable.extend (U.fromList [4, 5]) vector
+      let !() = consume vector
+      pureAfter (freezeUnboxed (reclaim lend))
+
+primitiveGrowth :: [Int]
+primitiveGrowth =
+  linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <-
+        borrowM
+          (Growable.withCapacity @P.Vector @Int 1 ownerLinear)
+      vector <- Growable.push 7 vector
+      vector <- Growable.push 8 vector
+      vector <- Growable.push 9 vector
+      let !() = consume vector
+      pureAfter (freezePrimitive (reclaim lend))
+
+fromVectorCopy :: ([Int], [Int])
+fromVectorCopy =
+  let source = V.fromList [1, 2, 3]
+      result =
+        linearly \linear -> DataFlow.do
+          (ownerLinear, runLinear) <- dup linear
+          runBO runLinear Control.do
+            (vector, lend) <-
+              borrowM (Growable.fromVector source ownerLinear)
+            vector <- Growable.write 0 9 vector
+            let !() = consume vector
+            pureAfter (freezeBoxed (reclaim lend))
+   in (V.toList source, result)
+
+unsafeMutableRoundTrip :: [Int]
+unsafeMutableRoundTrip =
+  linearly \linear ->
+    freezeBoxed
+      ( Growable.unsafeFromMutable
+          (unsafePerformIO (V.thaw (V.fromList [1, 2])))
+          linear
+      )
+
+unsafeVectorRoundTrip :: [Int]
+unsafeVectorRoundTrip =
+  linearly \linear ->
+    freezeUnboxed
+      ( Growable.unsafeFromVector
+          (U.fromList [3, 4])
+          linear
+      )
+
+test_backends :: TestTree
+test_backends =
+  testGroup
+    "construction, growth, and backends"
+    [ testCase "boxed backend preserves size and requested capacity" do
+        let ((logicalSize, allocated), values) = boxedGrowth
+        logicalSize @?= 3
+        assertBool "capacity did not grow to the request" (allocated >= 10)
+        values @?= [1, 2, 3]
+    , testCase "unboxed backend grows and extends" do
+        unboxedGrowth @?= [1, 2, 3, 4, 5]
+    , testCase "primitive backend grows repeatedly" do
+        primitiveGrowth @?= [7, 8, 9]
+    , testCase "constant and empty materialize only initialized entries" do
+        linearly
+          ( \linear ->
+              case dup linear of
+                (emptyLinear, constantLinear) ->
+                  ( freezeBoxed
+                      (Growable.empty @V.Vector @Int emptyLinear)
+                  , freezeUnboxed
+                      ( Growable.constant @U.Vector
+                          3
+                          (4 :: Int)
+                          constantLinear
+                      )
+                  )
+          )
+          @?= ([], [4, 4, 4])
+    , testCase "fromVector copies its immutable source" do
+        fromVectorCopy @?= ([1, 2, 3], [9, 2, 3])
+    , testCase "unsafe constructors adopt complete initialized sources" do
+        unsafeMutableRoundTrip @?= [1, 2]
+        unsafeVectorRoundTrip @?= [3, 4]
+    ]
+
+boxedOperations :: ((Int, Int, Int), [Int], [Int])
+boxedOperations =
+  linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <-
+        borrowM
+          (Growable.fromList @V.Vector [1, 2, 3] ownerLinear)
+      (Ur first, vector) <- Growable.get 0 vector
+      (Ur old, vector) <- Growable.set 1 20 vector
+      vector <- Growable.write 2 30 vector
+      (Ur auxiliary, vector) <-
+        Growable.update
+          0
+          (\value -> Control.pure (Ur (value * 10), Ur (value + 1)))
+          vector
+      vector <-
+        Growable.modify 1 (\value -> value NonLinear.+ 1) vector
+      vector <- Growable.swap vector 0 2
+      vector <- Growable.push 40 vector
+      vector <- Growable.extend (V.fromList [50, 60]) vector
+      (Ur snapshot, vector) <- Growable.copyToVector vector
+      let !() = consume vector
+      pureAfter
+        ( (first, old, auxiliary)
+        , V.toList snapshot
+        , freezeBoxed (reclaim lend)
+        )
+
+sharedReads :: (Int, Int, Int)
+sharedReads =
+  linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <-
+        borrowM
+          (Growable.fromList @V.Vector [11, 22, 33] ownerLinear)
+      ((first, second, third), vector) <-
+        sharing vector \shared -> Control.do
+          Ur first <- Growable.copyAt 0 shared
+          Ur second <- Growable.unsafeCopyAt 1 shared
+          (third, shared) <-
+            Growable.withContent shared \content ->
+              move content & \(Ur content) -> Control.do
+                Ur third <- Fixed.copyAt 2 content
+                Control.pure third
+          Control.pure
+            (consume shared `lseq` (first, second, third))
+      let !() = consume vector
+      pureAfter
+        ( case Growable.toVector (reclaim lend) of
+            Ur _ -> (first, second, third)
+        )
+
+ordinaryElementMultiplicity :: (Int, [Int])
+ordinaryElementMultiplicity =
+  linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <-
+        borrowM
+          (Growable.fromList @V.Vector [1, 2] ownerLinear)
+      let replacement = 7
+      (Ur displaced, vector) <- Growable.set 0 replacement vector
+      vector <- Growable.write 1 replacement vector
+      vector <- Growable.push replacement vector
+      let !() = consume vector
+      pureAfter
+        ( displaced + displaced
+        , freezeBoxed (reclaim lend)
+        )
+
+test_operations :: TestTree
+test_operations =
+  testGroup
+    "unrestricted element operations"
+    [ testCase "get, set, write, update, modify, swap, push, and snapshot" do
+        boxedOperations
+          @?= ( (1, 2, 10)
+              , [30, 21, 2, 40, 50, 60]
+              , [30, 21, 2, 40, 50, 60]
+              )
+    , testCase "shared and fixed-content reads need no copy capability" do
+        sharedReads @?= (11, 22, 33)
+    , testCase "inputs, callbacks, and displaced values are unrestricted" do
+        ordinaryElementMultiplicity @?= (2, [7, 7, 7])
+    ]
+
+mirroredSurface :: ([Int], Int, [Int])
+mirroredSurface =
+  linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <-
+        borrowM
+          (Growable.fromList @V.Vector [1, 2] ownerLinear)
+      vector <- Growable.reserveAdditional 5 vector
+      (Ur allocated, vector) <- Control.pure (Growable.capacity vector)
+      (Ur first, vector) <- Growable.head vector
+      (Ur unsafeFirst, vector) <- Growable.unsafeHead vector
+      (Ur final, vector) <- Growable.last vector
+      (Ur unsafeFinal, vector) <- Growable.unsafeLast vector
+      (Ur copiedFirst, vector) <- Growable.copyAtMut 0 vector
+      (Ur copiedFinal, vector) <- Growable.unsafeCopyAtMut 1 vector
+      vector <-
+        Growable.withContent_ vector \content -> Control.do
+          content <- Fixed.modify 0 (\value -> value NonLinear.+ 10) content
+          Control.pure (consume content)
+      let !() = consume vector
+      pureAfter
+        ( [first, unsafeFirst, final, unsafeFinal, copiedFirst, copiedFinal]
+        , allocated
+        , freezeBoxed (reclaim lend)
+        )
+
+test_mirroredSurface :: TestTree
+test_mirroredSurface =
+  testCase "mirrors read helpers, reserveAdditional, and withContent_" do
+    let (observed, allocated, values) = mirroredSurface
+    observed @?= [1, 1, 2, 2, 1, 2]
+    assertBool "additional reserve did not grow capacity" (allocated >= 7)
+    values @?= [11, 2]
+
+contentSplit :: [Int]
+contentSplit =
+  linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <-
+        borrowM
+          (Growable.fromList @V.Vector [1, 2, 3, 4] ownerLinear)
+      ((), vector) <-
+        Growable.withContent vector \content -> Control.do
+          let !(left, right) = Fixed.splitAt 2 content
+          (left, right) <-
+            parBO
+              (Fixed.modify 0 (\value -> value NonLinear.+ 10) left)
+              (Fixed.modify 1 (\value -> value NonLinear.+ 20) right)
+          Control.pure (consume (left, right))
+      vector <- Growable.push 5 vector
+      let !() = consume vector
+      pureAfter (freezeBoxed (reclaim lend))
+
+directContentLength :: (Int, [Int])
+directContentLength =
+  linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <-
+        borrowM
+          (Growable.fromList @V.Vector [1, 2] ownerLinear)
+      vector <- Growable.reserve 16 vector
+      case Fixed.size (preserveMutContent vector) of
+        (Ur logicalSize, content) ->
+          let !() = consume content
+           in pureAfter (logicalSize, freezeBoxed (reclaim lend))
+
+sharedContentProjection :: (Int, [Int])
+sharedContentProjection =
+  linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <-
+        borrowM
+          (Growable.fromList @V.Vector [1, 2, 3] ownerLinear)
+      share vector & \(Ur shared) ->
+        move (preserveShareContent shared) & \(Ur content) -> Control.do
+          Ur observed <- Fixed.copyAt 1 content
+          pureAfter (observed, freezeBoxed (reclaim lend))
+
+withContentMutation :: [Int]
+withContentMutation =
+  linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <-
+        borrowM
+          (Growable.fromList @V.Vector [1, 2, 3] ownerLinear)
+      vector <-
+        Growable.withContent_ vector \content -> Control.do
+          content <- Fixed.write 1 20 content
+          Control.pure (consume content)
+      vector <- Growable.push 4 vector
+      let !() = consume vector
+      pureAfter (freezeBoxed (reclaim lend))
+
+explicitContentMutation :: [Int]
+explicitContentMutation =
+  linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <-
+        borrowM
+          (Growable.fromList @V.Vector [1, 2, 3] ownerLinear)
+      ((), vector) <-
+        reborrowing vector \short -> Control.do
+          content <- Control.pure (Growable.getContents short)
+          content <- Fixed.write 1 20 content
+          Control.pure (consume content)
+      vector <- Growable.push 4 vector
+      let !() = consume vector
+      pureAfter (freezeBoxed (reclaim lend))
+
+test_content :: TestTree
+test_content =
+  testGroup
+    "fixed content scopes"
+    [ testCase "split mutation is safe before growth resumes" do
+        contentSplit @?= [11, 2, 3, 24, 5]
+    , testCase "direct projection excludes spare capacity" do
+        directContentLength @?= (2, [1, 2])
+    , testCase "getContents preserves mutable and shared kind and lifetime" do
+        directContentLength @?= (2, [1, 2])
+        sharedContentProjection @?= (2, [1, 2, 3])
+    , testCase "withContent matches explicit reborrowing and projection" do
+        withContentMutation @?= explicitContentMutation
+        withContentMutation @?= [1, 20, 3, 4]
+    ]
+
+data Tracked = Tracked
+  { capabilityCalls :: !(IORef Int)
+  , trackedValue :: !Int
+  }
+
+recordCapability :: Tracked -> Tracked
+recordCapability tracked =
+  case unsafePerformIO
+    (modifyIORef' (capabilityCalls tracked) NonLinear.succ) of
+    () -> tracked
+
+instance Consumable Tracked where
+  consume =
+    Unsafe.toLinear \tracked ->
+      recordCapability tracked `NonLinear.seq` ()
+
+instance Dupable Tracked where
+  dup2 =
+    Unsafe.toLinear \tracked ->
+      (recordCapability tracked, recordCapability tracked)
+
+instance Movable Tracked where
+  move = Unsafe.toLinear \tracked -> Ur (recordCapability tracked)
+
+instance Copyable Tracked where
+  copy =
+    Unsafe.toLinear \(UnsafeAlias tracked) ->
+      recordCapability tracked
+
+trackedValues :: V.Vector Tracked -> [Int]
+trackedValues vector =
+  NonLinear.map trackedValue (V.toList vector)
+
+capabilityFreeLifecycle ::
+  IORef Int ->
+  ([Int], [Int], [Int], [Int])
+capabilityFreeLifecycle calls =
+  linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <-
+        borrowM
+          ( Growable.fromVector
+              (V.fromList [Tracked calls 1, Tracked calls 2])
+              ownerLinear
+          )
+      vector <- Growable.reserve 8 vector
+      vector <- Growable.push (Tracked calls 3) vector
+      (cloned, vector) <- sharing vector (\shared -> clone shared)
+      (Ur snapshot, vector) <- Growable.copyToVector vector
+      (Ur first, vector) <- Growable.get 0 vector
+      (Ur old, vector) <- Growable.set 1 (Tracked calls 4) vector
+      vector <- Growable.write 0 (Tracked calls 5) vector
+      let
+        !() = consume vector
+        clonedValues =
+          case Growable.toVector cloned of
+            Ur frozen -> trackedValues frozen
+      pureAfter
+        ( case Growable.toVector (reclaim lend) of
+            Ur frozen ->
+              ( trackedValues snapshot
+              , clonedValues
+              , [trackedValue first, trackedValue old]
+              , trackedValues frozen
+              )
+        )
+
+referenceAliasAfterGrowth :: IORef Int -> [Int]
+referenceAliasAfterGrowth reference =
+  linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <-
+        borrowM
+          (Growable.fromVector (V.singleton reference) ownerLinear)
+      vector <- Growable.reserve 32 vector
+      vector <- Growable.push reference vector
+      (Ur observed, vector) <- Growable.get 0 vector
+      let !() = consume vector
+      pureAfter
+        ( case Growable.toVector (reclaim lend) of
+            Ur frozen ->
+              unsafePerformIO do
+                modifyIORef'
+                  observed
+                  (\value -> value NonLinear.+ 41)
+                NonLinear.mapM readIORef (V.toList frozen)
+        )
+
+test_capabilities :: TestTree
+test_capabilities =
+  testGroup
+    "capability-free GC-owned elements"
+    [ testCase "the complete lifecycle invokes no element capability" do
+        calls <- newIORef 0
+        capabilityFreeLifecycle calls
+          @?= ( [1, 2, 3]
+              , [1, 2, 3]
+              , [1, 2]
+              , [5, 4, 3]
+              )
+        readIORef calls NonLinear.>>= (@?= 0)
+    , testCase "growth preserves deliberate boxed aliases" do
+        reference <- newIORef 1
+        referenceAliasAfterGrowth reference @?= [42, 42]
+        readIORef reference NonLinear.>>= (@?= 42)
+    ]
+
+getOutOfBounds :: Int -> Int
+getOutOfBounds index =
+  linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <-
+        borrowM
+          (Growable.fromList @V.Vector [1, 2, 3] ownerLinear)
+      (Ur value, vector) <- Growable.get index vector
+      let !() = consume vector
+      pureAfter
+        ( case Growable.toVector (reclaim lend) of
+            Ur frozen -> value + V.length frozen
+        )
+
+writeOutOfBounds :: Int -> Int
+writeOutOfBounds index =
+  linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <-
+        borrowM
+          (Growable.fromList @V.Vector [1, 2, 3] ownerLinear)
+      vector <- Growable.write index 4 vector
+      let !() = consume vector
+      pureAfter
+        ( case Growable.toVector (reclaim lend) of
+            Ur frozen -> V.sum frozen
+        )
+
+negativeCapacity :: Int
+negativeCapacity =
+  linearly \linear ->
+    case Growable.toVector
+      (Growable.withCapacity @V.Vector @Int (-1) linear) of
+      Ur frozen -> V.length frozen
+
+assertErrorPrefix :: NonLinear.String -> a -> Assertion
+assertErrorPrefix expectedPrefix value = do
+  result <- Exception.try @Exception.ErrorCall (Exception.evaluate value)
+  case result of
+    Left exception ->
+      assertBool
+        ("unexpected error: " <> Exception.displayException exception)
+        (expectedPrefix `List.isPrefixOf` Exception.displayException exception)
+    Right _ ->
+      assertFailure ("expected error beginning with " <> expectedPrefix)
+
+test_bounds :: TestTree
+test_bounds =
+  testGroup
+    "bounds"
+    [ testCase "get rejects a negative index" do
+        assertErrorPrefix "get: index -1 out of bounds" (getOutOfBounds (-1))
+    , testCase "get rejects the upper bound" do
+        assertErrorPrefix "get: index 3 out of bounds" (getOutOfBounds 3)
+    , testCase "write rejects a negative index" do
+        assertErrorPrefix "write: index -1 out of bounds" (writeOutOfBounds (-1))
+    , testCase "write rejects the upper bound" do
+        assertErrorPrefix "write: index 3 out of bounds" (writeOutOfBounds 3)
+    , testCase "construction rejects negative capacity" do
+        assertErrorPrefix "withCapacity: negative capacity -1" negativeCapacity
+    ]
+
+assertDeferredTypeError :: NonLinear.String -> a -> Assertion
+assertDeferredTypeError expectedFragment value = do
+  result <- Exception.try @Exception.SomeException (Exception.evaluate value)
+  case result of
+    Left exception ->
+      assertBool
+        ("unexpected deferred error: " <> Exception.displayException exception)
+        (expectedFragment `List.isInfixOf` Exception.displayException exception)
+    Right _ ->
+      assertFailure
+        ("expected deferred type error containing " <> expectedFragment)
+
+test_typing :: TestTree
+test_typing =
+  testGroup
+    "typing boundaries"
+    [ testCase "backend role is nominal" do
+        assertDeferredTypeError "Couldn't match type" badBackendCoercion
+    , testCase "element role is nominal" do
+        assertDeferredTypeError "Couldn't match type" badElementCoercionCase
+    , testCase "element ownership cannot be coerced" do
+        assertDeferredTypeError "representation" badOwnershipCoercionCase
+    , testCase "growable owner cannot be coerced to fixed content" do
+        assertDeferredTypeError
+          "Couldn't match representation of type"
+          badGrowableToFixed
+    , testCase "fixed content cannot be coerced to a growable owner" do
+        assertDeferredTypeError
+          "Couldn't match representation of type"
+          badFixedToGrowable
+    , testCase "growable owner cannot be upcast to fixed content" do
+        assertDeferredTypeError
+          "Couldn't match representation of type"
+          badGrowableToFixedUpcast
+    , testCase "fixed content cannot be upcast to a growable owner" do
+        assertDeferredTypeError
+          "Couldn't match representation of type"
+          badFixedToGrowableUpcast
+    , testCase "a growable borrow cannot swap lifetime indices" do
+        assertDeferredTypeError "Couldn't match type" badLifetimeSwapCase
+    , testCase "a growable owner has no generic split" do
+        assertDeferredTypeError
+          "DistributesAlias"
+          badSplit
+    , testCase "a growable borrow cannot be coerced to content" do
+        assertDeferredTypeError
+          "Couldn't match representation of type"
+          badOwnerToContentCoercion
+    , testCase "get cannot manufacture an element borrow" do
+        assertDeferredTypeError "Couldn't match" badElementBorrowCase
+    , testCase "the mutable owner cannot be copied" do
+        assertDeferredTypeError "cannot be copied!" badDuplicate
+    , testCase "shared borrows cannot mutate" do
+        assertDeferredTypeError "Couldn't match" badMutateSharedCase
+    , testCase "shared borrows cannot grow" do
+        assertDeferredTypeError "Couldn't match" badGrowSharedCase
+    , testCase "fixed content cannot escape its scope" do
+        assertDeferredTypeError "Couldn't match" badContentEscapeCase
+    , testCase "shared fixed content cannot escape its scope" do
+        assertDeferredTypeError "Couldn't match" badSharedContentEscapeCase
+    ]

--- a/test/Data/Vector/Generic/Mutable/Linear/Borrow/Experimental/Multiplicity/TypingCases.hs
+++ b/test/Data/Vector/Generic/Mutable/Linear/Borrow/Experimental/Multiplicity/TypingCases.hs
@@ -1,0 +1,103 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE QualifiedDo #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# OPTIONS_GHC -O0 #-}
+{-# OPTIONS_GHC -Wno-name-shadowing #-}
+{-# OPTIONS_GHC -fdefer-type-errors -Wno-deferred-type-errors #-}
+
+module Data.Vector.Generic.Mutable.Linear.Borrow.Experimental.Multiplicity.TypingCases (
+  module Data.Vector.Generic.Mutable.Linear.Borrow.Experimental.Multiplicity.TypingCases,
+) where
+
+import Control.Functor.Linear qualified as Control
+import Control.Monad.Borrow.Pure.BO
+import Control.Monad.Borrow.Pure.BO.Unsafe (Alias (UnsafeAlias))
+import Control.Monad.Borrow.Pure.Clone (Clone (clone))
+import Control.Syntax.DataFlow qualified as DataFlow
+import Data.Vector qualified as V
+import Data.Vector.Generic.Mutable.Linear.Borrow.Experimental.Multiplicity qualified as Vector
+import GHC.Exts (Multiplicity (One))
+import Prelude.Linear
+
+data NoCapabilities = NoCapabilities Int
+
+data ConsumableOnly = ConsumableOnly Int
+
+instance Consumable ConsumableOnly where
+  consume (ConsumableOnly value) = consume value
+
+badOwningGet ::
+  Mut α (Vector.Vector One V.Vector Int) %1 ->
+  BO
+    α
+    ( Mut α Int
+    , Mut α (Vector.Vector One V.Vector Int)
+    )
+badOwningGet = Vector.get 0
+
+badOwningGetCase :: ()
+badOwningGetCase =
+  linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO_ runLinear Control.do
+      (element, vector) <-
+        badOwningGet
+          ( UnsafeAlias
+              ( Vector.fromList @V.Vector
+                  [1]
+                  ownerLinear ::
+                  Vector.Vector One V.Vector Int
+              )
+          )
+      Control.pure (consume (element, vector))
+
+badConsume ::
+  Vector.Vector One V.Vector NoCapabilities %1 ->
+  ()
+badConsume = consume
+
+badConsumeCase :: ()
+badConsumeCase =
+  linearly \linear ->
+    badConsume
+      ( Vector.fromList @V.Vector
+          [NoCapabilities 1]
+          linear
+      )
+
+badClone ::
+  Share α (Vector.Vector One V.Vector ConsumableOnly) %1 ->
+  BO α (Vector.Vector One V.Vector ConsumableOnly)
+badClone = clone
+
+badCloneCase :: ()
+badCloneCase =
+  linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <-
+        borrowM
+          ( Vector.fromList @V.Vector
+              [ConsumableOnly 1]
+              ownerLinear
+          )
+      (cloned, vector) <- sharing vector (\shared -> badClone shared)
+      let !() = consume vector
+      pureAfter
+        (consume cloned `lseq` consume (reclaim lend))
+
+badCopyCase :: ()
+badCopyCase =
+  linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <-
+        borrowM
+          ( Vector.fromList @V.Vector
+              [NoCapabilities 1]
+              ownerLinear
+          )
+      (Ur _, vector) <- Vector.copyToVector vector
+      let !() = consume vector
+      pureAfter (badConsume (reclaim lend))

--- a/test/Data/Vector/Generic/Mutable/Linear/Borrow/Experimental/MultiplicitySpec.hs
+++ b/test/Data/Vector/Generic/Mutable/Linear/Borrow/Experimental/MultiplicitySpec.hs
@@ -1,0 +1,317 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE QualifiedDo #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# OPTIONS_GHC -Wno-name-shadowing #-}
+
+module Data.Vector.Generic.Mutable.Linear.Borrow.Experimental.MultiplicitySpec (
+  module Data.Vector.Generic.Mutable.Linear.Borrow.Experimental.MultiplicitySpec,
+) where
+
+import Control.Exception qualified as Exception
+import Control.Functor.Linear qualified as Control
+import Control.Monad.Borrow.Pure.BO
+import Control.Monad.Borrow.Pure.BO.Unsafe (Alias (UnsafeAlias))
+import Control.Monad.Borrow.Pure.Clone (Clone (clone))
+import Control.Monad.Borrow.Pure.Copyable (Copyable (copy))
+import Control.Syntax.DataFlow qualified as DataFlow
+import Data.IORef (IORef, modifyIORef', newIORef, readIORef)
+import Data.List qualified as List
+import Data.Vector qualified as V
+import Data.Vector.Generic.Mutable.Linear.Borrow.Experimental.Multiplicity qualified as Vector
+import Data.Vector.Generic.Mutable.Linear.Borrow.Experimental.Multiplicity.TypingCases
+import GHC.Exts (Multiplicity (One))
+import GHC.IO (unsafePerformIO)
+import Prelude.Linear
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit
+import Unsafe.Linear qualified as Unsafe
+import Prelude qualified as NonLinear
+
+data Tracked = Tracked
+  { copyCalls :: !(IORef Int)
+  , consumeCalls :: !(IORef Int)
+  , duplicateCalls :: !(IORef Int)
+  , moveCalls :: !(IORef Int)
+  , trackedValue :: !Int
+  }
+
+instance Copyable Tracked where
+  copy =
+    Unsafe.toLinear \(UnsafeAlias tracked) ->
+      case unsafePerformIO do
+        consumed <- readIORef (consumeCalls tracked)
+        if consumed == 0
+          then modifyIORef' (copyCalls tracked) NonLinear.succ
+          else NonLinear.error "copy invoked after source retirement" of
+        () -> tracked
+
+instance Consumable Tracked where
+  consume =
+    Unsafe.toLinear \tracked ->
+      unsafePerformIO
+        (modifyIORef' (consumeCalls tracked) NonLinear.succ)
+
+instance Dupable Tracked where
+  dup2 =
+    Unsafe.toLinear \tracked ->
+      case unsafePerformIO
+        (modifyIORef' (duplicateCalls tracked) NonLinear.succ) of
+        () -> (tracked, tracked)
+
+instance Movable Tracked where
+  move =
+    Unsafe.toLinear \tracked ->
+      case unsafePerformIO
+        (modifyIORef' (moveCalls tracked) NonLinear.succ) of
+        () -> Ur tracked
+
+newTracked ::
+  IORef Int ->
+  IORef Int ->
+  IORef Int ->
+  IORef Int ->
+  Int ->
+  Tracked
+newTracked = Tracked
+
+owningVector ::
+  IORef Int ->
+  IORef Int ->
+  IORef Int ->
+  IORef Int ->
+  Linearly %1 ->
+  Vector.Vector One V.Vector Tracked
+owningVector copies consumes duplicates moves =
+  Vector.fromList @V.Vector
+    [ newTracked copies consumes duplicates moves 10
+    , newTracked copies consumes duplicates moves 20
+    ]
+
+consumeOwningVector ::
+  IORef Int ->
+  IORef Int ->
+  IORef Int ->
+  IORef Int ->
+  ()
+consumeOwningVector copies consumes duplicates moves =
+  linearly \linear ->
+    consume (owningVector copies consumes duplicates moves linear)
+
+getOwningElement ::
+  IORef Int ->
+  IORef Int ->
+  IORef Int ->
+  IORef Int ->
+  ()
+getOwningElement copies consumes duplicates moves =
+  linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <-
+        borrowM
+          (owningVector copies consumes duplicates moves ownerLinear)
+      element <- Vector.get 0 vector
+      let !() = consume element
+      pureAfter (consume (reclaim lend))
+
+writeOwningElement ::
+  IORef Int ->
+  IORef Int ->
+  IORef Int ->
+  IORef Int ->
+  ()
+writeOwningElement copies consumes duplicates moves =
+  linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <-
+        borrowM
+          (owningVector copies consumes duplicates moves ownerLinear)
+      vector <-
+        Vector.write
+          0
+          (newTracked copies consumes duplicates moves 30)
+          vector
+      let !() = consume vector
+      pureAfter (consume (reclaim lend))
+
+setOwningElement ::
+  IORef Int ->
+  IORef Int ->
+  IORef Int ->
+  IORef Int ->
+  ()
+setOwningElement copies consumes duplicates moves =
+  linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <-
+        borrowM
+          (owningVector copies consumes duplicates moves ownerLinear)
+      (displaced, vector) <-
+        Vector.set
+          0
+          (newTracked copies consumes duplicates moves 30)
+          vector
+      let
+        !() = consume displaced
+        !() = consume vector
+      pureAfter (consume (reclaim lend))
+
+cloneOwningVector ::
+  IORef Int ->
+  IORef Int ->
+  IORef Int ->
+  IORef Int ->
+  ()
+cloneOwningVector copies consumes duplicates moves =
+  linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <-
+        borrowM
+          (owningVector copies consumes duplicates moves ownerLinear)
+      (cloned, vector) <- sharing vector (\shared -> clone shared)
+      let !() = consume vector
+      pureAfter
+        (consume cloned `lseq` consume (reclaim lend))
+
+finishCopied :: Tracked %1 -> Int
+finishCopied =
+  Unsafe.toLinear \(Tracked copies consumes duplicates moves value) ->
+    consume (Tracked copies consumes duplicates moves value) `lseq` value
+
+copyAtBeforeRecovery ::
+  IORef Int ->
+  IORef Int ->
+  IORef Int ->
+  IORef Int ->
+  Int
+copyAtBeforeRecovery copies consumes duplicates moves =
+  linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <-
+        borrowM
+          (owningVector copies consumes duplicates moves ownerLinear)
+      (copied, vector) <- Vector.copyAtMut 0 vector
+      let !() = consume vector
+      pureAfter
+        ( consume (reclaim lend) `lseq`
+            finishCopied copied
+        )
+
+copyVectorBeforeRecovery ::
+  IORef Int ->
+  IORef Int ->
+  IORef Int ->
+  IORef Int ->
+  [Int]
+copyVectorBeforeRecovery copies consumes duplicates moves =
+  linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <-
+        borrowM
+          (owningVector copies consumes duplicates moves ownerLinear)
+      (Ur snapshot, vector) <- Vector.copyToVector vector
+      let !() = consume vector
+      pureAfter
+        ( consume (reclaim lend) `lseq`
+            NonLinear.map trackedValue (V.toList snapshot)
+        )
+
+moveOwningVector ::
+  IORef Int ->
+  IORef Int ->
+  IORef Int ->
+  IORef Int ->
+  [Int]
+moveOwningVector copies consumes duplicates moves =
+  linearly \linear ->
+    case Vector.toVector
+      (owningVector copies consumes duplicates moves linear) of
+      Ur vector -> NonLinear.map trackedValue (V.toList vector)
+
+withCounters ::
+  (IORef Int -> IORef Int -> IORef Int -> IORef Int -> Assertion) ->
+  Assertion
+withCounters assertion = do
+  copies <- newIORef 0
+  consumes <- newIORef 0
+  duplicates <- newIORef 0
+  moves <- newIORef 0
+  assertion copies consumes duplicates moves
+
+test_owning :: TestTree
+test_owning =
+  testGroup
+    "owning elements"
+    [ testCase "consuming the vector consumes every element" $
+        withCounters \copies consumes duplicates moves -> do
+          Exception.evaluate
+            (consumeOwningVector copies consumes duplicates moves)
+          readIORef consumes NonLinear.>>= (@?= 2)
+    , testCase "get transfers the vector borrow to the element" $
+        withCounters \copies consumes duplicates moves -> do
+          Exception.evaluate
+            (getOwningElement copies consumes duplicates moves)
+          readIORef consumes NonLinear.>>= (@?= 2)
+    , testCase "write consumes the displaced element exactly once" $
+        withCounters \copies consumes duplicates moves -> do
+          Exception.evaluate
+            (writeOwningElement copies consumes duplicates moves)
+          readIORef consumes NonLinear.>>= (@?= 3)
+    , testCase "set returns the displaced element to its caller" $
+        withCounters \copies consumes duplicates moves -> do
+          Exception.evaluate
+            (setOwningElement copies consumes duplicates moves)
+          readIORef consumes NonLinear.>>= (@?= 3)
+    , testCase "clone duplicates every owned element" $
+        withCounters \copies consumes duplicates moves -> do
+          Exception.evaluate
+            (cloneOwningVector copies consumes duplicates moves)
+          readIORef duplicates NonLinear.>>= (@?= 2)
+          readIORef consumes NonLinear.>>= (@?= 4)
+    , testCase "copyAtMut completes copying before owner recovery" $
+        withCounters \copies consumes duplicates moves -> do
+          copyAtBeforeRecovery copies consumes duplicates moves @?= 10
+          readIORef copies NonLinear.>>= (@?= 1)
+    , testCase "copyToVector copies every element before owner recovery" $
+        withCounters \copies consumes duplicates moves -> do
+          copyVectorBeforeRecovery copies consumes duplicates moves
+            @?= [10, 20]
+          readIORef copies NonLinear.>>= (@?= 2)
+    , testCase "toVector moves every element into GC ownership" $
+        withCounters \copies consumes duplicates moves -> do
+          moveOwningVector copies consumes duplicates moves @?= [10, 20]
+          readIORef moves NonLinear.>>= (@?= 2)
+    ]
+
+assertDeferredTypeError :: NonLinear.String -> a -> Assertion
+assertDeferredTypeError expectedFragment value = do
+  result <- Exception.try @Exception.SomeException (Exception.evaluate value)
+  case result of
+    Left exception ->
+      assertBool
+        ("unexpected deferred error: " <> Exception.displayException exception)
+        (expectedFragment `List.isInfixOf` Exception.displayException exception)
+    Right _ ->
+      assertFailure
+        ("expected deferred type error containing " <> expectedFragment)
+
+test_typing :: TestTree
+test_typing =
+  testGroup
+    "typing boundaries"
+    [ testCase "owning get cannot also return the vector borrow" do
+        assertDeferredTypeError "Couldn't match" badOwningGetCase
+    , testCase "owning consumption requires Consumable elements" do
+        assertDeferredTypeError "Consumable NoCapabilities" badConsumeCase
+    , testCase "owning clone requires Dupable elements" do
+        assertDeferredTypeError "Dupable" badCloneCase
+    , testCase "owning copyToVector requires Copyable elements" do
+        assertDeferredTypeError "Copyable" badCopyCase
+    ]

--- a/test/typing-fail/GenericGrowableUnrestricted/ContentOwnerReuse.hs
+++ b/test/typing-fail/GenericGrowableUnrestricted/ContentOwnerReuse.hs
@@ -1,0 +1,37 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE ImpredicativeTypes #-}
+{-# LANGUAGE LinearTypes #-}
+{-# LANGUAGE QualifiedDo #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module GenericGrowableUnrestricted.ContentOwnerReuse where
+
+import Control.Functor.Linear qualified as Control
+import Control.Monad.Borrow.Pure.BO
+import Data.Vector qualified as V
+import Data.Vector.Generic.Mutable.Growable.Linear.Borrow.Unrestricted qualified as Growable
+import Prelude.Linear
+
+shortenBO :: (α >= β) => BO α a %1 -> BO β a
+shortenBO = upcast
+
+-- This fixture must not typecheck: the outer mutable owner is captured by the
+-- content callback after the same linear capability has entered withContent_.
+--
+-- Verified with GHC 9.12.4: the resulting `Many`/`One` multiplicity mismatch is
+-- rejected while compiling this module even with
+-- `-fdefer-type-errors -Wno-deferred-type-errors`. It therefore cannot live in
+-- `TypingCases` as a runtime-observed deferred type error.
+badGrowthWhileContentLive ::
+  Mut α (Growable.GrowableVector V.Vector Int) %1 ->
+  BO α (Mut α (Growable.GrowableVector V.Vector Int))
+badGrowthWhileContentLive vector =
+  Growable.withContent_ vector \contents -> Control.do
+    grown <- shortenBO (Growable.push 1 vector)
+    let
+      !() = consume grown
+      !() = consume contents
+    Control.pure ()


### PR DESCRIPTION
Two more backend-generic vectors over the unrestricted base.

`Data.Vector.Generic.Mutable.Growable.Linear.Borrow.Unrestricted` is the
growable counterpart of the fixed generic unrestricted vector: one
implementation of amortized push/pop and prefix projection that works
for any `vector` backend, with GC-owned elements. It closes the grid —
boxed/unboxed x fixed/growable now all have a borrow-aware type, and the
backend-polymorphic pair covers the rest.

Its soundness gate is the wider part of the change. The spec and
`TypingCases` cover coercion, lifetime, splitting, escape and
projection; `getContents` in particular hands out a borrow derived from
the content owner, and the accompanying proof note records why that is
sound. Reusing a content owner is a linear multiplicity error that GHC
rejects during compilation rather than deferring, so that case lives in
`test/typing-fail/GenericGrowableUnrestricted/ContentOwnerReuse.hs`, and
an inspection test pins that the generic dictionaries specialize away in
optimized Core.

`Data.Vector.Generic.Mutable.Linear.Borrow.Experimental.Multiplicity` is
an experimental vector polymorphic in its elements' *multiplicity*
rather than fixing GC-owned or linearly-owned elements, so one type can
serve both settings of the element-ownership axis. It is exposed under
`Experimental` and is not yet load-bearing for anything else.
Part of #14.