### PR TITLE
bench: add multi-store-scan and worklist-resume benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,6 +110,7 @@ cabal.project.local~
 .ghc.environment.*
 *.eventlog
 /bench-results
+/bench/*.mjs
 *.png
 *.local.json
 haddocks

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,11 +35,11 @@ cabal build pure-borrow               # just the library
 
 cabal test                            # run all test suites
 cabal test pure-borrow-test           # main tasty suite only
-cabal test pure-borrow-inspection     # optimized-Core inspection tests
 cabal test pure-borrow-doctests       # doctests (needs GHC >= 9.12.3)
 
 cabal bench qsort-bench               # parallel quicksort benchmark (tasty-bench)
 cabal bench fft-bench                 # parallel FFT benchmark (tasty-bench)
+cabal bench pure-borrow-bench         # all single-threaded micro-benchmarks (needs -j1)
 
 cabal run qsort -- --help             # quicksort demo executable (needs +examples)
 cabal run fft   -- --help             # FFT demo executable (needs +examples)
@@ -95,7 +95,21 @@ Keep errors that GHC does defer in `TypingCases`.
 
 ### Benchmarks & profiling
 
-Benchmarks are `tasty-bench` executables; pass options through cabal, e.g. `cabal bench qsort-bench --benchmark-options='--csv bench-results/qsort.csv -j1 --time-mode=wall +RTS -N -s'`.
+There are exactly three benchmark suites, all `tasty-bench` executables:
+
+- **`qsort-bench`** (`bench/qsort.hs`) and **`fft-bench`** (`bench/fft.hs`) — the two parallel whole-algorithm suites from the paper.
+  Each is a single self-contained `main` module with no `other-modules`; they run under `-N` and take a tasty `--size` option, so they stay separate.
+- **`pure-borrow-bench`** (`bench/suite/`) — every single-threaded micro-benchmark (`copy-at`, `growable`, `unboxed`, `multi-store-scan`, `worklist-*`), merged into one `-N1 -T` executable.
+  Select a subset with tasty's `-p`; `-j1` is mandatory.
+
+`bench/suite/Main.hs` is only the `tasty-discover` driver; each sub-suite is a module under `bench/suite/PureBorrow/Bench/` exporting a single `test_… :: [Benchmark]`.
+Kernels that `pure-borrow-test` or `pure-borrow-inspection` also exercise stay in the `test-bench-common` internal library and are re-exported by a thin module here; kernels used only by the benchmark live under `bench/suite/` directly.
+Do **not** add a per-benchmark internal library — that pattern was removed deliberately, and a library is warranted only when a kernel needs a consumer outside its own benchmark.
+
+The driver's `--ingredient` flags rebuild `Test.Tasty.Bench.benchIngredients` (which `tasty-discover` cannot use directly) out of `listingTests` and `PureBorrow.Bench.Ingredients.benchReporter`; the reporters must stay composed or `--csv`/`--svg` become unreachable.
+`tasty-discover` imports only modules that export a discovered binding, so `Ingredients` needs no `--ignores`.
+
+Pass options through cabal, e.g. `cabal bench qsort-bench --benchmark-options='--csv bench-results/qsort.csv -j1 --time-mode=wall +RTS -N -s'`.
 For profiled runs use the dedicated project file: `cabal --project-file=cabal-bench.project ...` (enables `-fprof-late`/`-fprof-auto` profiling).
 CSV/plots land in `bench-results/`.
 

--- a/bench/suite/PureBorrow/Bench/MultiStoreScan.hs
+++ b/bench/suite/PureBorrow/Bench/MultiStoreScan.hs
@@ -1,0 +1,12 @@
+{- | Exposes the benchmarks of "PureBorrow.Internal.Bench.MultiStoreScan" to
+@tasty-discover@. The kernels themselves stay in the @bench-suites@ internal
+library because @pure-borrow-test@ and @pure-borrow-inspection@ exercise them
+too.
+-}
+module PureBorrow.Bench.MultiStoreScan (test_multiStoreScan) where
+
+import PureBorrow.Internal.Bench.MultiStoreScan qualified as MultiStoreScan
+import Test.Tasty.Bench (Benchmark)
+
+test_multiStoreScan :: [Benchmark]
+test_multiStoreScan = MultiStoreScan.benches

--- a/bench/suite/PureBorrow/Bench/Worklist/Resume.hs
+++ b/bench/suite/PureBorrow/Bench/Worklist/Resume.hs
@@ -1,0 +1,12 @@
+{- | Exposes the benchmarks of "PureBorrow.Internal.Bench.Worklist.Resume" to
+@tasty-discover@. The kernels themselves stay in the @bench-suites@ internal
+library because @pure-borrow-test@ and @pure-borrow-inspection@ exercise them
+too.
+-}
+module PureBorrow.Bench.Worklist.Resume (test_worklistResume) where
+
+import PureBorrow.Internal.Bench.Worklist.Resume qualified as Resume
+import Test.Tasty.Bench (Benchmark)
+
+test_worklistResume :: [Benchmark]
+test_worklistResume = Resume.benches

--- a/internal-src/test-bench-common/PureBorrow/Internal/Bench/MultiStoreScan.hs
+++ b/internal-src/test-bench-common/PureBorrow/Internal/Bench/MultiStoreScan.hs
@@ -1,0 +1,1866 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE ImpredicativeTypes #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE LinearTypes #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE QualifiedDo #-}
+{-# OPTIONS_GHC -Wno-name-shadowing #-}
+
+module PureBorrow.Internal.Bench.MultiStoreScan (
+  MultiStoreScanInput (..),
+  MultiStoreScanOutput (..),
+  MultiStoreScanResult (..),
+  MultiStoreScanSummary (..),
+  TraceEvent,
+  multiStoreScanDirectInput,
+  multiStoreScanDirectBenchmarkRoot,
+  multiStoreScanDirectHeaderMatchedBenchmarkRoot,
+  multiStoreScanDirectRoot,
+  multiStoreScanNodeCount,
+  multiStoreScanBoxedContentProjection,
+  multiStoreScanPureBorrowDirectBenchmarkRoot,
+  multiStoreScanPureBorrowDirectRoot,
+  multiStoreScanPureBorrowFixedUnrestrictedBenchmarkRoot,
+  multiStoreScanPureBorrowFixedUnrestrictedWorker,
+  multiStoreScanPureBorrowNestedBenchmarkRoot,
+  multiStoreScanPureBorrowNestedRoot,
+  multiStoreScanPureBorrowOwningBenchmarkRoot,
+  multiStoreScanPureBorrowOwningWorker,
+  multiStoreScanPureBorrowWorker,
+  multiStoreScanUnboxedContentProjection,
+  benches,
+  defaultMain,
+) where
+
+import Control.DeepSeq (NFData)
+import Control.Functor.Linear qualified as Control
+import Control.Monad.Borrow.Pure
+import Control.Monad.Borrow.Pure.Experimental.Borrows (
+  Aliases (..),
+  reborrowings,
+ )
+import Control.Monad.ST.Strict (ST, runST)
+import Control.Syntax.DataFlow qualified as DataFlow
+import Data.List qualified as List
+import Data.Record.Linear.Borrow.Experimental.PatternMatch (
+  RecordLabel,
+  (.@),
+ )
+import Data.STRef (STRef, newSTRef, readSTRef)
+import Data.Vector qualified as V
+import Data.Vector.Generic.Mutable.Growable.Linear.Borrow.Unrestricted qualified as Growable
+import Data.Vector.Generic.Mutable.Linear.Borrow.Unrestricted qualified as Fixed
+import Data.Vector.Mutable qualified as MV
+import Data.Vector.Mutable.Growable.Linear.Borrow qualified as OwningBoxedGrowable
+import Data.Vector.Mutable.Linear.Borrow qualified as OwningBoxedFixed
+import Data.Vector.Unboxed qualified as U
+import Data.Vector.Unboxed.Mutable qualified as UM
+import Data.Vector.Unboxed.Mutable.Growable.Linear.Borrow qualified as OwningUnboxedGrowable
+import Data.Vector.Unboxed.Mutable.Linear.Borrow qualified as OwningUnboxedFixed
+import GHC.Exts qualified as GHC
+import GHC.Generics (Generic)
+import GHC.Int (Int64 (I64#))
+import Prelude.Linear (
+  lseq,
+  unur,
+  (&),
+ )
+import Test.Tasty.Bench (Benchmark, bench, bgroup, env, nf)
+import Test.Tasty.Bench qualified as Bench
+
+data MultiStoreScanInput = MultiStoreScanInput
+  { inputNext :: !(U.Vector Int)
+  , inputWeight :: !(U.Vector Int)
+  , inputMark :: !(U.Vector Int)
+  , inputPayload :: !(V.Vector (Int, Int))
+  , inputScore :: !(U.Vector Int)
+  , inputLink :: !(U.Vector Int)
+  }
+  deriving stock (Generic)
+  deriving anyclass (NFData)
+
+data MultiStoreScanSummary = MultiStoreScanSummary
+  { visitedNodes :: !Int
+  , elementReads :: !Int
+  , elementWrites :: !Int
+  , headerReads :: !Int
+  , validationReads :: !Int
+  , finalDigest :: !Int64
+  }
+  deriving stock (Eq, Generic, Show)
+  deriving anyclass (NFData)
+
+data MultiStoreScanResult = MultiStoreScanResult
+  { resultSummary :: !MultiStoreScanSummary
+  , resultVisitedIndices :: !(U.Vector Int)
+  , resultEvents :: !(V.Vector TraceEvent)
+  , resultEventDigest :: !Int64
+  , resultMarks :: !(U.Vector Int)
+  , resultScores :: !(U.Vector Int)
+  }
+  deriving stock (Eq, Generic, Show)
+  deriving anyclass (NFData)
+
+data MultiStoreScanOutput = MultiStoreScanOutput
+  { outputDigest :: !Int64
+  , outputMarks :: !(U.Vector Int)
+  , outputScores :: !(U.Vector Int)
+  }
+  deriving stock (Eq, Generic, Show)
+  deriving anyclass (NFData)
+
+data TraceStore
+  = NextStore
+  | WeightStore
+  | MarkStore
+  | ScoreStore
+  | LinkStore
+  deriving stock (Eq, Generic, Show)
+  deriving anyclass (NFData)
+
+data TraceEvent
+  = ReadIntEvent !TraceStore !Int !Int
+  | ReadPayloadEvent !Int !Int !Int
+  | WriteIntEvent !TraceStore !Int !Int
+  deriving stock (Eq, Generic, Show)
+  deriving anyclass (NFData)
+
+data AccessTrace = AccessTrace
+  { traceVisitedIndicesRev :: ![Int]
+  , traceEventsRev :: ![TraceEvent]
+  , traceEventDigest :: !Int64
+  , traceVisitedNodes :: !Int
+  , traceElementReads :: !Int
+  , traceElementWrites :: !Int
+  , traceHeaderReads :: !Int
+  , traceReadDigest :: !Int64
+  }
+
+data FixedRoots = FixedRoots
+  { next :: !(Fixed.Vector U.Vector Int)
+  , weight :: !(Fixed.Vector U.Vector Int)
+  , mark :: !(Fixed.Vector U.Vector Int)
+  }
+
+data GrowableRoots = GrowableRoots
+  { payload :: !(Growable.GrowableVector V.Vector (Int, Int))
+  , score :: !(Growable.GrowableVector U.Vector Int)
+  , link :: !(Growable.GrowableVector U.Vector Int)
+  }
+
+data MultiStore = MultiStore
+  { fixedRoots :: !FixedRoots
+  , growableRoots :: !GrowableRoots
+  }
+
+data OwningFixedRoots = OwningFixedRoots
+  { owningNext :: !(OwningUnboxedFixed.Vector Int)
+  , owningWeight :: !(OwningUnboxedFixed.Vector Int)
+  , owningMark :: !(OwningUnboxedFixed.Vector Int)
+  }
+
+data OwningGrowableRoots = OwningGrowableRoots
+  { owningPayload :: !(OwningBoxedGrowable.GrowableVector (Int, Int))
+  , owningScore :: !(OwningUnboxedGrowable.GrowableVector Int)
+  , owningLink :: !(OwningUnboxedGrowable.GrowableVector Int)
+  }
+
+data OwningMultiStore = OwningMultiStore
+  { owningFixedRoots :: !OwningFixedRoots
+  , owningGrowableRoots :: !OwningGrowableRoots
+  }
+
+data FixedUnrestrictedStore = FixedUnrestrictedStore
+  { fixedUnrestrictedRoots :: !FixedRoots
+  , fixedUnrestrictedGrowableRoots :: !OwningGrowableRoots
+  }
+
+multiStoreScanBoxedContentProjection ::
+  Mut α (Growable.GrowableVector V.Vector (Int, Int)) %1 ->
+  Mut α (Fixed.Vector V.Vector (Int, Int))
+{-# INLINE multiStoreScanBoxedContentProjection #-}
+multiStoreScanBoxedContentProjection = Growable.getContents
+
+multiStoreScanUnboxedContentProjection ::
+  Mut α (Growable.GrowableVector U.Vector Int) %1 ->
+  Mut α (Fixed.Vector U.Vector Int)
+{-# INLINE multiStoreScanUnboxedContentProjection #-}
+multiStoreScanUnboxedContentProjection = Growable.getContents
+
+multiStoreScanNodeCount :: Int
+multiStoreScanNodeCount = 4096
+
+multiStoreScanDirectInput :: MultiStoreScanInput
+multiStoreScanDirectInput =
+  MultiStoreScanInput
+    { inputNext = U.generate multiStoreScanNodeCount \index -> (index + 1) `rem` multiStoreScanNodeCount
+    , inputWeight = U.generate multiStoreScanNodeCount \index -> (index * 17 + 3) `rem` 101
+    , inputMark = U.replicate multiStoreScanNodeCount 0
+    , inputPayload =
+        V.generate multiStoreScanNodeCount \index ->
+          (index `rem` 7, index `rem` 13)
+    , inputScore = U.generate multiStoreScanNodeCount \index -> (index * 5 + 11) `rem` 97
+    , inputLink = U.replicate multiStoreScanNodeCount 0
+    }
+
+validateInput :: MultiStoreScanInput -> Int
+{-# NOINLINE validateInput #-}
+validateInput input
+  | U.length (inputNext input)
+      == multiStoreScanNodeCount
+      && U.length (inputWeight input)
+        == multiStoreScanNodeCount
+      && U.length (inputMark input)
+        == multiStoreScanNodeCount
+      && V.length (inputPayload input)
+        == multiStoreScanNodeCount
+      && U.length (inputScore input)
+        == multiStoreScanNodeCount
+      && U.length (inputLink input)
+        == multiStoreScanNodeCount
+      && nextReads
+        == multiStoreScanNodeCount
+      && linkReads
+        == multiStoreScanNodeCount =
+      6 + nextReads + linkReads
+  | otherwise =
+      error
+        "multi-store scan requires six 4096-element vectors, in-range next indices, and zero links"
+  where
+    !nextReads =
+      U.foldl'
+        ( \count value ->
+            if value >= 0 && value < multiStoreScanNodeCount
+              then count + 1
+              else -multiStoreScanNodeCount
+        )
+        0
+        (inputNext input)
+    !linkReads =
+      U.foldl'
+        ( \count value ->
+            if value == 0
+              then count + 1
+              else -multiStoreScanNodeCount
+        )
+        0
+        (inputLink input)
+
+multiStoreScanDirectRoot :: MultiStoreScanInput -> MultiStoreScanResult
+{-# NOINLINE multiStoreScanDirectRoot #-}
+multiStoreScanDirectRoot input =
+  let !inputValidationReads = validateInput input
+   in runST do
+        next <- U.thaw (inputNext input)
+        weight <- U.thaw (inputWeight input)
+        mark <- U.thaw (inputMark input)
+        payloadBuffer <- V.thaw (inputPayload input)
+        scoreBuffer <- U.thaw (inputScore input)
+        linkBuffer <- U.thaw (inputLink input)
+
+        payloadHeader <- newSTRef (multiStoreScanNodeCount, payloadBuffer)
+        scoreHeader <- newSTRef (multiStoreScanNodeCount, scoreBuffer)
+        linkHeader <- newSTRef (multiStoreScanNodeCount, linkBuffer)
+        (_, payload) <- readSTRef payloadHeader
+        (_, score) <- readSTRef scoreHeader
+        (_, link) <- readSTRef linkHeader
+
+        trace <-
+          multiStoreScanTraceWorker
+            multiStoreScanNodeCount
+            0
+            0
+            emptyAccessTrace {traceHeaderReads = 3}
+            next
+            weight
+            mark
+            payload
+            score
+            link
+        frozenMarks <- U.unsafeFreeze mark
+        frozenScores <- U.unsafeFreeze score
+        let !digest =
+              digestVectors
+                (traceReadDigest trace)
+                frozenMarks
+                frozenScores
+        pure
+          MultiStoreScanResult
+            { resultSummary =
+                MultiStoreScanSummary
+                  { visitedNodes = traceVisitedNodes trace
+                  , elementReads = traceElementReads trace
+                  , elementWrites = traceElementWrites trace
+                  , headerReads = traceHeaderReads trace
+                  , validationReads = inputValidationReads
+                  , finalDigest = digest
+                  }
+            , resultVisitedIndices =
+                U.fromListN
+                  multiStoreScanNodeCount
+                  (reverse (traceVisitedIndicesRev trace))
+            , resultEvents =
+                V.fromListN
+                  (traceElementReads trace + traceElementWrites trace)
+                  (reverse (traceEventsRev trace))
+            , resultEventDigest = traceEventDigest trace
+            , resultMarks = frozenMarks
+            , resultScores = frozenScores
+            }
+
+emptyAccessTrace :: AccessTrace
+emptyAccessTrace =
+  AccessTrace
+    { traceVisitedIndicesRev = []
+    , traceEventsRev = []
+    , traceEventDigest = 1_469_598_103_934_665_603
+    , traceVisitedNodes = 0
+    , traceElementReads = 0
+    , traceElementWrites = 0
+    , traceHeaderReads = 0
+    , traceReadDigest = 0
+    }
+
+multiStoreScanTraceWorker ::
+  Int ->
+  Int ->
+  Int ->
+  AccessTrace ->
+  UM.MVector s Int ->
+  UM.MVector s Int ->
+  UM.MVector s Int ->
+  MV.MVector s (Int, Int) ->
+  UM.MVector s Int ->
+  UM.MVector s Int ->
+  ST s AccessTrace
+multiStoreScanTraceWorker !remaining !index !visits trace next weight mark payload score link
+  | remaining <= 0 = pure trace
+  | otherwise = do
+      nextIndex <- UM.unsafeRead next index
+      weightValue <- UM.unsafeRead weight index
+      markValue <- UM.unsafeRead mark index
+      (payloadTag, payloadDelta) <- MV.unsafeRead payload index
+      scoreValue <- UM.unsafeRead score index
+      linkValue <- UM.unsafeRead link index
+      let !shouldWrite =
+            (weightValue + scoreValue + payloadTag + visits) `rem` 5 == 0
+          !nextTrace =
+            recordTraceVisit
+              index
+              nextIndex
+              weightValue
+              markValue
+              payloadTag
+              payloadDelta
+              scoreValue
+              linkValue
+              shouldWrite
+              trace
+      if shouldWrite
+        then do
+          UM.unsafeWrite mark index (markValue + 1)
+          UM.unsafeWrite score index (scoreValue + payloadDelta + 1)
+        else pure ()
+      multiStoreScanTraceWorker
+        (remaining - 1)
+        ((nextIndex + linkValue) `rem` multiStoreScanNodeCount)
+        (visits + 1)
+        nextTrace
+        next
+        weight
+        mark
+        payload
+        score
+        link
+
+recordTraceVisit ::
+  Int ->
+  Int ->
+  Int ->
+  Int ->
+  Int ->
+  Int ->
+  Int ->
+  Int ->
+  Bool ->
+  AccessTrace ->
+  AccessTrace
+recordTraceVisit index nextIndex weightValue markValue payloadTag payloadDelta scoreValue linkValue shouldWrite trace =
+  let !readEvents =
+        [ ReadIntEvent NextStore index nextIndex
+        , ReadIntEvent WeightStore index weightValue
+        , ReadIntEvent MarkStore index markValue
+        , ReadPayloadEvent index payloadTag payloadDelta
+        , ReadIntEvent ScoreStore index scoreValue
+        , ReadIntEvent LinkStore index linkValue
+        ]
+      !writeEvents =
+        if shouldWrite
+          then
+            [ WriteIntEvent MarkStore index (markValue + 1)
+            , WriteIntEvent
+                ScoreStore
+                index
+                (scoreValue + payloadDelta + 1)
+            ]
+          else []
+      !events = readEvents <> writeEvents
+   in AccessTrace
+        { traceVisitedIndicesRev =
+            index : traceVisitedIndicesRev trace
+        , traceEventsRev =
+            List.foldl'
+              (flip (:))
+              (traceEventsRev trace)
+              events
+        , traceEventDigest =
+            List.foldl' hashTraceEvent (traceEventDigest trace) events
+        , traceVisitedNodes = traceVisitedNodes trace + 1
+        , traceElementReads = traceElementReads trace + 6
+        , traceElementWrites =
+            traceElementWrites trace + if shouldWrite then 2 else 0
+        , traceHeaderReads = traceHeaderReads trace
+        , traceReadDigest =
+            traceReadDigest trace
+              + fromIntegral
+                ( nextIndex
+                    + weightValue
+                    + markValue
+                    + payloadTag
+                    + payloadDelta
+                    + scoreValue
+                    + linkValue
+                )
+        }
+
+hashTraceEvent :: Int64 -> TraceEvent -> Int64
+hashTraceEvent digest event =
+  List.foldl' hashTraceWord digest case event of
+    ReadIntEvent store index value ->
+      [1, traceStoreCode store, index, value]
+    ReadPayloadEvent index tag delta ->
+      [2, index, tag, delta]
+    WriteIntEvent store index value ->
+      [3, traceStoreCode store, index, value]
+
+hashTraceWord :: Int64 -> Int -> Int64
+hashTraceWord digest value =
+  digest * 1_099_511_628_211 + fromIntegral value
+
+traceStoreCode :: TraceStore -> Int
+traceStoreCode = \case
+  NextStore -> 1
+  WeightStore -> 2
+  MarkStore -> 3
+  ScoreStore -> 4
+  LinkStore -> 5
+
+multiStoreScanDirectBenchmarkRoot ::
+  MultiStoreScanInput ->
+  MultiStoreScanOutput
+{-# NOINLINE multiStoreScanDirectBenchmarkRoot #-}
+multiStoreScanDirectBenchmarkRoot input =
+  validateInput input `seq` runST do
+    next <- U.thaw (inputNext input)
+    weight <- U.thaw (inputWeight input)
+    mark <- U.thaw (inputMark input)
+    payloadBuffer <- V.thaw (inputPayload input)
+    scoreBuffer <- U.thaw (inputScore input)
+    linkBuffer <- U.thaw (inputLink input)
+
+    payloadHeader <- newSTRef (multiStoreScanNodeCount, payloadBuffer)
+    scoreHeader <- newSTRef (multiStoreScanNodeCount, scoreBuffer)
+    linkHeader <- newSTRef (multiStoreScanNodeCount, linkBuffer)
+    (_, payload) <- readSTRef payloadHeader
+    (_, score) <- readSTRef scoreHeader
+    (_, link) <- readSTRef linkHeader
+
+    readDigest <-
+      multiStoreScanDirectWorker
+        multiStoreScanNodeCount
+        0
+        0
+        0
+        next
+        weight
+        mark
+        payload
+        score
+        link
+    frozenMarks <- U.unsafeFreeze mark
+    frozenScores <- U.unsafeFreeze score
+    pure
+      MultiStoreScanOutput
+        { outputDigest =
+            digestVectors readDigest frozenMarks frozenScores
+        , outputMarks = frozenMarks
+        , outputScores = frozenScores
+        }
+
+multiStoreScanDirectHeaderMatchedBenchmarkRoot ::
+  MultiStoreScanInput ->
+  MultiStoreScanOutput
+{-# NOINLINE multiStoreScanDirectHeaderMatchedBenchmarkRoot #-}
+multiStoreScanDirectHeaderMatchedBenchmarkRoot input =
+  validateInput input `seq` runST do
+    next <- U.thaw (inputNext input)
+    weight <- U.thaw (inputWeight input)
+    mark <- U.thaw (inputMark input)
+    payloadBuffer <- V.thaw (inputPayload input)
+    scoreBuffer <- U.thaw (inputScore input)
+    linkBuffer <- U.thaw (inputLink input)
+
+    payloadHeader <- newSTRef (multiStoreScanNodeCount, payloadBuffer)
+    scoreHeader <- newSTRef (multiStoreScanNodeCount, scoreBuffer)
+    linkHeader <- newSTRef (multiStoreScanNodeCount, linkBuffer)
+    payload <- readHeaderOpaque payloadHeader
+    score <- readHeaderOpaque scoreHeader
+    link <- readHeaderOpaque linkHeader
+
+    readDigest <-
+      multiStoreScanDirectWorker
+        multiStoreScanNodeCount
+        0
+        0
+        0
+        next
+        weight
+        mark
+        payload
+        score
+        link
+    frozenMarks <- U.unsafeFreeze mark
+    frozenScores <- U.unsafeFreeze score
+    pure
+      MultiStoreScanOutput
+        { outputDigest =
+            digestVectors readDigest frozenMarks frozenScores
+        , outputMarks = frozenMarks
+        , outputScores = frozenScores
+        }
+
+readHeaderOpaque :: STRef s (Int, vector) -> ST s vector
+{-# NOINLINE readHeaderOpaque #-}
+-- Keep the comparator's three header reads observable. If this helper inlines,
+-- GHC can cancel each locally allocated STRef against its read and turn the
+-- control back into the deliberately retained lower-bound root.
+readHeaderOpaque header = do
+  (_, vector) <- readSTRef header
+  pure vector
+
+multiStoreScanDirectWorker ::
+  Int ->
+  Int ->
+  Int ->
+  Int64 ->
+  UM.MVector s Int ->
+  UM.MVector s Int ->
+  UM.MVector s Int ->
+  MV.MVector s (Int, Int) ->
+  UM.MVector s Int ->
+  UM.MVector s Int ->
+  ST s Int64
+{-# NOINLINE multiStoreScanDirectWorker #-}
+multiStoreScanDirectWorker !remaining !index !visits !digest next weight mark payload score link
+  | remaining <= 0 = pure digest
+  | otherwise = do
+      nextIndex <- UM.unsafeRead next index
+      weightValue <- UM.unsafeRead weight index
+      markValue <- UM.unsafeRead mark index
+      (payloadTag, payloadDelta) <- MV.unsafeRead payload index
+      scoreValue <- UM.unsafeRead score index
+      linkValue <- UM.unsafeRead link index
+      let !shouldWrite =
+            (weightValue + scoreValue + payloadTag + visits) `rem` 5 == 0
+          !nextDigest =
+            digest
+              + fromIntegral
+                ( nextIndex
+                    + weightValue
+                    + markValue
+                    + payloadTag
+                    + payloadDelta
+                    + scoreValue
+                    + linkValue
+                )
+      if shouldWrite
+        then do
+          UM.unsafeWrite mark index (markValue + 1)
+          UM.unsafeWrite score index (scoreValue + payloadDelta + 1)
+        else pure ()
+      multiStoreScanDirectWorker
+        (remaining - 1)
+        ((nextIndex + linkValue) `rem` multiStoreScanNodeCount)
+        (visits + 1)
+        nextDigest
+        next
+        weight
+        mark
+        payload
+        score
+        link
+
+multiStoreScanPureBorrowOwningBenchmarkRoot ::
+  MultiStoreScanInput ->
+  MultiStoreScanOutput
+{-# NOINLINE multiStoreScanPureBorrowOwningBenchmarkRoot #-}
+multiStoreScanPureBorrowOwningBenchmarkRoot input =
+  validateInput input `seq`
+    unur
+      ( linearly \linear -> DataFlow.do
+          (allocationLinear, borrowLinear) <- dup linear
+          store <- newOwningMultiStore input allocationLinear
+          runBO borrowLinear Control.do
+            (storeBorrow, lender) <- borrowM store
+            (Ur digest, storeBorrow) <-
+              reborrowing storeBorrow \local -> Control.do
+                let %1 !(fixedRootBorrows, growableRootBorrows) =
+                      local
+                        .@ (owningFixedRootsField, owningGrowableRootsField)
+                let %1 !(nextBorrow, weightBorrow, markBorrow) =
+                      fixedRootBorrows
+                        .@ (owningNextField, owningWeightField, owningMarkField)
+                let %1 !(payloadBorrow, scoreBorrow, linkBorrow) =
+                      growableRootBorrows
+                        .@ (owningPayloadField, owningScoreField, owningLinkField)
+                let %1 !payloadContent =
+                      OwningBoxedGrowable.getContents payloadBorrow
+                let %1 !scoreContent =
+                      OwningUnboxedGrowable.getContents scoreBorrow
+                let %1 !linkContent =
+                      OwningUnboxedGrowable.getContents linkBorrow
+                ( Ur digest
+                  , nextBorrow
+                  , weightBorrow
+                  , markBorrow
+                  , payloadContent
+                  , scoreContent
+                  , linkContent
+                  ) <-
+                  multiStoreScanPureBorrowOwningWorker
+                    multiStoreScanNodeCount
+                    0
+                    0
+                    0
+                    nextBorrow
+                    weightBorrow
+                    markBorrow
+                    payloadContent
+                    scoreContent
+                    linkContent
+                let !(Ur _) = share nextBorrow
+                let !(Ur _) = share weightBorrow
+                let !(Ur _) = share markBorrow
+                let !(Ur _) = share payloadContent
+                let !(Ur _) = share scoreContent
+                let !(Ur _) = share linkContent
+                Control.pure (Ur digest)
+            let !(Ur _) = share storeBorrow
+            pureAfter
+              (finishOwningMultiStoreOutput digest (reclaim lender))
+      )
+
+multiStoreScanPureBorrowFixedUnrestrictedBenchmarkRoot ::
+  MultiStoreScanInput ->
+  MultiStoreScanOutput
+{-# NOINLINE multiStoreScanPureBorrowFixedUnrestrictedBenchmarkRoot #-}
+multiStoreScanPureBorrowFixedUnrestrictedBenchmarkRoot input =
+  validateInput input `seq`
+    unur
+      ( linearly \linear -> DataFlow.do
+          (allocationLinear, borrowLinear) <- dup linear
+          store <- newFixedUnrestrictedStore input allocationLinear
+          runBO borrowLinear Control.do
+            (storeBorrow, lender) <- borrowM store
+            (Ur digest, storeBorrow) <-
+              reborrowing storeBorrow \local -> Control.do
+                let %1 !(fixedRootBorrows, growableRootBorrows) =
+                      local
+                        .@ ( fixedUnrestrictedRootsField
+                           , fixedUnrestrictedGrowableRootsField
+                           )
+                let %1 !(nextBorrow, weightBorrow, markBorrow) =
+                      fixedRootBorrows .@ (nextField, weightField, markField)
+                let %1 !(payloadBorrow, scoreBorrow, linkBorrow) =
+                      growableRootBorrows
+                        .@ (owningPayloadField, owningScoreField, owningLinkField)
+                let %1 !payloadContent =
+                      OwningBoxedGrowable.getContents payloadBorrow
+                let %1 !scoreContent =
+                      OwningUnboxedGrowable.getContents scoreBorrow
+                let %1 !linkContent =
+                      OwningUnboxedGrowable.getContents linkBorrow
+                ( Ur digest
+                  , nextBorrow
+                  , weightBorrow
+                  , markBorrow
+                  , payloadContent
+                  , scoreContent
+                  , linkContent
+                  ) <-
+                  multiStoreScanPureBorrowFixedUnrestrictedWorker
+                    multiStoreScanNodeCount
+                    0
+                    0
+                    0
+                    nextBorrow
+                    weightBorrow
+                    markBorrow
+                    payloadContent
+                    scoreContent
+                    linkContent
+                let !(Ur _) = share nextBorrow
+                let !(Ur _) = share weightBorrow
+                let !(Ur _) = share markBorrow
+                let !(Ur _) = share payloadContent
+                let !(Ur _) = share scoreContent
+                let !(Ur _) = share linkContent
+                Control.pure (Ur digest)
+            let !(Ur _) = share storeBorrow
+            pureAfter
+              ( finishFixedUnrestrictedStoreOutput
+                  digest
+                  (reclaim lender)
+              )
+      )
+
+multiStoreScanPureBorrowOwningWorker ::
+  Int ->
+  Int ->
+  Int ->
+  Int64 ->
+  Mut α (OwningUnboxedFixed.Vector Int) %1 ->
+  Mut α (OwningUnboxedFixed.Vector Int) %1 ->
+  Mut α (OwningUnboxedFixed.Vector Int) %1 ->
+  Mut α (OwningBoxedFixed.Vector (Int, Int)) %1 ->
+  Mut α (OwningUnboxedFixed.Vector Int) %1 ->
+  Mut α (OwningUnboxedFixed.Vector Int) %1 ->
+  BO
+    α
+    ( Ur Int64
+    , Mut α (OwningUnboxedFixed.Vector Int)
+    , Mut α (OwningUnboxedFixed.Vector Int)
+    , Mut α (OwningUnboxedFixed.Vector Int)
+    , Mut α (OwningBoxedFixed.Vector (Int, Int))
+    , Mut α (OwningUnboxedFixed.Vector Int)
+    , Mut α (OwningUnboxedFixed.Vector Int)
+    )
+{-# NOINLINE multiStoreScanPureBorrowOwningWorker #-}
+multiStoreScanPureBorrowOwningWorker !remaining !index !visits !digest nextBorrow weightBorrow markBorrow payloadContent scoreContent linkContent
+  | remaining <= 0 =
+      Control.pure
+        ( Ur digest
+        , nextBorrow
+        , weightBorrow
+        , markBorrow
+        , payloadContent
+        , scoreContent
+        , linkContent
+        )
+  | otherwise = Control.do
+      (Ur nextIndex, nextBorrow) <-
+        OwningUnboxedFixed.copyAtMut index nextBorrow
+      (Ur weightValue, weightBorrow) <-
+        OwningUnboxedFixed.copyAtMut index weightBorrow
+      (Ur markValue, markBorrow) <-
+        OwningUnboxedFixed.copyAtMut index markBorrow
+      (Ur (payloadTag, payloadDelta), payloadContent) <-
+        OwningBoxedFixed.copyAtMut index payloadContent
+      (Ur scoreValue, scoreContent) <-
+        OwningUnboxedFixed.copyAtMut index scoreContent
+      (Ur linkValue, linkContent) <-
+        OwningUnboxedFixed.copyAtMut index linkContent
+      let !shouldWrite =
+            (weightValue + scoreValue + payloadTag + visits) `rem` 5 == 0
+          !nextDigest =
+            digest
+              + fromIntegral
+                ( nextIndex
+                    + weightValue
+                    + markValue
+                    + payloadTag
+                    + payloadDelta
+                    + scoreValue
+                    + linkValue
+                )
+      if shouldWrite
+        then Control.do
+          (oldMark, markBorrow) <-
+            OwningUnboxedFixed.unsafeSet
+              index
+              (markValue + 1)
+              markBorrow
+          (oldScore, scoreContent) <-
+            OwningUnboxedFixed.unsafeSet
+              index
+              (scoreValue + payloadDelta + 1)
+              scoreContent
+          multiStoreScanPureBorrowOwningWorker
+            (remaining - 1)
+            ((nextIndex + linkValue) `rem` multiStoreScanNodeCount)
+            (visits + 1)
+            nextDigest
+            nextBorrow
+            weightBorrow
+            (consume oldMark `lseq` markBorrow)
+            payloadContent
+            (consume oldScore `lseq` scoreContent)
+            linkContent
+        else
+          multiStoreScanPureBorrowOwningWorker
+            (remaining - 1)
+            ((nextIndex + linkValue) `rem` multiStoreScanNodeCount)
+            (visits + 1)
+            nextDigest
+            nextBorrow
+            weightBorrow
+            markBorrow
+            payloadContent
+            scoreContent
+            linkContent
+
+multiStoreScanPureBorrowFixedUnrestrictedWorker ::
+  Int ->
+  Int ->
+  Int ->
+  Int64 ->
+  Mut α (Fixed.Vector U.Vector Int) %1 ->
+  Mut α (Fixed.Vector U.Vector Int) %1 ->
+  Mut α (Fixed.Vector U.Vector Int) %1 ->
+  Mut α (OwningBoxedFixed.Vector (Int, Int)) %1 ->
+  Mut α (OwningUnboxedFixed.Vector Int) %1 ->
+  Mut α (OwningUnboxedFixed.Vector Int) %1 ->
+  BO
+    α
+    ( Ur Int64
+    , Mut α (Fixed.Vector U.Vector Int)
+    , Mut α (Fixed.Vector U.Vector Int)
+    , Mut α (Fixed.Vector U.Vector Int)
+    , Mut α (OwningBoxedFixed.Vector (Int, Int))
+    , Mut α (OwningUnboxedFixed.Vector Int)
+    , Mut α (OwningUnboxedFixed.Vector Int)
+    )
+{-# NOINLINE multiStoreScanPureBorrowFixedUnrestrictedWorker #-}
+multiStoreScanPureBorrowFixedUnrestrictedWorker !remaining !index !visits !digest nextBorrow weightBorrow markBorrow payloadContent scoreContent linkContent
+  | remaining <= 0 =
+      Control.pure
+        ( Ur digest
+        , nextBorrow
+        , weightBorrow
+        , markBorrow
+        , payloadContent
+        , scoreContent
+        , linkContent
+        )
+  | otherwise = Control.do
+      (Ur nextIndex, nextBorrow) <-
+        Fixed.unsafeGet index nextBorrow
+      (Ur weightValue, weightBorrow) <-
+        Fixed.unsafeGet index weightBorrow
+      (Ur markValue, markBorrow) <-
+        Fixed.unsafeGet index markBorrow
+      (Ur (payloadTag, payloadDelta), payloadContent) <-
+        OwningBoxedFixed.copyAtMut index payloadContent
+      (Ur scoreValue, scoreContent) <-
+        OwningUnboxedFixed.copyAtMut index scoreContent
+      (Ur linkValue, linkContent) <-
+        OwningUnboxedFixed.copyAtMut index linkContent
+      let !shouldWrite =
+            (weightValue + scoreValue + payloadTag + visits) `rem` 5 == 0
+          !nextDigest =
+            digest
+              + fromIntegral
+                ( nextIndex
+                    + weightValue
+                    + markValue
+                    + payloadTag
+                    + payloadDelta
+                    + scoreValue
+                    + linkValue
+                )
+      if shouldWrite
+        then Control.do
+          markBorrow <-
+            Fixed.unsafeWrite index (markValue + 1) markBorrow
+          (oldScore, scoreContent) <-
+            OwningUnboxedFixed.unsafeSet
+              index
+              (scoreValue + payloadDelta + 1)
+              scoreContent
+          multiStoreScanPureBorrowFixedUnrestrictedWorker
+            (remaining - 1)
+            ((nextIndex + linkValue) `rem` multiStoreScanNodeCount)
+            (visits + 1)
+            nextDigest
+            nextBorrow
+            weightBorrow
+            markBorrow
+            payloadContent
+            (consume oldScore `lseq` scoreContent)
+            linkContent
+        else
+          multiStoreScanPureBorrowFixedUnrestrictedWorker
+            (remaining - 1)
+            ((nextIndex + linkValue) `rem` multiStoreScanNodeCount)
+            (visits + 1)
+            nextDigest
+            nextBorrow
+            weightBorrow
+            markBorrow
+            payloadContent
+            scoreContent
+            linkContent
+
+multiStoreScanPureBorrowDirectBenchmarkRoot ::
+  MultiStoreScanInput ->
+  MultiStoreScanOutput
+{-# NOINLINE multiStoreScanPureBorrowDirectBenchmarkRoot #-}
+multiStoreScanPureBorrowDirectBenchmarkRoot input =
+  validateInput input `seq`
+    unur
+      ( linearly \linear -> DataFlow.do
+          (allocationLinear, borrowLinear) <- dup linear
+          store <- newMultiStore input allocationLinear
+          runBO borrowLinear Control.do
+            (storeBorrow, lender) <- borrowM store
+            (Ur digest, storeBorrow) <-
+              reborrowing storeBorrow \local -> Control.do
+                let %1 !(fixedRootBorrows, growableRootBorrows) =
+                      local .@ (fixedRootsField, growableRootsField)
+                let %1 !(nextBorrow, weightBorrow, markBorrow) =
+                      fixedRootBorrows .@ (nextField, weightField, markField)
+                let %1 !(payloadBorrow, scoreBorrow, linkBorrow) =
+                      growableRootBorrows .@ (payloadField, scoreField, linkField)
+                let %1 !payloadContent = Growable.getContents payloadBorrow
+                let %1 !scoreContent = Growable.getContents scoreBorrow
+                let %1 !linkContent = Growable.getContents linkBorrow
+                ( Ur digest
+                  , nextBorrow
+                  , weightBorrow
+                  , markBorrow
+                  , payloadContent
+                  , scoreContent
+                  , linkContent
+                  ) <-
+                  multiStoreScanPureBorrowWorker
+                    multiStoreScanNodeCount
+                    0
+                    0
+                    0
+                    nextBorrow
+                    weightBorrow
+                    markBorrow
+                    payloadContent
+                    scoreContent
+                    linkContent
+                let !() =
+                      consumeViews
+                        nextBorrow
+                        weightBorrow
+                        markBorrow
+                        payloadContent
+                        scoreContent
+                        linkContent
+                Control.pure (Ur digest)
+            let !(Ur _) = share storeBorrow
+            pureAfter (finishMultiStoreOutput digest (reclaim lender))
+      )
+
+multiStoreScanPureBorrowNestedBenchmarkRoot ::
+  MultiStoreScanInput ->
+  MultiStoreScanOutput
+{-# NOINLINE multiStoreScanPureBorrowNestedBenchmarkRoot #-}
+multiStoreScanPureBorrowNestedBenchmarkRoot input =
+  validateInput input `seq`
+    unur
+      ( linearly \linear -> DataFlow.do
+          (allocationLinear, borrowLinear) <- dup linear
+          store <- newMultiStore input allocationLinear
+          runBO borrowLinear Control.do
+            (storeBorrow, lender) <- borrowM store
+            (Ur digest, storeBorrow) <-
+              reborrowing storeBorrow \local -> Control.do
+                let %1 !(fixedRootBorrows, growableRootBorrows) =
+                      local .@ (fixedRootsField, growableRootsField)
+                let %1 !(nextBorrow, weightBorrow, markBorrow) =
+                      fixedRootBorrows .@ (nextField, weightField, markField)
+                let %1 !(payloadBorrow, scoreBorrow, linkBorrow) =
+                      growableRootBorrows .@ (payloadField, scoreField, linkField)
+                (Ur digest, fields) <-
+                  reborrowings
+                    ( nextBorrow
+                        :- weightBorrow
+                        :- markBorrow
+                        :- payloadBorrow
+                        :- scoreBorrow
+                        :- linkBorrow
+                        :- BNil
+                    )
+                    \case
+                      nextBorrow
+                        :- weightBorrow
+                        :- markBorrow
+                        :- payloadBorrow
+                        :- scoreBorrow
+                        :- linkBorrow
+                        :- BNil -> Control.do
+                          let %1 !payloadContent =
+                                Growable.getContents payloadBorrow
+                          let %1 !scoreContent =
+                                Growable.getContents scoreBorrow
+                          let %1 !linkContent =
+                                Growable.getContents linkBorrow
+                          ( Ur digest
+                            , nextBorrow
+                            , weightBorrow
+                            , markBorrow
+                            , payloadContent
+                            , scoreContent
+                            , linkContent
+                            ) <-
+                            multiStoreScanPureBorrowWorker
+                              multiStoreScanNodeCount
+                              0
+                              0
+                              0
+                              nextBorrow
+                              weightBorrow
+                              markBorrow
+                              payloadContent
+                              scoreContent
+                              linkContent
+                          let !() =
+                                consumeViews
+                                  nextBorrow
+                                  weightBorrow
+                                  markBorrow
+                                  payloadContent
+                                  scoreContent
+                                  linkContent
+                          Control.pure (Ur digest)
+                let !() = consume fields
+                Control.pure (Ur digest)
+            let !(Ur _) = share storeBorrow
+            pureAfter (finishMultiStoreOutput digest (reclaim lender))
+      )
+
+multiStoreScanPureBorrowDirectRoot ::
+  MultiStoreScanInput ->
+  MultiStoreScanResult
+{-# NOINLINE multiStoreScanPureBorrowDirectRoot #-}
+multiStoreScanPureBorrowDirectRoot input =
+  let !inputValidationReads = validateInput input
+   in unur
+        ( linearly \linear -> DataFlow.do
+            (allocationLinear, borrowLinear) <- dup linear
+            store <- newMultiStore input allocationLinear
+            runBO borrowLinear Control.do
+              (storeBorrow, lender) <- borrowM store
+              (Ur trace, storeBorrow) <-
+                reborrowing storeBorrow \local -> Control.do
+                  let %1 !(fixedRootBorrows, growableRootBorrows) =
+                        local .@ (fixedRootsField, growableRootsField)
+                  let %1 !(nextBorrow, weightBorrow, markBorrow) =
+                        fixedRootBorrows .@ (nextField, weightField, markField)
+                  let %1 !(payloadBorrow, scoreBorrow, linkBorrow) =
+                        growableRootBorrows .@ (payloadField, scoreField, linkField)
+                  let %1 !payloadContent = Growable.getContents payloadBorrow
+                  let %1 !scoreContent = Growable.getContents scoreBorrow
+                  let %1 !linkContent = Growable.getContents linkBorrow
+                  ( Ur trace
+                    , nextBorrow
+                    , weightBorrow
+                    , markBorrow
+                    , payloadContent
+                    , scoreContent
+                    , linkContent
+                    ) <-
+                    multiStoreScanPureBorrowTraceWorker
+                      multiStoreScanNodeCount
+                      0
+                      0
+                      emptyAccessTrace {traceHeaderReads = 3}
+                      nextBorrow
+                      weightBorrow
+                      markBorrow
+                      payloadContent
+                      scoreContent
+                      linkContent
+                  let !() =
+                        consumeViews
+                          nextBorrow
+                          weightBorrow
+                          markBorrow
+                          payloadContent
+                          scoreContent
+                          linkContent
+                  Control.pure (Ur trace)
+              let !(Ur _) = share storeBorrow
+              pureAfter
+                ( finishMultiStoreResult
+                    inputValidationReads
+                    trace
+                    (reclaim lender)
+                )
+        )
+
+multiStoreScanPureBorrowNestedRoot ::
+  MultiStoreScanInput ->
+  MultiStoreScanResult
+{-# NOINLINE multiStoreScanPureBorrowNestedRoot #-}
+multiStoreScanPureBorrowNestedRoot input =
+  let !inputValidationReads = validateInput input
+   in unur
+        ( linearly \linear -> DataFlow.do
+            (allocationLinear, borrowLinear) <- dup linear
+            store <- newMultiStore input allocationLinear
+            runBO borrowLinear Control.do
+              (storeBorrow, lender) <- borrowM store
+              (Ur trace, storeBorrow) <-
+                reborrowing storeBorrow \local -> Control.do
+                  let %1 !(fixedRootBorrows, growableRootBorrows) =
+                        local .@ (fixedRootsField, growableRootsField)
+                  let %1 !(nextBorrow, weightBorrow, markBorrow) =
+                        fixedRootBorrows .@ (nextField, weightField, markField)
+                  let %1 !(payloadBorrow, scoreBorrow, linkBorrow) =
+                        growableRootBorrows .@ (payloadField, scoreField, linkField)
+                  (Ur trace, fields) <-
+                    reborrowings
+                      ( nextBorrow
+                          :- weightBorrow
+                          :- markBorrow
+                          :- payloadBorrow
+                          :- scoreBorrow
+                          :- linkBorrow
+                          :- BNil
+                      )
+                      \case
+                        nextBorrow
+                          :- weightBorrow
+                          :- markBorrow
+                          :- payloadBorrow
+                          :- scoreBorrow
+                          :- linkBorrow
+                          :- BNil -> Control.do
+                            let %1 !payloadContent =
+                                  Growable.getContents payloadBorrow
+                            let %1 !scoreContent =
+                                  Growable.getContents scoreBorrow
+                            let %1 !linkContent =
+                                  Growable.getContents linkBorrow
+                            ( Ur trace
+                              , nextBorrow
+                              , weightBorrow
+                              , markBorrow
+                              , payloadContent
+                              , scoreContent
+                              , linkContent
+                              ) <-
+                              multiStoreScanPureBorrowTraceWorker
+                                multiStoreScanNodeCount
+                                0
+                                0
+                                emptyAccessTrace {traceHeaderReads = 3}
+                                nextBorrow
+                                weightBorrow
+                                markBorrow
+                                payloadContent
+                                scoreContent
+                                linkContent
+                            let !() =
+                                  consumeViews
+                                    nextBorrow
+                                    weightBorrow
+                                    markBorrow
+                                    payloadContent
+                                    scoreContent
+                                    linkContent
+                            Control.pure (Ur trace)
+                  let !() = consume fields
+                  Control.pure (Ur trace)
+              let !(Ur _) = share storeBorrow
+              pureAfter
+                ( finishMultiStoreResult
+                    inputValidationReads
+                    trace
+                    (reclaim lender)
+                )
+        )
+
+multiStoreScanPureBorrowWorker ::
+  Int ->
+  Int ->
+  Int ->
+  Int64 ->
+  Mut α (Fixed.Vector U.Vector Int) %1 ->
+  Mut α (Fixed.Vector U.Vector Int) %1 ->
+  Mut α (Fixed.Vector U.Vector Int) %1 ->
+  Mut α (Fixed.Vector V.Vector (Int, Int)) %1 ->
+  Mut α (Fixed.Vector U.Vector Int) %1 ->
+  Mut α (Fixed.Vector U.Vector Int) %1 ->
+  BO
+    α
+    ( Ur Int64
+    , Mut α (Fixed.Vector U.Vector Int)
+    , Mut α (Fixed.Vector U.Vector Int)
+    , Mut α (Fixed.Vector U.Vector Int)
+    , Mut α (Fixed.Vector V.Vector (Int, Int))
+    , Mut α (Fixed.Vector U.Vector Int)
+    , Mut α (Fixed.Vector U.Vector Int)
+    )
+{-# INLINEABLE multiStoreScanPureBorrowWorker #-}
+multiStoreScanPureBorrowWorker !remaining !index !visits !digest nextBorrow weightBorrow markBorrow payloadContent scoreContent linkContent =
+  -- An ordinary strict Int64 accumulator is still rebuilt as I64# at every
+  -- recursive call because the BO result also returns six linear borrows.
+  -- Entering an explicitly unboxed local loop keeps the accumulator in
+  -- Int64# until the single ownership boundary below.
+  case digest of
+    I64# digest# ->
+      go
+        remaining
+        index
+        visits
+        digest#
+        nextBorrow
+        weightBorrow
+        markBorrow
+        payloadContent
+        scoreContent
+        linkContent
+  where
+    go ::
+      Int ->
+      Int ->
+      Int ->
+      GHC.Int64# ->
+      Mut α (Fixed.Vector U.Vector Int) %1 ->
+      Mut α (Fixed.Vector U.Vector Int) %1 ->
+      Mut α (Fixed.Vector U.Vector Int) %1 ->
+      Mut α (Fixed.Vector V.Vector (Int, Int)) %1 ->
+      Mut α (Fixed.Vector U.Vector Int) %1 ->
+      Mut α (Fixed.Vector U.Vector Int) %1 ->
+      BO
+        α
+        ( Ur Int64
+        , Mut α (Fixed.Vector U.Vector Int)
+        , Mut α (Fixed.Vector U.Vector Int)
+        , Mut α (Fixed.Vector U.Vector Int)
+        , Mut α (Fixed.Vector V.Vector (Int, Int))
+        , Mut α (Fixed.Vector U.Vector Int)
+        , Mut α (Fixed.Vector U.Vector Int)
+        )
+    go !remaining !index !visits digest# nextBorrow weightBorrow markBorrow payloadContent scoreContent linkContent
+      | remaining <= 0 =
+          Control.pure
+            ( Ur (I64# digest#)
+            , nextBorrow
+            , weightBorrow
+            , markBorrow
+            , payloadContent
+            , scoreContent
+            , linkContent
+            )
+      | otherwise = Control.do
+          (Ur nextIndex, nextBorrow) <-
+            Fixed.unsafeGet index nextBorrow
+          (Ur weightValue, weightBorrow) <-
+            Fixed.unsafeGet index weightBorrow
+          (Ur markValue, markBorrow) <-
+            Fixed.unsafeGet index markBorrow
+          (Ur (payloadTag, payloadDelta), payloadContent) <-
+            Fixed.unsafeGet index payloadContent
+          (Ur scoreValue, scoreContent) <-
+            Fixed.unsafeGet index scoreContent
+          (Ur linkValue, linkContent) <-
+            Fixed.unsafeGet index linkContent
+          let !shouldWrite =
+                (weightValue + scoreValue + payloadTag + visits) `rem` 5 == 0
+              !nextDigest =
+                I64# digest#
+                  + fromIntegral
+                    ( nextIndex
+                        + weightValue
+                        + markValue
+                        + payloadTag
+                        + payloadDelta
+                        + scoreValue
+                        + linkValue
+                    )
+          case nextDigest of
+            I64# nextDigest# ->
+              if shouldWrite
+                then Control.do
+                  markBorrow <-
+                    Fixed.unsafeWrite index (markValue + 1) markBorrow
+                  scoreContent <-
+                    Fixed.unsafeWrite
+                      index
+                      (scoreValue + payloadDelta + 1)
+                      scoreContent
+                  go
+                    (remaining - 1)
+                    ((nextIndex + linkValue) `rem` multiStoreScanNodeCount)
+                    (visits + 1)
+                    nextDigest#
+                    nextBorrow
+                    weightBorrow
+                    markBorrow
+                    payloadContent
+                    scoreContent
+                    linkContent
+                else
+                  go
+                    (remaining - 1)
+                    ((nextIndex + linkValue) `rem` multiStoreScanNodeCount)
+                    (visits + 1)
+                    nextDigest#
+                    nextBorrow
+                    weightBorrow
+                    markBorrow
+                    payloadContent
+                    scoreContent
+                    linkContent
+
+multiStoreScanPureBorrowTraceWorker ::
+  Int ->
+  Int ->
+  Int ->
+  AccessTrace ->
+  Mut α (Fixed.Vector U.Vector Int) %1 ->
+  Mut α (Fixed.Vector U.Vector Int) %1 ->
+  Mut α (Fixed.Vector U.Vector Int) %1 ->
+  Mut α (Fixed.Vector V.Vector (Int, Int)) %1 ->
+  Mut α (Fixed.Vector U.Vector Int) %1 ->
+  Mut α (Fixed.Vector U.Vector Int) %1 ->
+  BO
+    α
+    ( Ur AccessTrace
+    , Mut α (Fixed.Vector U.Vector Int)
+    , Mut α (Fixed.Vector U.Vector Int)
+    , Mut α (Fixed.Vector U.Vector Int)
+    , Mut α (Fixed.Vector V.Vector (Int, Int))
+    , Mut α (Fixed.Vector U.Vector Int)
+    , Mut α (Fixed.Vector U.Vector Int)
+    )
+{-# NOINLINE multiStoreScanPureBorrowTraceWorker #-}
+multiStoreScanPureBorrowTraceWorker !remaining !index !visits !trace nextBorrow weightBorrow markBorrow payloadContent scoreContent linkContent
+  | remaining <= 0 =
+      Control.pure
+        ( Ur trace
+        , nextBorrow
+        , weightBorrow
+        , markBorrow
+        , payloadContent
+        , scoreContent
+        , linkContent
+        )
+  | otherwise = Control.do
+      (Ur nextIndex, nextBorrow) <-
+        Fixed.unsafeGet index nextBorrow
+      (Ur weightValue, weightBorrow) <-
+        Fixed.unsafeGet index weightBorrow
+      (Ur markValue, markBorrow) <-
+        Fixed.unsafeGet index markBorrow
+      (Ur (payloadTag, payloadDelta), payloadContent) <-
+        Fixed.unsafeGet index payloadContent
+      (Ur scoreValue, scoreContent) <-
+        Fixed.unsafeGet index scoreContent
+      (Ur linkValue, linkContent) <-
+        Fixed.unsafeGet index linkContent
+      let !shouldWrite =
+            (weightValue + scoreValue + payloadTag + visits) `rem` 5 == 0
+          !nextTrace =
+            recordTraceVisit
+              index
+              nextIndex
+              weightValue
+              markValue
+              payloadTag
+              payloadDelta
+              scoreValue
+              linkValue
+              shouldWrite
+              trace
+      if shouldWrite
+        then Control.do
+          markBorrow <-
+            Fixed.unsafeWrite index (markValue + 1) markBorrow
+          scoreContent <-
+            Fixed.unsafeWrite
+              index
+              (scoreValue + payloadDelta + 1)
+              scoreContent
+          multiStoreScanPureBorrowTraceWorker
+            (remaining - 1)
+            ((nextIndex + linkValue) `rem` multiStoreScanNodeCount)
+            (visits + 1)
+            nextTrace
+            nextBorrow
+            weightBorrow
+            markBorrow
+            payloadContent
+            scoreContent
+            linkContent
+        else
+          multiStoreScanPureBorrowTraceWorker
+            (remaining - 1)
+            ((nextIndex + linkValue) `rem` multiStoreScanNodeCount)
+            (visits + 1)
+            nextTrace
+            nextBorrow
+            weightBorrow
+            markBorrow
+            payloadContent
+            scoreContent
+            linkContent
+
+consumeViews ::
+  Mut α (Fixed.Vector U.Vector Int) %1 ->
+  Mut α (Fixed.Vector U.Vector Int) %1 ->
+  Mut α (Fixed.Vector U.Vector Int) %1 ->
+  Mut α (Fixed.Vector V.Vector (Int, Int)) %1 ->
+  Mut α (Fixed.Vector U.Vector Int) %1 ->
+  Mut α (Fixed.Vector U.Vector Int) %1 ->
+  ()
+consumeViews nextBorrow weightBorrow markBorrow payloadContent scoreContent linkContent =
+  let !(Ur _) = share nextBorrow
+      !(Ur _) = share weightBorrow
+      !(Ur _) = share markBorrow
+      !(Ur _) = share payloadContent
+      !(Ur _) = share scoreContent
+      !(Ur _) = share linkContent
+   in ()
+
+newOwningMultiStore ::
+  MultiStoreScanInput ->
+  Linearly %1 ->
+  OwningMultiStore
+{-# NOINLINE newOwningMultiStore #-}
+newOwningMultiStore =
+  GHC.noinline \input linear ->
+    dup linear & \(nextLinear, rest1) ->
+      dup rest1 & \(weightLinear, rest2) ->
+        dup rest2 & \(markLinear, rest3) ->
+          dup rest3 & \(payloadLinear, rest4) ->
+            dup rest4 & \(scoreLinear, linkLinear) ->
+              OwningMultiStore
+                { owningFixedRoots =
+                    OwningFixedRoots
+                      { owningNext =
+                          OwningUnboxedFixed.fromVector
+                            (inputNext input)
+                            nextLinear
+                      , owningWeight =
+                          OwningUnboxedFixed.fromVector
+                            (inputWeight input)
+                            weightLinear
+                      , owningMark =
+                          OwningUnboxedFixed.fromVector
+                            (inputMark input)
+                            markLinear
+                      }
+                , owningGrowableRoots =
+                    OwningGrowableRoots
+                      { owningPayload =
+                          OwningBoxedGrowable.fromVector
+                            (inputPayload input)
+                            payloadLinear
+                      , owningScore =
+                          OwningUnboxedGrowable.fromVector
+                            (inputScore input)
+                            scoreLinear
+                      , owningLink =
+                          OwningUnboxedGrowable.fromVector
+                            (inputLink input)
+                            linkLinear
+                      }
+                }
+
+newFixedUnrestrictedStore ::
+  MultiStoreScanInput ->
+  Linearly %1 ->
+  FixedUnrestrictedStore
+{-# NOINLINE newFixedUnrestrictedStore #-}
+newFixedUnrestrictedStore =
+  GHC.noinline \input linear ->
+    dup linear & \(nextLinear, rest1) ->
+      dup rest1 & \(weightLinear, rest2) ->
+        dup rest2 & \(markLinear, rest3) ->
+          dup rest3 & \(payloadLinear, rest4) ->
+            dup rest4 & \(scoreLinear, linkLinear) ->
+              FixedUnrestrictedStore
+                { fixedUnrestrictedRoots =
+                    FixedRoots
+                      { next =
+                          Fixed.fromVector
+                            (inputNext input)
+                            nextLinear
+                      , weight =
+                          Fixed.fromVector
+                            (inputWeight input)
+                            weightLinear
+                      , mark =
+                          Fixed.fromVector
+                            (inputMark input)
+                            markLinear
+                      }
+                , fixedUnrestrictedGrowableRoots =
+                    OwningGrowableRoots
+                      { owningPayload =
+                          OwningBoxedGrowable.fromVector
+                            (inputPayload input)
+                            payloadLinear
+                      , owningScore =
+                          OwningUnboxedGrowable.fromVector
+                            (inputScore input)
+                            scoreLinear
+                      , owningLink =
+                          OwningUnboxedGrowable.fromVector
+                            (inputLink input)
+                            linkLinear
+                      }
+                }
+
+newMultiStore :: MultiStoreScanInput -> Linearly %1 -> MultiStore
+{-# NOINLINE newMultiStore #-}
+newMultiStore =
+  GHC.noinline \input linear ->
+    dup linear & \(nextLinear, rest1) ->
+      dup rest1 & \(weightLinear, rest2) ->
+        dup rest2 & \(markLinear, rest3) ->
+          dup rest3 & \(payloadLinear, rest4) ->
+            dup rest4 & \(scoreLinear, linkLinear) ->
+              MultiStore
+                { fixedRoots =
+                    FixedRoots
+                      { next =
+                          Fixed.fromVector
+                            (inputNext input)
+                            nextLinear
+                      , weight =
+                          Fixed.fromVector
+                            (inputWeight input)
+                            weightLinear
+                      , mark =
+                          Fixed.fromVector
+                            (inputMark input)
+                            markLinear
+                      }
+                , growableRoots =
+                    GrowableRoots
+                      { payload =
+                          Growable.fromVector
+                            (inputPayload input)
+                            payloadLinear
+                      , score =
+                          Growable.fromVector
+                            (inputScore input)
+                            scoreLinear
+                      , link =
+                          Growable.fromVector
+                            (inputLink input)
+                            linkLinear
+                      }
+                }
+
+finishOwningMultiStoreOutput ::
+  Int64 ->
+  OwningMultiStore %1 ->
+  Ur MultiStoreScanOutput
+{-# NOINLINE finishOwningMultiStoreOutput #-}
+finishOwningMultiStoreOutput
+  digest
+  ( OwningMultiStore
+      (OwningFixedRoots nextOwner weightOwner markOwner)
+      (OwningGrowableRoots payloadOwner scoreOwner linkOwner)
+    ) =
+    case OwningUnboxedFixed.toVector nextOwner of
+      Ur nextVector ->
+        case OwningUnboxedFixed.toVector weightOwner of
+          Ur weightVector ->
+            case OwningUnboxedFixed.toVector markOwner of
+              Ur markVector ->
+                case OwningBoxedGrowable.toVector payloadOwner of
+                  Ur payloadVector ->
+                    case OwningUnboxedGrowable.toVector scoreOwner of
+                      Ur scoreVector ->
+                        case OwningUnboxedGrowable.toVector linkOwner of
+                          Ur linkVector ->
+                            U.length nextVector `lseq`
+                              U.length weightVector `lseq`
+                                V.length payloadVector `lseq`
+                                  U.length linkVector `lseq`
+                                    Ur
+                                      MultiStoreScanOutput
+                                        { outputDigest =
+                                            digestVectors
+                                              digest
+                                              markVector
+                                              scoreVector
+                                        , outputMarks = markVector
+                                        , outputScores = scoreVector
+                                        }
+
+finishFixedUnrestrictedStoreOutput ::
+  Int64 ->
+  FixedUnrestrictedStore %1 ->
+  Ur MultiStoreScanOutput
+{-# NOINLINE finishFixedUnrestrictedStoreOutput #-}
+finishFixedUnrestrictedStoreOutput
+  digest
+  ( FixedUnrestrictedStore
+      (FixedRoots nextOwner weightOwner markOwner)
+      (OwningGrowableRoots payloadOwner scoreOwner linkOwner)
+    ) =
+    case Fixed.toVector nextOwner of
+      Ur nextVector ->
+        case Fixed.toVector weightOwner of
+          Ur weightVector ->
+            case Fixed.toVector markOwner of
+              Ur markVector ->
+                case OwningBoxedGrowable.toVector payloadOwner of
+                  Ur payloadVector ->
+                    case OwningUnboxedGrowable.toVector scoreOwner of
+                      Ur scoreVector ->
+                        case OwningUnboxedGrowable.toVector linkOwner of
+                          Ur linkVector ->
+                            U.length nextVector `lseq`
+                              U.length weightVector `lseq`
+                                V.length payloadVector `lseq`
+                                  U.length linkVector `lseq`
+                                    Ur
+                                      MultiStoreScanOutput
+                                        { outputDigest =
+                                            digestVectors
+                                              digest
+                                              markVector
+                                              scoreVector
+                                        , outputMarks = markVector
+                                        , outputScores = scoreVector
+                                        }
+
+finishMultiStoreOutput ::
+  Int64 ->
+  MultiStore %1 ->
+  Ur MultiStoreScanOutput
+{-# NOINLINE finishMultiStoreOutput #-}
+finishMultiStoreOutput
+  digest
+  ( MultiStore
+      (FixedRoots nextOwner weightOwner markOwner)
+      (GrowableRoots payloadOwner scoreOwner linkOwner)
+    ) =
+    case Fixed.toVector nextOwner of
+      Ur nextVector ->
+        case Fixed.toVector weightOwner of
+          Ur weightVector ->
+            case Fixed.toVector markOwner of
+              Ur markVector ->
+                case Growable.toVector payloadOwner of
+                  Ur payloadVector ->
+                    case Growable.toVector scoreOwner of
+                      Ur scoreVector ->
+                        case Growable.toVector linkOwner of
+                          Ur linkVector ->
+                            U.length nextVector `lseq`
+                              U.length weightVector `lseq`
+                                V.length payloadVector `lseq`
+                                  U.length linkVector `lseq`
+                                    Ur
+                                      MultiStoreScanOutput
+                                        { outputDigest =
+                                            digestVectors
+                                              digest
+                                              markVector
+                                              scoreVector
+                                        , outputMarks = markVector
+                                        , outputScores = scoreVector
+                                        }
+
+finishMultiStoreResult ::
+  Int ->
+  AccessTrace ->
+  MultiStore %1 ->
+  Ur MultiStoreScanResult
+finishMultiStoreResult inputValidationReads trace store =
+  case finishMultiStoreOutput (traceReadDigest trace) store of
+    Ur output ->
+      Ur
+        MultiStoreScanResult
+          { resultSummary =
+              MultiStoreScanSummary
+                { visitedNodes = traceVisitedNodes trace
+                , elementReads = traceElementReads trace
+                , elementWrites = traceElementWrites trace
+                , headerReads = traceHeaderReads trace
+                , validationReads = inputValidationReads
+                , finalDigest = outputDigest output
+                }
+          , resultVisitedIndices =
+              U.fromListN
+                multiStoreScanNodeCount
+                (reverse (traceVisitedIndicesRev trace))
+          , resultEvents =
+              V.fromListN
+                (traceElementReads trace + traceElementWrites trace)
+                (reverse (traceEventsRev trace))
+          , resultEventDigest = traceEventDigest trace
+          , resultMarks = outputMarks output
+          , resultScores = outputScores output
+          }
+
+owningFixedRootsField ::
+  RecordLabel
+    OwningMultiStore
+    "owningFixedRoots"
+    OwningFixedRoots
+owningFixedRootsField = #owningFixedRoots
+
+owningGrowableRootsField ::
+  RecordLabel
+    OwningMultiStore
+    "owningGrowableRoots"
+    OwningGrowableRoots
+owningGrowableRootsField = #owningGrowableRoots
+
+owningNextField ::
+  RecordLabel
+    OwningFixedRoots
+    "owningNext"
+    (OwningUnboxedFixed.Vector Int)
+owningNextField = #owningNext
+
+owningWeightField ::
+  RecordLabel
+    OwningFixedRoots
+    "owningWeight"
+    (OwningUnboxedFixed.Vector Int)
+owningWeightField = #owningWeight
+
+owningMarkField ::
+  RecordLabel
+    OwningFixedRoots
+    "owningMark"
+    (OwningUnboxedFixed.Vector Int)
+owningMarkField = #owningMark
+
+owningPayloadField ::
+  RecordLabel
+    OwningGrowableRoots
+    "owningPayload"
+    (OwningBoxedGrowable.GrowableVector (Int, Int))
+owningPayloadField = #owningPayload
+
+owningScoreField ::
+  RecordLabel
+    OwningGrowableRoots
+    "owningScore"
+    (OwningUnboxedGrowable.GrowableVector Int)
+owningScoreField = #owningScore
+
+owningLinkField ::
+  RecordLabel
+    OwningGrowableRoots
+    "owningLink"
+    (OwningUnboxedGrowable.GrowableVector Int)
+owningLinkField = #owningLink
+
+fixedUnrestrictedRootsField ::
+  RecordLabel
+    FixedUnrestrictedStore
+    "fixedUnrestrictedRoots"
+    FixedRoots
+fixedUnrestrictedRootsField = #fixedUnrestrictedRoots
+
+fixedUnrestrictedGrowableRootsField ::
+  RecordLabel
+    FixedUnrestrictedStore
+    "fixedUnrestrictedGrowableRoots"
+    OwningGrowableRoots
+fixedUnrestrictedGrowableRootsField = #fixedUnrestrictedGrowableRoots
+
+fixedRootsField ::
+  RecordLabel MultiStore "fixedRoots" FixedRoots
+fixedRootsField = #fixedRoots
+
+growableRootsField ::
+  RecordLabel MultiStore "growableRoots" GrowableRoots
+growableRootsField = #growableRoots
+
+nextField ::
+  RecordLabel FixedRoots "next" (Fixed.Vector U.Vector Int)
+nextField = #next
+
+weightField ::
+  RecordLabel FixedRoots "weight" (Fixed.Vector U.Vector Int)
+weightField = #weight
+
+markField ::
+  RecordLabel FixedRoots "mark" (Fixed.Vector U.Vector Int)
+markField = #mark
+
+payloadField ::
+  RecordLabel
+    GrowableRoots
+    "payload"
+    (Growable.GrowableVector V.Vector (Int, Int))
+payloadField = #payload
+
+scoreField ::
+  RecordLabel
+    GrowableRoots
+    "score"
+    (Growable.GrowableVector U.Vector Int)
+scoreField = #score
+
+linkField ::
+  RecordLabel
+    GrowableRoots
+    "link"
+    (Growable.GrowableVector U.Vector Int)
+linkField = #link
+
+digestVectors :: Int64 -> U.Vector Int -> U.Vector Int -> Int64
+digestVectors initial marks scores =
+  let !marksDigest =
+        U.ifoldl'
+          (\digest index value -> mixDigest digest (index * 17 + value))
+          initial
+          marks
+   in U.ifoldl'
+        (\digest index value -> mixDigest digest (index * 31 + value))
+        marksDigest
+        scores
+
+mixDigest :: Int64 -> Int -> Int64
+mixDigest digest value =
+  digest * 1_099_511_628_211 + fromIntegral value
+
+benches :: [Benchmark]
+benches =
+  [ env (pure multiStoreScanDirectInput) \input ->
+      bgroup
+        "multi-store-scan"
+        [ bench "direct" $ nf multiStoreScanDirectBenchmarkRoot input
+        , bench "direct/header-matched" $
+            nf multiStoreScanDirectHeaderMatchedBenchmarkRoot input
+        , bench "pure-borrow/all-owning" $
+            nf multiStoreScanPureBorrowOwningBenchmarkRoot input
+        , bench "pure-borrow/fixed-unrestricted" $
+            nf
+              multiStoreScanPureBorrowFixedUnrestrictedBenchmarkRoot
+              input
+        , bench "pure-borrow/all-unrestricted/direct-shape" $
+            nf multiStoreScanPureBorrowDirectBenchmarkRoot input
+        , bench "pure-borrow/all-unrestricted/nested-shape" $
+            nf multiStoreScanPureBorrowNestedBenchmarkRoot input
+        ]
+  ]
+
+defaultMain :: IO ()
+defaultMain = Bench.defaultMain benches

--- a/internal-src/test-bench-common/PureBorrow/Internal/Bench/Worklist/Resume.hs
+++ b/internal-src/test-bench-common/PureBorrow/Internal/Bench/Worklist/Resume.hs
@@ -1,0 +1,2349 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE ImpredicativeTypes #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE LinearTypes #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE QualifiedDo #-}
+{-# LANGUAGE TypeOperators #-}
+{-# OPTIONS_GHC -Wno-name-shadowing #-}
+
+module PureBorrow.Internal.Bench.Worklist.Resume (
+  WorklistGrowth (..),
+  WorklistOutcome (..),
+  WorklistReopenShape (..),
+  WorklistTarget (..),
+  WorklistSummary (..),
+  WorklistOutput (..),
+  worklistBatchSize,
+  worklistInitialCapacity,
+  worklistNodeCount,
+  worklistDirectOpenOnceRoot,
+  worklistDirectOpenOnceRootWithSeed,
+  worklistDirectReopenRoot,
+  worklistDirectReopenRootWithSeed,
+  worklistPureBorrowOpenOnceRoot,
+  worklistPureBorrowOpenOnceRootWithSeed,
+  worklistPureBorrowOpenOnceWorker,
+  worklistPureBorrowOpenOnceEdgeWorker,
+  worklistPureBorrowFlatReopenRoot,
+  worklistPureBorrowFlatReopenRootWithSeed,
+  worklistPureBorrowNestedReopenRoot,
+  worklistPureBorrowNestedReopenRootWithSeed,
+  worklistPureBorrowResumeWorker,
+  worklistPureBorrowResumeEdgeWorker,
+  benches,
+  defaultMain,
+) where
+
+import Control.DeepSeq (NFData)
+import Control.Functor.Linear qualified as Control
+import Control.Monad (when)
+import Control.Monad.Borrow.Pure
+import Control.Monad.Borrow.Pure.Experimental.Borrows (
+  Aliases (..),
+  Muts,
+  reborrowings,
+ )
+import Control.Monad.ST.Strict (ST, runST)
+import Control.Syntax.DataFlow qualified as DataFlow
+import Data.Int (Int64)
+import Data.Record.Linear.Borrow.Experimental.PatternMatch (
+  RecordLabel,
+  (.@),
+ )
+import Data.STRef (STRef, newSTRef, readSTRef, writeSTRef)
+import Data.Vector qualified as V
+import Data.Vector.Generic.Mutable.Growable.Linear.Borrow.Unrestricted qualified as Growable
+import Data.Vector.Generic.Mutable.Linear.Borrow.Unrestricted qualified as Fixed
+import Data.Vector.Mutable qualified as MV
+import Data.Vector.Unboxed qualified as U
+import Data.Vector.Unboxed.Mutable qualified as UM
+import GHC.Exts qualified as GHC
+import GHC.Generics (Generic)
+import Prelude.Linear (
+  lseq,
+  unur,
+  (&),
+ )
+import Test.Tasty.Bench (Benchmark, bench, bgroup, nf)
+import Test.Tasty.Bench qualified as Bench
+
+data WorklistGrowth
+  = NoGrowth
+  | NoGrowthBatch64
+  | NoGrowthBatch8
+  | SparseGrowth
+  | DenseGrowth
+  deriving stock (Bounded, Enum, Eq, Generic, Show)
+  deriving anyclass (NFData)
+
+data WorklistTarget
+  = Drain
+  | StopEarly
+  deriving stock (Bounded, Enum, Eq, Generic, Show)
+  deriving anyclass (NFData)
+
+data WorklistReopenShape
+  = FlatReopen
+  | NestedReopen
+  deriving stock (Bounded, Enum, Eq, Generic, Show)
+  deriving anyclass (NFData)
+
+data WorklistOutcome
+  = Drained
+  | Stopped
+  deriving stock (Eq, Generic, Show)
+  deriving anyclass (NFData)
+
+data WorklistSummary = WorklistSummary
+  { outcome :: !WorklistOutcome
+  , visitedNodes :: !Int
+  , enqueueTransitions :: !Int
+  , offsetReads :: !Int
+  , adjacencyReads :: !Int
+  , payloadReads :: !Int
+  , markReads :: !Int
+  , markWrites :: !Int
+  , queueReads :: !Int
+  , queueWrites :: !Int
+  , logWrites :: !Int
+  , contentOpens :: !Int
+  , resumeBoundaries :: !Int
+  , headerUpdates :: !Int
+  , bufferGrowths :: !Int
+  , finalDigest :: !Int64
+  }
+  deriving stock (Eq, Generic, Show)
+  deriving anyclass (NFData)
+
+data WorklistOutput = WorklistOutput
+  { summary :: !WorklistSummary
+  , finalMarks :: !(U.Vector Int)
+  , finalState :: !(U.Vector Int)
+  , finalQueue :: !(U.Vector Int)
+  , finalLog :: !(U.Vector Int)
+  }
+  deriving stock (Eq, Generic, Show)
+  deriving anyclass (NFData)
+
+data UnboxedHeader s
+  = UnboxedHeader !Int !(UM.MVector s Int)
+
+data BoxedHeader s
+  = BoxedHeader !Int !(MV.MVector s (Int, Int))
+
+data TraversalState = TraversalState
+  { stateHead :: !Int
+  , stateTail :: !Int
+  , stateVisits :: !Int
+  , stateEnqueues :: !Int
+  , stateLogSize :: !Int
+  , stateDigest :: !Int64
+  }
+
+data SegmentResult = SegmentResult
+  { segmentState :: !TraversalState
+  , segmentPendingRev :: ![Int]
+  , segmentLogRev :: ![Int]
+  , segmentStopped :: !Bool
+  }
+
+data ReopenEvidence = ReopenEvidence
+  { reopenTraversal :: !TraversalState
+  , reopenScopeCount :: !Int
+  , reopenHeaderUpdates :: !Int
+  , reopenGrowthCount :: !Int
+  , reopenOutcome :: !WorklistOutcome
+  }
+
+data WorklistFixedRoots = WorklistFixedRoots
+  { fixedOffsets :: !(Fixed.Vector U.Vector Int)
+  , fixedMarks :: !(Fixed.Vector U.Vector Int)
+  , fixedState :: !(Fixed.Vector U.Vector Int)
+  }
+
+data WorklistGraphRoots = WorklistGraphRoots
+  { graphAdjacency :: !(Growable.GrowableVector U.Vector Int)
+  , graphPayload :: !(Growable.GrowableVector V.Vector (Int, Int))
+  }
+
+data WorklistFrontierRoots = WorklistFrontierRoots
+  { frontierQueue :: !(Growable.GrowableVector U.Vector Int)
+  , frontierLog :: !(Growable.GrowableVector U.Vector Int)
+  }
+
+data WorklistStore = WorklistStore
+  { worklistFixedRoots :: !WorklistFixedRoots
+  , worklistGraphRoots :: !WorklistGraphRoots
+  , worklistFrontierRoots :: !WorklistFrontierRoots
+  }
+
+type FlatWorklist α =
+  Muts
+    α
+    '[ Fixed.Vector U.Vector Int
+     , Fixed.Vector U.Vector Int
+     , Fixed.Vector U.Vector Int
+     , Growable.GrowableVector U.Vector Int
+     , Growable.GrowableVector V.Vector (Int, Int)
+     , Growable.GrowableVector U.Vector Int
+     , Growable.GrowableVector U.Vector Int
+     ]
+
+type NestedFrontierWorklist α =
+  Muts
+    α
+    '[ Growable.GrowableVector U.Vector Int
+     , Growable.GrowableVector U.Vector Int
+     ]
+
+worklistNodeCount :: Int
+worklistNodeCount = 4096
+
+worklistDegree :: Int
+worklistDegree = 3
+
+worklistEdgeCount :: Int
+worklistEdgeCount = worklistNodeCount * worklistDegree
+
+worklistEarlyStop :: Int
+worklistEarlyStop = 1365
+
+defaultMain :: IO ()
+defaultMain = Bench.defaultMain benches
+
+benches :: [Benchmark]
+benches =
+  [ bgroup
+      "worklist-open-once"
+      [ bgroup
+          (show target)
+          [ bench "direct" $
+              nf worklistDirectOpenOnceRoot target
+          , bench "pure-borrow" $
+              nf worklistPureBorrowOpenOnceRoot target
+          ]
+      | target <- [minBound .. maxBound]
+      ]
+  , bgroup
+      "worklist-push-extend-reopen"
+      [ bgroup
+          (show growth)
+          [ bgroup
+              (show target)
+              [ bench "direct-flat" $
+                  nf
+                    (worklistDirectReopenRoot FlatReopen growth)
+                    target
+              , bench "pure-borrow-flat" $
+                  nf
+                    (worklistPureBorrowFlatReopenRoot growth)
+                    target
+              , bench "direct-nested" $
+                  nf
+                    (worklistDirectReopenRoot NestedReopen growth)
+                    target
+              , bench "pure-borrow-nested" $
+                  nf
+                    (worklistPureBorrowNestedReopenRoot growth)
+                    target
+              ]
+          | target <- [minBound .. maxBound]
+          ]
+      | growth <- [minBound .. maxBound]
+      ]
+  ]
+
+worklistOffsets :: U.Vector Int
+worklistOffsets =
+  U.generate (worklistNodeCount + 1) \node ->
+    node * worklistDegree
+
+worklistAdjacency :: U.Vector Int
+worklistAdjacency =
+  U.generate worklistEdgeCount \edge ->
+    let (node, slot) = edge `quotRem` worklistDegree
+     in case slot of
+          0 -> (node + 1) `rem` worklistNodeCount
+          1 -> (node * 17 + 13) `rem` worklistNodeCount
+          _ -> (node * 31 + 7) `rem` worklistNodeCount
+
+worklistPayload :: V.Vector (Int, Int)
+worklistPayload =
+  V.generate worklistEdgeCount \edge ->
+    let !node = edge `quot` worklistDegree
+        !neighbor = worklistAdjacency U.! edge
+     in (edge `rem` 11, (node + neighbor) `rem` 17)
+
+targetVisits :: WorklistTarget -> Int
+targetVisits Drain = worklistNodeCount
+targetVisits StopEarly = worklistEarlyStop
+
+initialMarks :: U.Vector Int
+initialMarks =
+  U.replicate worklistNodeCount 0 U.// [(0, 1)]
+
+initialState :: U.Vector Int
+initialState = U.fromListN 5 [0, 1, 0, 0, 0]
+
+data WorklistStorage
+  = OpenOnceStorage
+  | ReopenStorage !WorklistGrowth
+
+newWorklistStore :: WorklistStorage -> Linearly %1 -> WorklistStore
+{-# NOINLINE newWorklistStore #-}
+newWorklistStore =
+  GHC.noinline \storage linear ->
+    dup linear & \(offsetsLinear, rest1) ->
+      dup rest1 & \(marksLinear, rest2) ->
+        dup rest2 & \(stateLinear, rest3) ->
+          dup rest3 & \(adjacencyLinear, rest4) ->
+            dup rest4 & \(payloadLinear, rest5) ->
+              dup rest5 & \(queueLinear, logLinear) ->
+                WorklistStore
+                  { worklistFixedRoots =
+                      WorklistFixedRoots
+                        { fixedOffsets =
+                            Fixed.fromVector
+                              worklistOffsets
+                              offsetsLinear
+                        , fixedMarks =
+                            Fixed.fromVector
+                              initialMarks
+                              marksLinear
+                        , fixedState =
+                            Fixed.fromVector
+                              initialState
+                              stateLinear
+                        }
+                  , worklistGraphRoots =
+                      WorklistGraphRoots
+                        { graphAdjacency =
+                            Growable.fromVector
+                              worklistAdjacency
+                              adjacencyLinear
+                        , graphPayload =
+                            Growable.fromVector
+                              worklistPayload
+                              payloadLinear
+                        }
+                  , worklistFrontierRoots =
+                      WorklistFrontierRoots
+                        { frontierQueue =
+                            case storage of
+                              OpenOnceStorage ->
+                                Growable.fromVector
+                                  ( U.cons
+                                      0
+                                      ( U.replicate
+                                          (worklistNodeCount - 1)
+                                          0
+                                      )
+                                  )
+                                  queueLinear
+                              ReopenStorage growth ->
+                                Growable.withCapacity
+                                  (worklistInitialCapacity growth)
+                                  queueLinear
+                        , frontierLog =
+                            case storage of
+                              OpenOnceStorage ->
+                                Growable.fromVector
+                                  (U.replicate worklistNodeCount 0)
+                                  logLinear
+                              ReopenStorage growth ->
+                                Growable.withCapacity
+                                  (worklistInitialCapacity growth)
+                                  logLinear
+                        }
+                  }
+
+worklistFixedRootsField ::
+  RecordLabel WorklistStore "worklistFixedRoots" WorklistFixedRoots
+worklistFixedRootsField = #worklistFixedRoots
+
+worklistGraphRootsField ::
+  RecordLabel WorklistStore "worklistGraphRoots" WorklistGraphRoots
+worklistGraphRootsField = #worklistGraphRoots
+
+worklistFrontierRootsField ::
+  RecordLabel WorklistStore "worklistFrontierRoots" WorklistFrontierRoots
+worklistFrontierRootsField = #worklistFrontierRoots
+
+fixedOffsetsField ::
+  RecordLabel
+    WorklistFixedRoots
+    "fixedOffsets"
+    (Fixed.Vector U.Vector Int)
+fixedOffsetsField = #fixedOffsets
+
+fixedMarksField ::
+  RecordLabel
+    WorklistFixedRoots
+    "fixedMarks"
+    (Fixed.Vector U.Vector Int)
+fixedMarksField = #fixedMarks
+
+fixedStateField ::
+  RecordLabel
+    WorklistFixedRoots
+    "fixedState"
+    (Fixed.Vector U.Vector Int)
+fixedStateField = #fixedState
+
+graphAdjacencyField ::
+  RecordLabel
+    WorklistGraphRoots
+    "graphAdjacency"
+    (Growable.GrowableVector U.Vector Int)
+graphAdjacencyField = #graphAdjacency
+
+graphPayloadField ::
+  RecordLabel
+    WorklistGraphRoots
+    "graphPayload"
+    (Growable.GrowableVector V.Vector (Int, Int))
+graphPayloadField = #graphPayload
+
+frontierQueueField ::
+  RecordLabel
+    WorklistFrontierRoots
+    "frontierQueue"
+    (Growable.GrowableVector U.Vector Int)
+frontierQueueField = #frontierQueue
+
+frontierLogField ::
+  RecordLabel
+    WorklistFrontierRoots
+    "frontierLog"
+    (Growable.GrowableVector U.Vector Int)
+frontierLogField = #frontierLog
+
+worklistDirectOpenOnceRoot ::
+  WorklistTarget ->
+  WorklistOutput
+{-# NOINLINE worklistDirectOpenOnceRoot #-}
+worklistDirectOpenOnceRoot =
+  worklistDirectOpenOnceRootWithSeed 0
+
+worklistDirectOpenOnceRootWithSeed ::
+  Int ->
+  WorklistTarget ->
+  WorklistOutput
+{-# NOINLINE worklistDirectOpenOnceRootWithSeed #-}
+worklistDirectOpenOnceRootWithSeed seed target =
+  runST do
+    offsets <- U.thaw worklistOffsets
+    marks <- U.thaw initialMarks
+    state <- U.thaw initialState
+    adjacencyHeader <- newUnboxedHeaderFromVector worklistAdjacency
+    payloadHeader <- newBoxedHeaderFromVector worklistPayload
+    queueHeader <-
+      newUnboxedHeaderFromVector
+        (U.cons 0 (U.replicate (worklistNodeCount - 1) 0))
+    logHeader <-
+      newUnboxedHeaderFromVector
+        (U.replicate worklistNodeCount 0)
+    UnboxedHeader _ adjacency <- readSTRef adjacencyHeader
+    BoxedHeader _ payload <- readSTRef payloadHeader
+    UnboxedHeader _ queue <- readSTRef queueHeader
+    UnboxedHeader _ outputLog <- readSTRef logHeader
+    finalTraversal <-
+      runOpenOnce
+        (targetVisits target)
+        offsets
+        adjacency
+        payload
+        marks
+        queue
+        outputLog
+        (TraversalState 0 1 0 0 0 (initialDigestForSeed seed))
+    writeTraversalState state finalTraversal
+    finishDirect
+      (if stateVisits finalTraversal == targetVisits target && target == StopEarly then Stopped else Drained)
+      4
+      0
+      0
+      0
+      offsets
+      adjacency
+      payload
+      marks
+      state
+      queue
+      outputLog
+      finalTraversal
+
+worklistDirectReopenRoot ::
+  WorklistReopenShape ->
+  WorklistGrowth ->
+  WorklistTarget ->
+  WorklistOutput
+{-# NOINLINE worklistDirectReopenRoot #-}
+worklistDirectReopenRoot =
+  worklistDirectReopenRootWithSeed 0
+
+worklistDirectReopenRootWithSeed ::
+  Int ->
+  WorklistReopenShape ->
+  WorklistGrowth ->
+  WorklistTarget ->
+  WorklistOutput
+{-# NOINLINE worklistDirectReopenRootWithSeed #-}
+worklistDirectReopenRootWithSeed seed reopenShape growth target =
+  runST do
+    offsets <- U.thaw worklistOffsets
+    marks <- U.thaw initialMarks
+    state <- U.thaw initialState
+    adjacencyHeader <- newUnboxedHeaderFromVector worklistAdjacency
+    payloadHeader <- newBoxedHeaderFromVector worklistPayload
+    queueHeader <- newUnboxedHeader (worklistInitialCapacity growth) U.empty
+    _ <- appendUnboxed queueHeader (U.singleton 0)
+    logHeader <- newUnboxedHeader (worklistInitialCapacity growth) U.empty
+    (finalTraversal, scopeCount, headerUpdateCount, growthCount, finalOutcome) <-
+      case reopenShape of
+        FlatReopen ->
+          runFlatReopenDirect
+            growth
+            target
+            offsets
+            marks
+            state
+            adjacencyHeader
+            payloadHeader
+            queueHeader
+            logHeader
+            (TraversalState 0 1 0 0 0 (initialDigestForSeed seed))
+            0
+            0
+            0
+        NestedReopen -> do
+          UnboxedHeader _ adjacency <- readSTRef adjacencyHeader
+          BoxedHeader _ payload <- readSTRef payloadHeader
+          runNestedReopenDirect
+            growth
+            target
+            offsets
+            adjacency
+            payload
+            marks
+            state
+            queueHeader
+            logHeader
+            (TraversalState 0 1 0 0 0 (initialDigestForSeed seed))
+            0
+            0
+            0
+    UnboxedHeader _ adjacency <- readSTRef adjacencyHeader
+    BoxedHeader _ payload <- readSTRef payloadHeader
+    UnboxedHeader queueSize queue <- readSTRef queueHeader
+    UnboxedHeader logSize outputLog <- readSTRef logHeader
+    finishDirect
+      finalOutcome
+      ( case reopenShape of
+          FlatReopen -> 4 * scopeCount
+          NestedReopen -> 2 + 2 * scopeCount
+      )
+      (max 0 (scopeCount - 1))
+      headerUpdateCount
+      growthCount
+      offsets
+      adjacency
+      payload
+      marks
+      state
+      (UM.unsafeTake queueSize queue)
+      (UM.unsafeTake logSize outputLog)
+      finalTraversal
+
+worklistPureBorrowOpenOnceRoot ::
+  WorklistTarget ->
+  WorklistOutput
+{-# NOINLINE worklistPureBorrowOpenOnceRoot #-}
+worklistPureBorrowOpenOnceRoot =
+  worklistPureBorrowOpenOnceRootWithSeed 0
+
+worklistPureBorrowOpenOnceRootWithSeed ::
+  Int ->
+  WorklistTarget ->
+  WorklistOutput
+{-# NOINLINE worklistPureBorrowOpenOnceRootWithSeed #-}
+worklistPureBorrowOpenOnceRootWithSeed seed target =
+  unur
+    ( linearly \linear -> DataFlow.do
+        (allocationLinear, borrowLinear) <- dup linear
+        store <- newWorklistStore OpenOnceStorage allocationLinear
+        runBO borrowLinear Control.do
+          (storeBorrow, lender) <- borrowM store
+          (Ur traversal, storeBorrow) <-
+            reborrowing storeBorrow \local -> Control.do
+              let %1 !(fixedRootBorrows, graphRootBorrows, frontierRootBorrows) =
+                    local
+                      .@ ( worklistFixedRootsField
+                         , worklistGraphRootsField
+                         , worklistFrontierRootsField
+                         )
+              let %1 !(offsetsBorrow, marksBorrow, stateBorrow) =
+                    fixedRootBorrows
+                      .@ (fixedOffsetsField, fixedMarksField, fixedStateField)
+              let %1 !(adjacencyBorrow, payloadBorrow) =
+                    graphRootBorrows
+                      .@ (graphAdjacencyField, graphPayloadField)
+              let %1 !(queueBorrow, logBorrow) =
+                    frontierRootBorrows
+                      .@ (frontierQueueField, frontierLogField)
+              let %1 !adjacencyContent =
+                    Growable.getContents adjacencyBorrow
+              let %1 !payloadContent =
+                    Growable.getContents payloadBorrow
+              let %1 !queueContent =
+                    Growable.getContents queueBorrow
+              let %1 !logContent =
+                    Growable.getContents logBorrow
+              (Ur initial, stateBorrow) <-
+                readTraversalState stateBorrow
+              let !seededInitial =
+                    initial
+                      { stateDigest = initialDigestForSeed seed
+                      }
+              ( Ur traversal
+                , offsetsBorrow
+                , marksBorrow
+                , stateBorrow
+                , adjacencyContent
+                , payloadContent
+                , queueContent
+                , logContent
+                ) <-
+                worklistPureBorrowOpenOnceWorker
+                  (targetVisits target)
+                  seededInitial
+                  offsetsBorrow
+                  marksBorrow
+                  stateBorrow
+                  adjacencyContent
+                  payloadContent
+                  queueContent
+                  logContent
+              let !() =
+                    consumeWorklistViews
+                      offsetsBorrow
+                      marksBorrow
+                      stateBorrow
+                      adjacencyContent
+                      payloadContent
+                      queueContent
+                      logContent
+              Control.pure (Ur traversal)
+          let !(Ur _) = share storeBorrow
+          pureAfter
+            ( finishWorklistStore
+                (outcomeFor target traversal)
+                4
+                0
+                0
+                0
+                traversal
+                (reclaim lender)
+            )
+    )
+
+worklistPureBorrowFlatReopenRoot ::
+  WorklistGrowth ->
+  WorklistTarget ->
+  WorklistOutput
+{-# NOINLINE worklistPureBorrowFlatReopenRoot #-}
+worklistPureBorrowFlatReopenRoot =
+  worklistPureBorrowReopenRoot FlatReopen
+
+worklistPureBorrowFlatReopenRootWithSeed ::
+  Int ->
+  WorklistGrowth ->
+  WorklistTarget ->
+  WorklistOutput
+{-# NOINLINE worklistPureBorrowFlatReopenRootWithSeed #-}
+worklistPureBorrowFlatReopenRootWithSeed seed =
+  worklistPureBorrowReopenRootWithSeed seed FlatReopen
+
+worklistPureBorrowNestedReopenRoot ::
+  WorklistGrowth ->
+  WorklistTarget ->
+  WorklistOutput
+{-# NOINLINE worklistPureBorrowNestedReopenRoot #-}
+worklistPureBorrowNestedReopenRoot =
+  worklistPureBorrowReopenRoot NestedReopen
+
+worklistPureBorrowNestedReopenRootWithSeed ::
+  Int ->
+  WorklistGrowth ->
+  WorklistTarget ->
+  WorklistOutput
+{-# NOINLINE worklistPureBorrowNestedReopenRootWithSeed #-}
+worklistPureBorrowNestedReopenRootWithSeed seed =
+  worklistPureBorrowReopenRootWithSeed seed NestedReopen
+
+worklistPureBorrowReopenRoot ::
+  WorklistReopenShape ->
+  WorklistGrowth ->
+  WorklistTarget ->
+  WorklistOutput
+{-# NOINLINE worklistPureBorrowReopenRoot #-}
+worklistPureBorrowReopenRoot =
+  worklistPureBorrowReopenRootWithSeed 0
+
+worklistPureBorrowReopenRootWithSeed ::
+  Int ->
+  WorklistReopenShape ->
+  WorklistGrowth ->
+  WorklistTarget ->
+  WorklistOutput
+{-# NOINLINE worklistPureBorrowReopenRootWithSeed #-}
+worklistPureBorrowReopenRootWithSeed seed reopenShape growth target =
+  unur
+    ( linearly \linear -> DataFlow.do
+        (allocationLinear, borrowLinear) <- dup linear
+        store <-
+          newWorklistStore
+            (ReopenStorage growth)
+            allocationLinear
+        runBO borrowLinear Control.do
+          (storeBorrow, lender) <- borrowM store
+          (Ur evidence, storeBorrow) <-
+            reborrowing storeBorrow \local -> Control.do
+              let %1 !(fixedRootBorrows, graphRootBorrows, frontierRootBorrows) =
+                    local
+                      .@ ( worklistFixedRootsField
+                         , worklistGraphRootsField
+                         , worklistFrontierRootsField
+                         )
+              let %1 !(offsetsBorrow, marksBorrow, stateBorrow) =
+                    fixedRootBorrows
+                      .@ (fixedOffsetsField, fixedMarksField, fixedStateField)
+              let %1 !(adjacencyBorrow, payloadBorrow) =
+                    graphRootBorrows
+                      .@ (graphAdjacencyField, graphPayloadField)
+              let %1 !(queueBorrow, logBorrow) =
+                    frontierRootBorrows
+                      .@ (frontierQueueField, frontierLogField)
+              queueBorrow <- Growable.push 0 queueBorrow
+              (Ur initial, stateBorrow) <-
+                readTraversalState stateBorrow
+              let !seededInitial =
+                    initial
+                      { stateDigest = initialDigestForSeed seed
+                      }
+              case reopenShape of
+                FlatReopen -> Control.do
+                  (Ur evidence, fields) <-
+                    runFlatReopenPureBorrow
+                      growth
+                      target
+                      seededInitial
+                      (worklistInitialCapacity growth)
+                      (worklistInitialCapacity growth)
+                      0
+                      0
+                      0
+                      ( offsetsBorrow
+                          :- marksBorrow
+                          :- stateBorrow
+                          :- adjacencyBorrow
+                          :- payloadBorrow
+                          :- queueBorrow
+                          :- logBorrow
+                          :- BNil
+                      )
+                  let !() = consume fields
+                  Control.pure (Ur evidence)
+                NestedReopen -> Control.do
+                  let !(Ur sharedOffsets) = share offsetsBorrow
+                  let !(Ur sharedAdjacency) = share adjacencyBorrow
+                  let !(Ur sharedPayload) = share payloadBorrow
+                  let !adjacencyContent =
+                        Growable.getContents sharedAdjacency
+                  let !payloadContent =
+                        Growable.getContents sharedPayload
+                  (Ur evidence, fixedFields) <-
+                    reborrowings
+                      (marksBorrow :- stateBorrow :- BNil)
+                      \case
+                        marks :- state :- BNil -> Control.do
+                          ( Ur evidence
+                            , marks
+                            , state
+                            , frontierFields
+                            ) <-
+                            runNestedReopenPureBorrow
+                              growth
+                              target
+                              seededInitial
+                              (worklistInitialCapacity growth)
+                              (worklistInitialCapacity growth)
+                              0
+                              0
+                              0
+                              (subShare sharedOffsets)
+                              (subShare adjacencyContent)
+                              (subShare payloadContent)
+                              marks
+                              state
+                              (upcast (queueBorrow :- logBorrow :- BNil))
+                          let !(Ur _) = share marks
+                              !(Ur _) = share state
+                              !() = consume frontierFields
+                          Control.pure (Ur evidence)
+                  let !() = consume fixedFields
+                  Control.pure (Ur evidence)
+          let !(Ur _) = share storeBorrow
+          pureAfter
+            ( finishWorklistStore
+                (reopenOutcome evidence)
+                ( case reopenShape of
+                    FlatReopen ->
+                      4 * reopenScopeCount evidence
+                    NestedReopen ->
+                      2 + 2 * reopenScopeCount evidence
+                )
+                (max 0 (reopenScopeCount evidence - 1))
+                (reopenHeaderUpdates evidence)
+                (reopenGrowthCount evidence)
+                (reopenTraversal evidence)
+                (reclaim lender)
+            )
+    )
+
+runFlatReopenPureBorrow ::
+  WorklistGrowth ->
+  WorklistTarget ->
+  TraversalState ->
+  Int ->
+  Int ->
+  Int ->
+  Int ->
+  Int ->
+  FlatWorklist α %1 ->
+  BO α (Ur ReopenEvidence, FlatWorklist α)
+runFlatReopenPureBorrow
+  growth
+  target
+  current
+  queueCapacity
+  logCapacity
+  scopes
+  updates
+  growths
+  fields
+    | stateVisits current >= targetVisits target =
+        Control.pure
+          ( Ur
+              ( reopenEvidence
+                  target
+                  current
+                  scopes
+                  updates
+                  growths
+              )
+          , fields
+          )
+    | stateHead current >= stateTail current =
+        Control.pure
+          ( Ur
+              ReopenEvidence
+                { reopenTraversal = current
+                , reopenScopeCount = scopes
+                , reopenHeaderUpdates = updates
+                , reopenGrowthCount = growths
+                , reopenOutcome = Drained
+                }
+          , fields
+          )
+    | otherwise = Control.do
+        (Ur segment, fields) <-
+          reborrowings fields \case
+            offsets
+              :- marks
+              :- state
+              :- adjacency
+              :- payload
+              :- queue
+              :- outputLog
+              :- BNil -> Control.do
+                let %1 !adjacencyContent =
+                      Growable.getContents adjacency
+                let %1 !payloadContent =
+                      Growable.getContents payload
+                let %1 !queueContent =
+                      Growable.getContents queue
+                let %1 !logContent =
+                      Growable.getContents outputLog
+                ( Ur segment
+                  , offsets
+                  , marks
+                  , state
+                  , adjacencyContent
+                  , payloadContent
+                  , queueContent
+                  , logContent
+                  ) <-
+                  worklistPureBorrowResumeWorker
+                    (targetVisits target)
+                    ( min
+                        (stateTail current)
+                        (stateHead current + worklistBatchSize growth)
+                    )
+                    current
+                    []
+                    []
+                    offsets
+                    marks
+                    state
+                    adjacencyContent
+                    payloadContent
+                    queueContent
+                    logContent
+                let !() =
+                      consumeWorklistViews
+                        offsets
+                        marks
+                        state
+                        adjacencyContent
+                        payloadContent
+                        queueContent
+                        logContent
+                Control.pure (Ur segment)
+        let %1 !( offsets
+                    :- marks
+                    :- state
+                    :- adjacency
+                    :- payload
+                    :- queue
+                    :- outputLog
+                    :- BNil
+                  ) = fields
+        let !pending =
+              U.fromList (reverse (segmentPendingRev segment))
+            !newLogs =
+              U.fromList (reverse (segmentLogRev segment))
+            !nextTraversal = segmentState segment
+            !( nextQueueCapacity
+               , nextLogCapacity
+               , nextGrowths
+               ) =
+                nextCapacities
+                  queueCapacity
+                  logCapacity
+                  growths
+                  pending
+                  nextTraversal
+            !nextUpdates =
+              updates
+                + (if U.null pending then 0 else 1)
+                + 1
+            !nextScopes = scopes + 1
+        queue <-
+          if U.null pending
+            then Control.pure queue
+            else Growable.extend pending queue
+        outputLog <- Growable.extend newLogs outputLog
+        state <-
+          writeTraversalStatePureBorrow nextTraversal state
+        let %1 !nextFields =
+              offsets
+                :- marks
+                :- state
+                :- adjacency
+                :- payload
+                :- queue
+                :- outputLog
+                :- BNil
+        if segmentStopped segment
+          then
+            Control.pure
+              ( Ur
+                  ( reopenEvidence
+                      target
+                      nextTraversal
+                      nextScopes
+                      nextUpdates
+                      nextGrowths
+                  )
+              , nextFields
+              )
+          else
+            runFlatReopenPureBorrow
+              growth
+              target
+              nextTraversal
+              nextQueueCapacity
+              nextLogCapacity
+              nextScopes
+              nextUpdates
+              nextGrowths
+              nextFields
+
+runNestedReopenPureBorrow ::
+  WorklistGrowth ->
+  WorklistTarget ->
+  TraversalState ->
+  Int ->
+  Int ->
+  Int ->
+  Int ->
+  Int ->
+  Share α (Fixed.Vector U.Vector Int) ->
+  Share α (Fixed.Vector U.Vector Int) ->
+  Share α (Fixed.Vector V.Vector (Int, Int)) ->
+  Mut α (Fixed.Vector U.Vector Int) %1 ->
+  Mut α (Fixed.Vector U.Vector Int) %1 ->
+  NestedFrontierWorklist α %1 ->
+  BO
+    α
+    ( Ur ReopenEvidence
+    , Mut α (Fixed.Vector U.Vector Int)
+    , Mut α (Fixed.Vector U.Vector Int)
+    , NestedFrontierWorklist α
+    )
+runNestedReopenPureBorrow
+  growth
+  target
+  current
+  queueCapacity
+  logCapacity
+  scopes
+  updates
+  growths
+  offsets
+  adjacency
+  payload
+  marks
+  state
+  fields
+    | stateVisits current >= targetVisits target =
+        Control.pure
+          ( Ur
+              ( reopenEvidence
+                  target
+                  current
+                  scopes
+                  updates
+                  growths
+              )
+          , marks
+          , state
+          , fields
+          )
+    | stateHead current >= stateTail current =
+        Control.pure
+          ( Ur
+              ReopenEvidence
+                { reopenTraversal = current
+                , reopenScopeCount = scopes
+                , reopenHeaderUpdates = updates
+                , reopenGrowthCount = growths
+                , reopenOutcome = Drained
+                }
+          , marks
+          , state
+          , fields
+          )
+    | otherwise = Control.do
+        ((Ur segment, marks, state), fields) <-
+          reborrowings fields \case
+            queue :- outputLog :- BNil -> Control.do
+              let %1 !queueContent =
+                    Growable.getContents queue
+              let %1 !logContent =
+                    Growable.getContents outputLog
+              ( Ur segment
+                , offsetsOccurrence
+                , marks
+                , state
+                , adjacencyOccurrence
+                , payloadOccurrence
+                , queueContent
+                , logContent
+                ) <-
+                worklistPureBorrowResumeWorker
+                  (targetVisits target)
+                  ( min
+                      (stateTail current)
+                      (stateHead current + worklistBatchSize growth)
+                  )
+                  current
+                  []
+                  []
+                  offsets
+                  marks
+                  state
+                  adjacency
+                  payload
+                  queueContent
+                  logContent
+              let !() = consume offsetsOccurrence
+                  !() = consume adjacencyOccurrence
+                  !() = consume payloadOccurrence
+                  !(Ur _) = share queueContent
+                  !(Ur _) = share logContent
+              Control.pure (Ur segment, marks, state)
+        let %1 !(queue :- outputLog :- BNil) =
+              fields
+        let !pending =
+              U.fromList (reverse (segmentPendingRev segment))
+            !newLogs =
+              U.fromList (reverse (segmentLogRev segment))
+            !nextTraversal = segmentState segment
+            !( nextQueueCapacity
+               , nextLogCapacity
+               , nextGrowths
+               ) =
+                nextCapacities
+                  queueCapacity
+                  logCapacity
+                  growths
+                  pending
+                  nextTraversal
+            !nextUpdates =
+              updates
+                + (if U.null pending then 0 else 1)
+                + 1
+            !nextScopes = scopes + 1
+        queue <-
+          if U.null pending
+            then Control.pure queue
+            else Growable.extend pending queue
+        outputLog <- Growable.extend newLogs outputLog
+        state <-
+          writeTraversalStatePureBorrow nextTraversal state
+        let %1 !nextFields =
+              queue :- outputLog :- BNil
+        if segmentStopped segment
+          then
+            Control.pure
+              ( Ur
+                  ( reopenEvidence
+                      target
+                      nextTraversal
+                      nextScopes
+                      nextUpdates
+                      nextGrowths
+                  )
+              , marks
+              , state
+              , nextFields
+              )
+          else
+            runNestedReopenPureBorrow
+              growth
+              target
+              nextTraversal
+              nextQueueCapacity
+              nextLogCapacity
+              nextScopes
+              nextUpdates
+              nextGrowths
+              offsets
+              adjacency
+              payload
+              marks
+              state
+              nextFields
+
+reopenEvidence ::
+  WorklistTarget ->
+  TraversalState ->
+  Int ->
+  Int ->
+  Int ->
+  ReopenEvidence
+reopenEvidence target traversal scopes updates growths =
+  ReopenEvidence
+    { reopenTraversal = traversal
+    , reopenScopeCount = scopes
+    , reopenHeaderUpdates = updates
+    , reopenGrowthCount = growths
+    , reopenOutcome =
+        case target of
+          Drain -> Drained
+          StopEarly -> Stopped
+    }
+
+nextCapacities ::
+  Int ->
+  Int ->
+  Int ->
+  U.Vector Int ->
+  TraversalState ->
+  (Int, Int, Int)
+nextCapacities
+  queueCapacity
+  logCapacity
+  growths
+  pending
+  traversal =
+    let !nextQueueCapacity =
+          if U.null pending
+            then queueCapacity
+            else growthTarget queueCapacity (stateTail traversal)
+        !nextLogCapacity =
+          growthTarget logCapacity (stateLogSize traversal)
+        !nextGrowths =
+          growths
+            + fromEnum (nextQueueCapacity > queueCapacity)
+            + fromEnum (nextLogCapacity > logCapacity)
+     in (nextQueueCapacity, nextLogCapacity, nextGrowths)
+
+worklistPureBorrowResumeWorker ::
+  ( α >= ζ
+  , β >= ζ
+  , γ >= ζ
+  , δ >= ζ
+  , ε >= ζ
+  ) =>
+  Int ->
+  Int ->
+  TraversalState ->
+  [Int] ->
+  [Int] ->
+  Borrow bk1 α (Fixed.Vector U.Vector Int) %1 ->
+  Mut β (Fixed.Vector U.Vector Int) %1 ->
+  Mut γ (Fixed.Vector U.Vector Int) %1 ->
+  Borrow bk2 δ (Fixed.Vector U.Vector Int) %1 ->
+  Borrow bk3 ε (Fixed.Vector V.Vector (Int, Int)) %1 ->
+  Mut ζ (Fixed.Vector U.Vector Int) %1 ->
+  Mut ζ (Fixed.Vector U.Vector Int) %1 ->
+  BO
+    ζ
+    ( Ur SegmentResult
+    , Borrow bk1 α (Fixed.Vector U.Vector Int)
+    , Mut β (Fixed.Vector U.Vector Int)
+    , Mut γ (Fixed.Vector U.Vector Int)
+    , Borrow bk2 δ (Fixed.Vector U.Vector Int)
+    , Borrow bk3 ε (Fixed.Vector V.Vector (Int, Int))
+    , Mut ζ (Fixed.Vector U.Vector Int)
+    , Mut ζ (Fixed.Vector U.Vector Int)
+    )
+{-# NOINLINE worklistPureBorrowResumeWorker #-}
+worklistPureBorrowResumeWorker
+  stopAfter
+  snapshotTail
+  current
+  pendingRev
+  logRev
+  offsets
+  marks
+  state
+  adjacency
+  payload
+  queue
+  outputLog
+    | stateVisits current >= stopAfter =
+        Control.pure
+          ( Ur (SegmentResult current pendingRev logRev True)
+          , offsets
+          , marks
+          , state
+          , adjacency
+          , payload
+          , queue
+          , outputLog
+          )
+    | stateHead current >= snapshotTail =
+        Control.pure
+          ( Ur (SegmentResult current pendingRev logRev False)
+          , offsets
+          , marks
+          , state
+          , adjacency
+          , payload
+          , queue
+          , outputLog
+          )
+    | otherwise = Control.do
+        (Ur node, queue) <-
+          Fixed.unsafeGet (stateHead current) queue
+        (Ur start, offsets) <-
+          Fixed.unsafeGet node offsets
+        (Ur end, offsets) <-
+          Fixed.unsafeGet (node + 1) offsets
+        ( Ur (nextTail, nextEnqueues, nextPendingRev, nodeDigest)
+          , adjacency
+          , payload
+          , marks
+          ) <-
+          worklistPureBorrowResumeEdgeWorker
+            start
+            end
+            (stateTail current)
+            (stateEnqueues current)
+            pendingRev
+            (stateDigest current)
+            adjacency
+            payload
+            marks
+        let !logValue = digestToLogValue nodeDigest node
+            !nextState =
+              TraversalState
+                { stateHead = stateHead current + 1
+                , stateTail = nextTail
+                , stateVisits = stateVisits current + 1
+                , stateEnqueues = nextEnqueues
+                , stateLogSize = stateLogSize current + 1
+                , stateDigest = mixDigest nodeDigest logValue
+                }
+        worklistPureBorrowResumeWorker
+          stopAfter
+          snapshotTail
+          nextState
+          nextPendingRev
+          (logValue : logRev)
+          offsets
+          marks
+          state
+          adjacency
+          payload
+          queue
+          outputLog
+
+worklistPureBorrowResumeEdgeWorker ::
+  (α >= δ, β >= δ, γ >= δ) =>
+  Int ->
+  Int ->
+  Int ->
+  Int ->
+  [Int] ->
+  Int64 ->
+  Borrow bk1 α (Fixed.Vector U.Vector Int) %1 ->
+  Borrow bk2 β (Fixed.Vector V.Vector (Int, Int)) %1 ->
+  Mut γ (Fixed.Vector U.Vector Int) %1 ->
+  BO
+    δ
+    ( Ur (Int, Int, [Int], Int64)
+    , Borrow bk1 α (Fixed.Vector U.Vector Int)
+    , Borrow bk2 β (Fixed.Vector V.Vector (Int, Int))
+    , Mut γ (Fixed.Vector U.Vector Int)
+    )
+-- This benchmark-internal export exists only to anchor optimized-Core
+-- inspection. Its indices are unchecked; only the benchmark roots establish
+-- the offset and neighbor bounds required by the unsafe element operations.
+{-# INLINEABLE worklistPureBorrowResumeEdgeWorker #-}
+worklistPureBorrowResumeEdgeWorker
+  edge
+  end
+  tailIndex
+  enqueues
+  pendingRev
+  digest
+  adjacency
+  payload
+  marks
+    | edge >= end =
+        Control.pure
+          ( Ur (tailIndex, enqueues, pendingRev, digest)
+          , adjacency
+          , payload
+          , marks
+          )
+    | otherwise = Control.do
+        (Ur neighbor, adjacency) <-
+          Fixed.unsafeGet edge adjacency
+        (Ur (tag, delta), payload) <-
+          Fixed.unsafeGet edge payload
+        (Ur marked, marks) <-
+          Fixed.unsafeGet neighbor marks
+        let !nextDigest =
+              mixDigest
+                digest
+                (neighbor * 31 + tag * 17 + delta + marked)
+        if marked == 0
+          then Control.do
+            marks <- Fixed.unsafeWrite neighbor 1 marks
+            worklistPureBorrowResumeEdgeWorker
+              (edge + 1)
+              end
+              (tailIndex + 1)
+              (enqueues + 1)
+              (neighbor : pendingRev)
+              nextDigest
+              adjacency
+              payload
+              marks
+          else
+            worklistPureBorrowResumeEdgeWorker
+              (edge + 1)
+              end
+              tailIndex
+              enqueues
+              pendingRev
+              nextDigest
+              adjacency
+              payload
+              marks
+
+worklistPureBorrowOpenOnceWorker ::
+  Int ->
+  TraversalState ->
+  Mut α (Fixed.Vector U.Vector Int) %1 ->
+  Mut α (Fixed.Vector U.Vector Int) %1 ->
+  Mut α (Fixed.Vector U.Vector Int) %1 ->
+  Mut α (Fixed.Vector U.Vector Int) %1 ->
+  Mut α (Fixed.Vector V.Vector (Int, Int)) %1 ->
+  Mut α (Fixed.Vector U.Vector Int) %1 ->
+  Mut α (Fixed.Vector U.Vector Int) %1 ->
+  BO
+    α
+    ( Ur TraversalState
+    , Mut α (Fixed.Vector U.Vector Int)
+    , Mut α (Fixed.Vector U.Vector Int)
+    , Mut α (Fixed.Vector U.Vector Int)
+    , Mut α (Fixed.Vector U.Vector Int)
+    , Mut α (Fixed.Vector V.Vector (Int, Int))
+    , Mut α (Fixed.Vector U.Vector Int)
+    , Mut α (Fixed.Vector U.Vector Int)
+    )
+{-# NOINLINE worklistPureBorrowOpenOnceWorker #-}
+worklistPureBorrowOpenOnceWorker
+  stopAfter
+  current
+  offsets
+  marks
+  state
+  adjacency
+  payload
+  queue
+  outputLog
+    | stateVisits current >= stopAfter
+        || stateHead current >= stateTail current = Control.do
+        state <- writeTraversalStatePureBorrow current state
+        Control.pure
+          ( Ur current
+          , offsets
+          , marks
+          , state
+          , adjacency
+          , payload
+          , queue
+          , outputLog
+          )
+    | otherwise = Control.do
+        (Ur node, queue) <-
+          Fixed.unsafeGet (stateHead current) queue
+        (Ur start, offsets) <-
+          Fixed.unsafeGet node offsets
+        (Ur end, offsets) <-
+          Fixed.unsafeGet (node + 1) offsets
+        ( Ur (nextTail, nextEnqueues, nodeDigest)
+          , adjacency
+          , payload
+          , marks
+          , queue
+          ) <-
+          worklistPureBorrowOpenOnceEdgeWorker
+            start
+            end
+            (stateTail current)
+            (stateEnqueues current)
+            (stateDigest current)
+            adjacency
+            payload
+            marks
+            queue
+        let !logValue = digestToLogValue nodeDigest node
+        outputLog <-
+          Fixed.unsafeWrite
+            (stateLogSize current)
+            logValue
+            outputLog
+        let !nextState =
+              TraversalState
+                { stateHead = stateHead current + 1
+                , stateTail = nextTail
+                , stateVisits = stateVisits current + 1
+                , stateEnqueues = nextEnqueues
+                , stateLogSize = stateLogSize current + 1
+                , stateDigest = mixDigest nodeDigest logValue
+                }
+        worklistPureBorrowOpenOnceWorker
+          stopAfter
+          nextState
+          offsets
+          marks
+          state
+          adjacency
+          payload
+          queue
+          outputLog
+
+worklistPureBorrowOpenOnceEdgeWorker ::
+  Int ->
+  Int ->
+  Int ->
+  Int ->
+  Int64 ->
+  Mut α (Fixed.Vector U.Vector Int) %1 ->
+  Mut α (Fixed.Vector V.Vector (Int, Int)) %1 ->
+  Mut α (Fixed.Vector U.Vector Int) %1 ->
+  Mut α (Fixed.Vector U.Vector Int) %1 ->
+  BO
+    α
+    ( Ur (Int, Int, Int64)
+    , Mut α (Fixed.Vector U.Vector Int)
+    , Mut α (Fixed.Vector V.Vector (Int, Int))
+    , Mut α (Fixed.Vector U.Vector Int)
+    , Mut α (Fixed.Vector U.Vector Int)
+    )
+-- This benchmark-internal export exists only to anchor optimized-Core
+-- inspection. Its indices are unchecked; only the benchmark roots establish
+-- the edge, neighbor, and queue-capacity bounds required by the unsafe element
+-- operations.
+{-# INLINEABLE worklistPureBorrowOpenOnceEdgeWorker #-}
+worklistPureBorrowOpenOnceEdgeWorker
+  edge
+  end
+  tailIndex
+  enqueues
+  digest
+  adjacency
+  payload
+  marks
+  queue
+    | edge >= end =
+        Control.pure
+          ( Ur (tailIndex, enqueues, digest)
+          , adjacency
+          , payload
+          , marks
+          , queue
+          )
+    | otherwise = Control.do
+        (Ur neighbor, adjacency) <-
+          Fixed.unsafeGet edge adjacency
+        (Ur (tag, delta), payload) <-
+          Fixed.unsafeGet edge payload
+        (Ur marked, marks) <-
+          Fixed.unsafeGet neighbor marks
+        let !nextDigest =
+              mixDigest
+                digest
+                (neighbor * 31 + tag * 17 + delta + marked)
+        if marked == 0
+          then Control.do
+            marks <-
+              Fixed.unsafeWrite neighbor 1 marks
+            queue <-
+              Fixed.unsafeWrite tailIndex neighbor queue
+            worklistPureBorrowOpenOnceEdgeWorker
+              (edge + 1)
+              end
+              (tailIndex + 1)
+              (enqueues + 1)
+              nextDigest
+              adjacency
+              payload
+              marks
+              queue
+          else
+            worklistPureBorrowOpenOnceEdgeWorker
+              (edge + 1)
+              end
+              tailIndex
+              enqueues
+              nextDigest
+              adjacency
+              payload
+              marks
+              queue
+
+readTraversalState ::
+  Mut α (Fixed.Vector U.Vector Int) %1 ->
+  BO
+    α
+    ( Ur TraversalState
+    , Mut α (Fixed.Vector U.Vector Int)
+    )
+readTraversalState state = Control.do
+  (Ur headIndex, state) <- Fixed.unsafeGet 0 state
+  (Ur tailIndex, state) <- Fixed.unsafeGet 1 state
+  (Ur visits, state) <- Fixed.unsafeGet 2 state
+  (Ur enqueues, state) <- Fixed.unsafeGet 3 state
+  (Ur logSize, state) <- Fixed.unsafeGet 4 state
+  Control.pure
+    ( Ur
+        TraversalState
+          { stateHead = headIndex
+          , stateTail = tailIndex
+          , stateVisits = visits
+          , stateEnqueues = enqueues
+          , stateLogSize = logSize
+          , stateDigest = initialDigest
+          }
+    , state
+    )
+
+writeTraversalStatePureBorrow ::
+  TraversalState ->
+  Mut α (Fixed.Vector U.Vector Int) %1 ->
+  BO α (Mut α (Fixed.Vector U.Vector Int))
+writeTraversalStatePureBorrow traversal state = Control.do
+  state <- Fixed.unsafeWrite 0 (stateHead traversal) state
+  state <- Fixed.unsafeWrite 1 (stateTail traversal) state
+  state <- Fixed.unsafeWrite 2 (stateVisits traversal) state
+  state <- Fixed.unsafeWrite 3 (stateEnqueues traversal) state
+  Fixed.unsafeWrite 4 (stateLogSize traversal) state
+
+consumeWorklistViews ::
+  Mut α (Fixed.Vector U.Vector Int) %1 ->
+  Mut α (Fixed.Vector U.Vector Int) %1 ->
+  Mut α (Fixed.Vector U.Vector Int) %1 ->
+  Mut α (Fixed.Vector U.Vector Int) %1 ->
+  Mut α (Fixed.Vector V.Vector (Int, Int)) %1 ->
+  Mut α (Fixed.Vector U.Vector Int) %1 ->
+  Mut α (Fixed.Vector U.Vector Int) %1 ->
+  ()
+consumeWorklistViews
+  offsets
+  marks
+  state
+  adjacency
+  payload
+  queue
+  outputLog =
+    let !(Ur _) = share offsets
+        !(Ur _) = share marks
+        !(Ur _) = share state
+        !(Ur _) = share adjacency
+        !(Ur _) = share payload
+        !(Ur _) = share queue
+        !(Ur _) = share outputLog
+     in ()
+
+outcomeFor :: WorklistTarget -> TraversalState -> WorklistOutcome
+outcomeFor target traversal
+  | target == StopEarly
+      && stateVisits traversal >= targetVisits target =
+      Stopped
+  | otherwise =
+      Drained
+
+runOpenOnce ::
+  Int ->
+  UM.MVector s Int ->
+  UM.MVector s Int ->
+  MV.MVector s (Int, Int) ->
+  UM.MVector s Int ->
+  UM.MVector s Int ->
+  UM.MVector s Int ->
+  TraversalState ->
+  ST s TraversalState
+runOpenOnce stopAfter offsets adjacency payload marks queue outputLog current
+  | stateVisits current >= stopAfter =
+      pure current
+  | stateHead current >= stateTail current =
+      pure current
+  | otherwise = do
+      node <- UM.unsafeRead queue (stateHead current)
+      start <- UM.unsafeRead offsets node
+      end <- UM.unsafeRead offsets (node + 1)
+      (nextTail, nextEnqueues, nodeDigest) <-
+        scanEdgesOpenOnce
+          start
+          end
+          adjacency
+          payload
+          marks
+          queue
+          (stateTail current)
+          (stateEnqueues current)
+          (stateDigest current)
+      let !logValue = digestToLogValue nodeDigest node
+      UM.unsafeWrite outputLog (stateLogSize current) logValue
+      let !nextState =
+            TraversalState
+              { stateHead = stateHead current + 1
+              , stateTail = nextTail
+              , stateVisits = stateVisits current + 1
+              , stateEnqueues = nextEnqueues
+              , stateLogSize = stateLogSize current + 1
+              , stateDigest = mixDigest nodeDigest logValue
+              }
+      runOpenOnce
+        stopAfter
+        offsets
+        adjacency
+        payload
+        marks
+        queue
+        outputLog
+        nextState
+
+scanEdgesOpenOnce ::
+  Int ->
+  Int ->
+  UM.MVector s Int ->
+  MV.MVector s (Int, Int) ->
+  UM.MVector s Int ->
+  UM.MVector s Int ->
+  Int ->
+  Int ->
+  Int64 ->
+  ST s (Int, Int, Int64)
+scanEdgesOpenOnce edge end adjacency payload marks queue tailIndex enqueues digest
+  | edge >= end =
+      pure (tailIndex, enqueues, digest)
+  | otherwise = do
+      neighbor <- UM.unsafeRead adjacency edge
+      (tag, delta) <- MV.unsafeRead payload edge
+      marked <- UM.unsafeRead marks neighbor
+      let !nextDigest =
+            mixDigest
+              digest
+              (neighbor * 31 + tag * 17 + delta + marked)
+      if marked == 0
+        then do
+          UM.unsafeWrite marks neighbor 1
+          UM.unsafeWrite queue tailIndex neighbor
+          scanEdgesOpenOnce
+            (edge + 1)
+            end
+            adjacency
+            payload
+            marks
+            queue
+            (tailIndex + 1)
+            (enqueues + 1)
+            nextDigest
+        else
+          scanEdgesOpenOnce
+            (edge + 1)
+            end
+            adjacency
+            payload
+            marks
+            queue
+            tailIndex
+            enqueues
+            nextDigest
+
+runFlatReopenDirect ::
+  WorklistGrowth ->
+  WorklistTarget ->
+  UM.MVector s Int ->
+  UM.MVector s Int ->
+  UM.MVector s Int ->
+  STRef s (UnboxedHeader s) ->
+  STRef s (BoxedHeader s) ->
+  STRef s (UnboxedHeader s) ->
+  STRef s (UnboxedHeader s) ->
+  TraversalState ->
+  Int ->
+  Int ->
+  Int ->
+  ST s (TraversalState, Int, Int, Int, WorklistOutcome)
+runFlatReopenDirect
+  growth
+  target
+  offsets
+  marks
+  state
+  adjacencyHeader
+  payloadHeader
+  queueHeader
+  logHeader
+  current
+  scopes
+  updates
+  growths
+    | stateVisits current >= targetVisits target =
+        pure
+          ( current
+          , scopes
+          , updates
+          , growths
+          , case target of
+              Drain -> Drained
+              StopEarly -> Stopped
+          )
+    | stateHead current >= stateTail current =
+        pure (current, scopes, updates, growths, Drained)
+    | otherwise = do
+        UnboxedHeader _ adjacency <- readSTRef adjacencyHeader
+        BoxedHeader _ payload <- readSTRef payloadHeader
+        (segment, nextScopes, nextUpdates, nextGrowths) <-
+          runReopenSegmentDirect
+            growth
+            target
+            offsets
+            adjacency
+            payload
+            marks
+            state
+            queueHeader
+            logHeader
+            current
+            scopes
+            updates
+            growths
+        if segmentStopped segment
+          then
+            pure
+              ( segmentState segment
+              , nextScopes
+              , nextUpdates
+              , nextGrowths
+              , case target of
+                  Drain -> Drained
+                  StopEarly -> Stopped
+              )
+          else
+            runFlatReopenDirect
+              growth
+              target
+              offsets
+              marks
+              state
+              adjacencyHeader
+              payloadHeader
+              queueHeader
+              logHeader
+              (segmentState segment)
+              nextScopes
+              nextUpdates
+              nextGrowths
+
+runNestedReopenDirect ::
+  WorklistGrowth ->
+  WorklistTarget ->
+  UM.MVector s Int ->
+  UM.MVector s Int ->
+  MV.MVector s (Int, Int) ->
+  UM.MVector s Int ->
+  UM.MVector s Int ->
+  STRef s (UnboxedHeader s) ->
+  STRef s (UnboxedHeader s) ->
+  TraversalState ->
+  Int ->
+  Int ->
+  Int ->
+  ST s (TraversalState, Int, Int, Int, WorklistOutcome)
+runNestedReopenDirect
+  growth
+  target
+  offsets
+  adjacency
+  payload
+  marks
+  state
+  queueHeader
+  logHeader
+  current
+  scopes
+  updates
+  growths
+    | stateVisits current >= targetVisits target =
+        pure
+          ( current
+          , scopes
+          , updates
+          , growths
+          , case target of
+              Drain -> Drained
+              StopEarly -> Stopped
+          )
+    | stateHead current >= stateTail current =
+        pure (current, scopes, updates, growths, Drained)
+    | otherwise = do
+        (segment, nextScopes, nextUpdates, nextGrowths) <-
+          runReopenSegmentDirect
+            growth
+            target
+            offsets
+            adjacency
+            payload
+            marks
+            state
+            queueHeader
+            logHeader
+            current
+            scopes
+            updates
+            growths
+        if segmentStopped segment
+          then
+            pure
+              ( segmentState segment
+              , nextScopes
+              , nextUpdates
+              , nextGrowths
+              , case target of
+                  Drain -> Drained
+                  StopEarly -> Stopped
+              )
+          else
+            runNestedReopenDirect
+              growth
+              target
+              offsets
+              adjacency
+              payload
+              marks
+              state
+              queueHeader
+              logHeader
+              (segmentState segment)
+              nextScopes
+              nextUpdates
+              nextGrowths
+
+runReopenSegmentDirect ::
+  WorklistGrowth ->
+  WorklistTarget ->
+  UM.MVector s Int ->
+  UM.MVector s Int ->
+  MV.MVector s (Int, Int) ->
+  UM.MVector s Int ->
+  UM.MVector s Int ->
+  STRef s (UnboxedHeader s) ->
+  STRef s (UnboxedHeader s) ->
+  TraversalState ->
+  Int ->
+  Int ->
+  Int ->
+  ST s (SegmentResult, Int, Int, Int)
+{-# INLINE runReopenSegmentDirect #-}
+runReopenSegmentDirect
+  growth
+  target
+  offsets
+  adjacency
+  payload
+  marks
+  state
+  queueHeader
+  logHeader
+  current
+  scopes
+  updates
+  growths = do
+    UnboxedHeader queueSize queue <- readSTRef queueHeader
+    UnboxedHeader _ outputLog <- readSTRef logHeader
+    when (queueSize /= stateTail current) $
+      error "worklist queue header and scalar tail diverged"
+    when (UM.length outputLog < stateLogSize current) $
+      error "worklist log header and scalar frontier diverged"
+    segment <-
+      runSegment
+        (targetVisits target)
+        (min queueSize (stateHead current + worklistBatchSize growth))
+        offsets
+        adjacency
+        payload
+        marks
+        queue
+        current
+        []
+        []
+    let !pending = U.fromList (reverse (segmentPendingRev segment))
+        !newLogs = U.fromList (reverse (segmentLogRev segment))
+    queueGrew <-
+      if U.null pending
+        then pure False
+        else appendUnboxed queueHeader pending
+    logGrew <- appendUnboxed logHeader newLogs
+    writeTraversalState state (segmentState segment)
+    let !nextScopes = scopes + 1
+        !nextUpdates =
+          updates
+            + (if U.null pending then 0 else 1)
+            + 1
+        !nextGrowths =
+          growths
+            + fromEnum queueGrew
+            + fromEnum logGrew
+    pure (segment, nextScopes, nextUpdates, nextGrowths)
+
+runSegment ::
+  Int ->
+  Int ->
+  UM.MVector s Int ->
+  UM.MVector s Int ->
+  MV.MVector s (Int, Int) ->
+  UM.MVector s Int ->
+  UM.MVector s Int ->
+  TraversalState ->
+  [Int] ->
+  [Int] ->
+  ST s SegmentResult
+runSegment stopAfter snapshotTail offsets adjacency payload marks queue current queueRev logRev
+  | stateVisits current >= stopAfter =
+      pure (SegmentResult current queueRev logRev True)
+  | stateHead current >= snapshotTail =
+      pure (SegmentResult current queueRev logRev False)
+  | otherwise = do
+      node <- UM.unsafeRead queue (stateHead current)
+      start <- UM.unsafeRead offsets node
+      end <- UM.unsafeRead offsets (node + 1)
+      (nextTail, nextEnqueues, nextQueueRev, nodeDigest) <-
+        scanEdgesSegment
+          start
+          end
+          adjacency
+          payload
+          marks
+          (stateTail current)
+          (stateEnqueues current)
+          queueRev
+          (stateDigest current)
+      let !logValue = digestToLogValue nodeDigest node
+          !nextState =
+            TraversalState
+              { stateHead = stateHead current + 1
+              , stateTail = nextTail
+              , stateVisits = stateVisits current + 1
+              , stateEnqueues = nextEnqueues
+              , stateLogSize = stateLogSize current + 1
+              , stateDigest = mixDigest nodeDigest logValue
+              }
+      runSegment
+        stopAfter
+        snapshotTail
+        offsets
+        adjacency
+        payload
+        marks
+        queue
+        nextState
+        nextQueueRev
+        (logValue : logRev)
+
+scanEdgesSegment ::
+  Int ->
+  Int ->
+  UM.MVector s Int ->
+  MV.MVector s (Int, Int) ->
+  UM.MVector s Int ->
+  Int ->
+  Int ->
+  [Int] ->
+  Int64 ->
+  ST s (Int, Int, [Int], Int64)
+scanEdgesSegment edge end adjacency payload marks tailIndex enqueues queueRev digest
+  | edge >= end =
+      pure (tailIndex, enqueues, queueRev, digest)
+  | otherwise = do
+      neighbor <- UM.unsafeRead adjacency edge
+      (tag, delta) <- MV.unsafeRead payload edge
+      marked <- UM.unsafeRead marks neighbor
+      let !nextDigest =
+            mixDigest
+              digest
+              (neighbor * 31 + tag * 17 + delta + marked)
+      if marked == 0
+        then do
+          UM.unsafeWrite marks neighbor 1
+          scanEdgesSegment
+            (edge + 1)
+            end
+            adjacency
+            payload
+            marks
+            (tailIndex + 1)
+            (enqueues + 1)
+            (neighbor : queueRev)
+            nextDigest
+        else
+          scanEdgesSegment
+            (edge + 1)
+            end
+            adjacency
+            payload
+            marks
+            tailIndex
+            enqueues
+            queueRev
+            nextDigest
+
+finishDirect ::
+  WorklistOutcome ->
+  Int ->
+  Int ->
+  Int ->
+  Int ->
+  UM.MVector s Int ->
+  UM.MVector s Int ->
+  MV.MVector s (Int, Int) ->
+  UM.MVector s Int ->
+  UM.MVector s Int ->
+  UM.MVector s Int ->
+  UM.MVector s Int ->
+  TraversalState ->
+  ST s WorklistOutput
+finishDirect
+  finalOutcome
+  opens
+  resumes
+  updates
+  growths
+  offsets
+  adjacency
+  payload
+  marks
+  state
+  queue
+  outputLog
+  traversal = do
+    offsetsVector <- U.unsafeFreeze offsets
+    adjacencyVector <- U.unsafeFreeze adjacency
+    payloadVector <- V.unsafeFreeze payload
+    marksVector <- U.unsafeFreeze marks
+    stateVector <- U.unsafeFreeze state
+    queueVector <-
+      U.unsafeFreeze (UM.unsafeTake (stateTail traversal) queue)
+    logVector <-
+      U.unsafeFreeze (UM.unsafeTake (stateLogSize traversal) outputLog)
+    U.length offsetsVector `seq`
+      U.length adjacencyVector `seq`
+        V.length payloadVector `seq`
+          pure
+            ( makeWorklistOutput
+                finalOutcome
+                opens
+                resumes
+                updates
+                growths
+                traversal
+                marksVector
+                stateVector
+                queueVector
+                logVector
+            )
+
+finishWorklistStore ::
+  WorklistOutcome ->
+  Int ->
+  Int ->
+  Int ->
+  Int ->
+  TraversalState ->
+  WorklistStore %1 ->
+  Ur WorklistOutput
+{-# NOINLINE finishWorklistStore #-}
+finishWorklistStore
+  finalOutcome
+  opens
+  resumes
+  updates
+  growths
+  traversal
+  ( WorklistStore
+      (WorklistFixedRoots offsetsOwner marksOwner stateOwner)
+      (WorklistGraphRoots adjacencyOwner payloadOwner)
+      (WorklistFrontierRoots queueOwner logOwner)
+    ) =
+    case Fixed.toVector offsetsOwner of
+      Ur offsetsVector ->
+        case Fixed.toVector marksOwner of
+          Ur marksVector ->
+            case Fixed.toVector stateOwner of
+              Ur stateVector ->
+                case Growable.toVector adjacencyOwner of
+                  Ur adjacencyVector ->
+                    case Growable.toVector payloadOwner of
+                      Ur payloadVector ->
+                        case Growable.toVector queueOwner of
+                          Ur queueVector ->
+                            case Growable.toVector logOwner of
+                              Ur logVector ->
+                                U.length offsetsVector `lseq`
+                                  U.length adjacencyVector `lseq`
+                                    V.length payloadVector `lseq`
+                                      Ur
+                                        ( makeWorklistOutput
+                                            finalOutcome
+                                            opens
+                                            resumes
+                                            updates
+                                            growths
+                                            traversal
+                                            marksVector
+                                            stateVector
+                                            ( U.take
+                                                (stateTail traversal)
+                                                queueVector
+                                            )
+                                            ( U.take
+                                                (stateLogSize traversal)
+                                                logVector
+                                            )
+                                        )
+
+makeWorklistOutput ::
+  WorklistOutcome ->
+  Int ->
+  Int ->
+  Int ->
+  Int ->
+  TraversalState ->
+  U.Vector Int ->
+  U.Vector Int ->
+  U.Vector Int ->
+  U.Vector Int ->
+  WorklistOutput
+makeWorklistOutput
+  finalOutcome
+  opens
+  resumes
+  updates
+  growths
+  traversal
+  marksVector
+  stateVector
+  queueVector
+  logVector =
+    let !digest =
+          digestOutput
+            (stateDigest traversal)
+            marksVector
+            stateVector
+            queueVector
+            logVector
+        !visits = stateVisits traversal
+        !enqueues = stateEnqueues traversal
+     in WorklistOutput
+          { summary =
+              WorklistSummary
+                { outcome = finalOutcome
+                , visitedNodes = visits
+                , enqueueTransitions = enqueues
+                , offsetReads = visits * 2
+                , adjacencyReads = visits * worklistDegree
+                , payloadReads = visits * worklistDegree
+                , markReads = visits * worklistDegree
+                , markWrites = enqueues
+                , queueReads = visits
+                , queueWrites = enqueues
+                , logWrites = visits
+                , contentOpens = opens
+                , resumeBoundaries = resumes
+                , headerUpdates = updates
+                , bufferGrowths = growths
+                , finalDigest = digest
+                }
+          , finalMarks = marksVector
+          , finalState = stateVector
+          , finalQueue = queueVector
+          , finalLog = logVector
+          }
+
+writeTraversalState :: UM.MVector s Int -> TraversalState -> ST s ()
+writeTraversalState state traversal = do
+  UM.unsafeWrite state 0 (stateHead traversal)
+  UM.unsafeWrite state 1 (stateTail traversal)
+  UM.unsafeWrite state 2 (stateVisits traversal)
+  UM.unsafeWrite state 3 (stateEnqueues traversal)
+  UM.unsafeWrite state 4 (stateLogSize traversal)
+
+newUnboxedHeaderFromVector :: U.Vector Int -> ST s (STRef s (UnboxedHeader s))
+newUnboxedHeaderFromVector vector = do
+  buffer <- U.thaw vector
+  newSTRef (UnboxedHeader (U.length vector) buffer)
+
+newBoxedHeaderFromVector :: V.Vector (Int, Int) -> ST s (STRef s (BoxedHeader s))
+newBoxedHeaderFromVector vector = do
+  buffer <- V.thaw vector
+  newSTRef (BoxedHeader (V.length vector) buffer)
+
+newUnboxedHeader :: Int -> U.Vector Int -> ST s (STRef s (UnboxedHeader s))
+newUnboxedHeader requested initial = do
+  let !capacity = max requested (U.length initial)
+  buffer <- UM.new capacity
+  U.copy (UM.unsafeTake (U.length initial) buffer) initial
+  newSTRef (UnboxedHeader (U.length initial) buffer)
+
+appendUnboxed :: STRef s (UnboxedHeader s) -> U.Vector Int -> ST s Bool
+appendUnboxed header values = do
+  UnboxedHeader logicalSize buffer <- readSTRef header
+  let !required = logicalSize + U.length values
+      !oldCapacity = UM.length buffer
+      !target = growthTarget oldCapacity required
+  (grown, didGrow) <-
+    if target <= oldCapacity
+      then pure (buffer, False)
+      else do
+        grown <- UM.new target
+        UM.unsafeCopy
+          (UM.unsafeTake logicalSize grown)
+          (UM.unsafeTake logicalSize buffer)
+        pure (grown, True)
+  U.copy (UM.unsafeSlice logicalSize (U.length values) grown) values
+  writeSTRef header (UnboxedHeader required grown)
+  pure didGrow
+
+worklistInitialCapacity :: WorklistGrowth -> Int
+worklistInitialCapacity NoGrowth = worklistNodeCount
+worklistInitialCapacity NoGrowthBatch64 = worklistNodeCount
+worklistInitialCapacity NoGrowthBatch8 = worklistNodeCount
+worklistInitialCapacity SparseGrowth = 256
+worklistInitialCapacity DenseGrowth = 1
+
+worklistBatchSize :: WorklistGrowth -> Int
+worklistBatchSize NoGrowth = 256
+worklistBatchSize NoGrowthBatch64 = 64
+worklistBatchSize NoGrowthBatch8 = 8
+worklistBatchSize SparseGrowth = 64
+worklistBatchSize DenseGrowth = 8
+
+growthTarget :: Int -> Int -> Int
+growthTarget oldCapacity required
+  | required <= oldCapacity = oldCapacity
+  | oldCapacity <= 0 = max required 1
+  | oldCapacity > maxBound `quot` 2 = required
+  | otherwise = max required (oldCapacity * 2)
+
+initialDigest :: Int64
+initialDigest = 0x51A7C0DE
+
+initialDigestForSeed :: Int -> Int64
+initialDigestForSeed seed =
+  initialDigest + fromIntegral seed
+
+digestToLogValue :: Int64 -> Int -> Int
+digestToLogValue digest node =
+  fromIntegral
+    ((digest + fromIntegral (node * 97 + 11)) `rem` 1000000007)
+
+digestOutput ::
+  Int64 ->
+  U.Vector Int ->
+  U.Vector Int ->
+  U.Vector Int ->
+  U.Vector Int ->
+  Int64
+digestOutput initial marks state queue outputLog =
+  let !marksDigest =
+        U.ifoldl'
+          (\digest index value -> mixDigest digest (index * 17 + value))
+          initial
+          marks
+      !stateDigest =
+        U.ifoldl'
+          (\digest index value -> mixDigest digest (index * 19 + value))
+          marksDigest
+          state
+      !queueDigest =
+        U.ifoldl'
+          (\digest index value -> mixDigest digest (index * 23 + value))
+          stateDigest
+          queue
+   in U.ifoldl'
+        (\digest index value -> mixDigest digest (index * 29 + value))
+        queueDigest
+        outputLog
+
+mixDigest :: Int64 -> Int -> Int64
+mixDigest digest value =
+  (digest * 6364136223846793005)
+    + fromIntegral value
+    + 1442695040888963407

--- a/pure-borrow.cabal
+++ b/pure-borrow.cabal
@@ -188,6 +188,8 @@ test-suite pure-borrow-test
     Data.Vector.Unboxed.Mutable.Growable.Linear.TypingCases
     Data.Vector.Unboxed.Mutable.Linear.BorrowSpec
     Data.Vector.Unboxed.Mutable.Linear.TypingCases
+    PureBorrow.Internal.Bench.MultiStoreScanSpec
+    PureBorrow.Internal.Bench.Worklist.ResumeSpec
 
   ghc-options:
     -O2
@@ -220,7 +222,9 @@ test-suite pure-borrow-inspection
   other-modules:
     PureBorrow.Inspection.Fft
     PureBorrow.Inspection.GenericGrowableUnrestricted
+    PureBorrow.Inspection.MultiStoreScan
     PureBorrow.Inspection.QSort
+    PureBorrow.Inspection.Worklist.Resume
 
   ghc-options:
     -O2
@@ -228,6 +232,7 @@ test-suite pure-borrow-inspection
 
   build-depends:
     pure-borrow,
+    pure-borrow:test-bench-common,
     tasty,
     tasty-inspection-testing,
     vector,
@@ -254,52 +259,24 @@ test-suite pure-borrow-doctests
     doctest-parallel >=0.4.1,
     pure-borrow,
 
--- Kernels shared by `pure-borrow-test` and the benchmark suites. Kernels used
--- only by a benchmark live under `bench/suite` instead.
+-- Hosts the common cases used in both benchmarks and tests.
 library test-bench-common
   import: defaults
   hs-source-dirs: internal-src/test-bench-common
   -- cabal-gild: discover internal-src/test-bench-common
   exposed-modules:
+    PureBorrow.Internal.Bench.MultiStoreScan
     PureBorrow.Internal.Bench.Unboxed
+    PureBorrow.Internal.Bench.Worklist.Resume
 
   build-depends:
     base >=4.7 && <5,
+    deepseq,
     pure-borrow,
     tasty-bench,
     vector,
 
-  default-language: GHC2021
-
-benchmark pure-borrow-bench
-  import: defaults
-  type: exitcode-stdio-1.0
-  main-is: Main.hs
-  hs-source-dirs: bench/suite
-  -- cabal-gild: discover bench/suite --exclude=bench/suite/Main.hs
-  other-modules:
-    PureBorrow.Bench.CopyAt
-    PureBorrow.Bench.Growable
-    PureBorrow.Bench.Ingredients
-    PureBorrow.Bench.Unboxed
-
-  ghc-options:
-    -threaded
-    -rtsopts
-    -O2
-    "-with-rtsopts=-N1 -T"
-
-  build-tool-depends:
-    tasty-discover:tasty-discover >=5.0.1
-
-  build-depends:
-    base >=4.7 && <5,
-    pure-borrow,
-    pure-borrow:test-bench-common,
-    tasty,
-    tasty-bench,
-    vector,
-
+  ghc-options: -O2
   default-language: GHC2021
 
 benchmark qsort-bench
@@ -321,6 +298,44 @@ benchmark qsort-bench
     tasty-bench,
     vector,
     vector-algorithms,
+
+  default-language: GHC2021
+
+-- Every single-threaded micro-benchmark lives here, discovered by
+-- tasty-discover from bench/suite. Kernels shared with pure-borrow-test or
+-- pure-borrow-inspection stay in lib:test-bench-common and are re-exported by a
+-- thin module under PureBorrow.Bench; kernels used only by this benchmark live
+-- in bench/suite directly.
+benchmark pure-borrow-bench
+  import: defaults
+  type: exitcode-stdio-1.0
+  main-is: Main.hs
+  hs-source-dirs: bench/suite
+  -- cabal-gild: discover bench/suite --exclude=bench/suite/Main.hs
+  other-modules:
+    PureBorrow.Bench.CopyAt
+    PureBorrow.Bench.Growable
+    PureBorrow.Bench.Ingredients
+    PureBorrow.Bench.MultiStoreScan
+    PureBorrow.Bench.Unboxed
+    PureBorrow.Bench.Worklist.Resume
+
+  ghc-options:
+    -threaded
+    -rtsopts
+    -O2
+    "-with-rtsopts=-N1 -T"
+
+  build-tool-depends:
+    tasty-discover:tasty-discover >=5.0.1
+
+  build-depends:
+    base >=4.7 && <5,
+    pure-borrow,
+    pure-borrow:test-bench-common,
+    tasty,
+    tasty-bench,
+    vector,
 
   default-language: GHC2021
 

--- a/test-inspection/Main.hs
+++ b/test-inspection/Main.hs
@@ -2,7 +2,9 @@ module Main (main) where
 
 import PureBorrow.Inspection.Fft qualified as Fft
 import PureBorrow.Inspection.GenericGrowableUnrestricted qualified as GenericGrowableUnrestricted
+import PureBorrow.Inspection.MultiStoreScan qualified as MultiStoreScan
 import PureBorrow.Inspection.QSort qualified as QSort
+import PureBorrow.Inspection.Worklist.Resume qualified as WorklistResume
 import Test.Tasty (defaultMain, testGroup)
 
 main :: IO ()
@@ -12,5 +14,7 @@ main =
       "optimized Core"
       [ Fft.tests
       , GenericGrowableUnrestricted.tests
+      , MultiStoreScan.tests
       , QSort.tests
+      , WorklistResume.tests
       ]

--- a/test-inspection/PureBorrow/Inspection/MultiStoreScan.hs
+++ b/test-inspection/PureBorrow/Inspection/MultiStoreScan.hs
@@ -1,0 +1,122 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module PureBorrow.Inspection.MultiStoreScan (
+  tests,
+  hotWorker,
+  boxedContentProjection,
+  unboxedContentProjection,
+) where
+
+import Control.Monad.Borrow.Pure.BO (BO, Mut)
+import Control.Monad.Borrow.Pure.Experimental.Borrows (Aliases)
+import Data.Int (Int64)
+import Data.Vector qualified as V
+import Data.Vector.Generic.Mutable.Growable.Linear.Borrow.Unrestricted qualified as Growable
+import Data.Vector.Generic.Mutable.Linear.Borrow.Unrestricted qualified as Fixed
+import Data.Vector.Unboxed qualified as U
+import Prelude.Linear
+import PureBorrow.Internal.Bench.MultiStoreScan
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.Inspection
+
+hotWorker ::
+  Int ->
+  Int ->
+  Int ->
+  Int64 ->
+  Mut α (Fixed.Vector U.Vector Int) %1 ->
+  Mut α (Fixed.Vector U.Vector Int) %1 ->
+  Mut α (Fixed.Vector U.Vector Int) %1 ->
+  Mut α (Fixed.Vector V.Vector (Int, Int)) %1 ->
+  Mut α (Fixed.Vector U.Vector Int) %1 ->
+  Mut α (Fixed.Vector U.Vector Int) %1 ->
+  BO
+    α
+    ( Ur Int64
+    , Mut α (Fixed.Vector U.Vector Int)
+    , Mut α (Fixed.Vector U.Vector Int)
+    , Mut α (Fixed.Vector U.Vector Int)
+    , Mut α (Fixed.Vector V.Vector (Int, Int))
+    , Mut α (Fixed.Vector U.Vector Int)
+    , Mut α (Fixed.Vector U.Vector Int)
+    )
+{-# NOINLINE hotWorker #-}
+hotWorker = multiStoreScanPureBorrowWorker
+
+boxedContentProjection ::
+  Mut α (Growable.GrowableVector V.Vector (Int, Int)) %1 ->
+  Mut α (Fixed.Vector V.Vector (Int, Int))
+{-# NOINLINE boxedContentProjection #-}
+boxedContentProjection = multiStoreScanBoxedContentProjection
+
+unboxedContentProjection ::
+  Mut α (Growable.GrowableVector U.Vector Int) %1 ->
+  Mut α (Fixed.Vector U.Vector Int)
+{-# NOINLINE unboxedContentProjection #-}
+unboxedContentProjection = multiStoreScanUnboxedContentProjection
+
+tests :: TestTree
+tests =
+  testGroup
+    "multi-store scan"
+    [ $( inspectTest
+           ( (hasNoTypeClasses 'hotWorker)
+               { testName =
+                   Just "hot worker has no type-class dictionaries"
+               }
+           )
+       )
+    , $( inspectTest
+           ( (hasNoType 'hotWorker ''Growable.GrowableVector)
+               { testName =
+                   Just "hot worker has no growable header"
+               }
+           )
+       )
+    , $( inspectTest
+           ( (hasNoType 'hotWorker ''Aliases)
+               { testName =
+                   Just "hot worker has no plural-borrow bundle"
+               }
+           )
+       )
+    , $( inspectTest
+           ( ( doesNotUseAnyOf
+                 'hotWorker
+                 [ 'multiStoreScanPureBorrowWorker
+                 , 'Fixed.unsafeGet
+                 , 'Fixed.unsafeWrite
+                 , 'Growable.getContents
+                 ]
+             )
+               { testName =
+                   Just "hot worker contains no generic access or projection calls"
+               }
+           )
+       )
+    , $( inspectTest
+           ( ( doesNotUseAnyOf
+                 'boxedContentProjection
+                 [ 'multiStoreScanBoxedContentProjection
+                 , 'Growable.getContents
+                 ]
+             )
+               { testName =
+                   Just "boxed projection inlines getContents"
+               }
+           )
+       )
+    , $( inspectTest
+           ( ( doesNotUseAnyOf
+                 'unboxedContentProjection
+                 [ 'multiStoreScanUnboxedContentProjection
+                 , 'Growable.getContents
+                 ]
+             )
+               { testName =
+                   Just "unboxed projection inlines getContents"
+               }
+           )
+       )
+    ]

--- a/test-inspection/PureBorrow/Inspection/Worklist/Resume.hs
+++ b/test-inspection/PureBorrow/Inspection/Worklist/Resume.hs
@@ -1,0 +1,130 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module PureBorrow.Inspection.Worklist.Resume (
+  tests,
+  resumeEdgeWorker,
+  openOnceEdgeWorker,
+) where
+
+import Control.Monad.Borrow.Pure.BO (BO, Borrow, Mut)
+import Control.Monad.Borrow.Pure.Experimental.Borrows (Aliases, reborrowings)
+import Control.Monad.Borrow.Pure.Lifetime (type (>=))
+import Data.Int (Int64)
+import Data.Vector qualified as V
+import Data.Vector.Generic.Mutable.Growable.Linear.Borrow.Unrestricted qualified as Growable
+import Data.Vector.Generic.Mutable.Linear.Borrow.Unrestricted qualified as Fixed
+import Data.Vector.Unboxed qualified as U
+import Prelude.Linear
+import PureBorrow.Internal.Bench.Worklist.Resume
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.Inspection
+
+resumeEdgeWorker ::
+  (α >= δ, β >= δ, γ >= δ) =>
+  Int ->
+  Int ->
+  Int ->
+  Int ->
+  [Int] ->
+  Int64 ->
+  Borrow bk1 α (Fixed.Vector U.Vector Int) %1 ->
+  Borrow bk2 β (Fixed.Vector V.Vector (Int, Int)) %1 ->
+  Mut γ (Fixed.Vector U.Vector Int) %1 ->
+  BO
+    δ
+    ( Ur (Int, Int, [Int], Int64)
+    , Borrow bk1 α (Fixed.Vector U.Vector Int)
+    , Borrow bk2 β (Fixed.Vector V.Vector (Int, Int))
+    , Mut γ (Fixed.Vector U.Vector Int)
+    )
+{-# NOINLINE resumeEdgeWorker #-}
+resumeEdgeWorker = worklistPureBorrowResumeEdgeWorker
+
+openOnceEdgeWorker ::
+  Int ->
+  Int ->
+  Int ->
+  Int ->
+  Int64 ->
+  Mut α (Fixed.Vector U.Vector Int) %1 ->
+  Mut α (Fixed.Vector V.Vector (Int, Int)) %1 ->
+  Mut α (Fixed.Vector U.Vector Int) %1 ->
+  Mut α (Fixed.Vector U.Vector Int) %1 ->
+  BO
+    α
+    ( Ur (Int, Int, Int64)
+    , Mut α (Fixed.Vector U.Vector Int)
+    , Mut α (Fixed.Vector V.Vector (Int, Int))
+    , Mut α (Fixed.Vector U.Vector Int)
+    , Mut α (Fixed.Vector U.Vector Int)
+    )
+{-# NOINLINE openOnceEdgeWorker #-}
+openOnceEdgeWorker = worklistPureBorrowOpenOnceEdgeWorker
+
+tests :: TestTree
+tests =
+  testGroup
+    "worklist resume"
+    [ $( inspectTest
+           ( (hasNoTypeClasses 'resumeEdgeWorker)
+               { testName =
+                   Just "resume edge worker has no type-class dictionaries"
+               }
+           )
+       )
+    , $( inspectTest
+           ( (hasNoTypeClasses 'openOnceEdgeWorker)
+               { testName =
+                   Just "open-once edge worker has no type-class dictionaries"
+               }
+           )
+       )
+    , $( inspectTest
+           ( (hasNoType 'resumeEdgeWorker ''Growable.GrowableVector)
+               { testName =
+                   Just "resume edge worker has no growable header"
+               }
+           )
+       )
+    , $( inspectTest
+           ( (hasNoType 'resumeEdgeWorker ''Aliases)
+               { testName =
+                   Just "resume edge worker has no plural-borrow bundle"
+               }
+           )
+       )
+    , $( inspectTest
+           ( ( doesNotUseAnyOf
+                 'resumeEdgeWorker
+                 [ 'worklistPureBorrowResumeEdgeWorker
+                 , 'Fixed.unsafeGet
+                 , 'Fixed.unsafeWrite
+                 , 'Growable.getContents
+                 , 'Growable.extend
+                 , 'reborrowings
+                 ]
+             )
+               { testName =
+                   Just "resume edge worker contains only specialized backing access"
+               }
+           )
+       )
+    , $( inspectTest
+           ( ( doesNotUseAnyOf
+                 'openOnceEdgeWorker
+                 [ 'worklistPureBorrowOpenOnceEdgeWorker
+                 , 'Fixed.unsafeGet
+                 , 'Fixed.unsafeWrite
+                 , 'Growable.getContents
+                 , 'Growable.extend
+                 , 'reborrowings
+                 ]
+             )
+               { testName =
+                   Just "open-once edge worker contains only specialized backing access"
+               }
+           )
+       )
+    ]

--- a/test/PureBorrow/Internal/Bench/MultiStoreScanSpec.hs
+++ b/test/PureBorrow/Internal/Bench/MultiStoreScanSpec.hs
@@ -1,0 +1,96 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE TypeApplications #-}
+
+module PureBorrow.Internal.Bench.MultiStoreScanSpec (
+  module PureBorrow.Internal.Bench.MultiStoreScanSpec,
+) where
+
+import Control.Exception (SomeException, displayException, evaluate, try)
+import Data.List (isInfixOf)
+import Data.Vector qualified as V
+import Data.Vector.Unboxed qualified as U
+import PureBorrow.Internal.Bench.MultiStoreScan
+import Test.Tasty (TestTree)
+import Test.Tasty.HUnit
+
+test_multiStoreScanDirectEvidence :: TestTree
+test_multiStoreScanDirectEvidence =
+  testCase "multi-store scan direct control preserves its frozen trace and digest" do
+    let result = multiStoreScanDirectRoot multiStoreScanDirectInput
+    visitedNodes (resultSummary result) @?= 4096
+    elementReads (resultSummary result) @?= 24576
+    elementWrites (resultSummary result) @?= 1742
+    headerReads (resultSummary result) @?= 3
+    validationReads (resultSummary result) @?= 8198
+    finalDigest (resultSummary result) @?= 7192365686207673759
+    resultVisitedIndices result @?= U.fromList [0 .. 4095]
+    V.length (resultEvents result) @?= 26318
+    resultEventDigest result @?= -6999049615496738955
+    U.length (resultMarks result) @?= 4096
+    U.length (resultScores result) @?= 4096
+    let output =
+          multiStoreScanDirectBenchmarkRoot multiStoreScanDirectInput
+    outputDigest output @?= finalDigest (resultSummary result)
+    outputMarks output @?= resultMarks result
+    outputScores output @?= resultScores result
+
+test_multiStoreScanPureBorrowEvidence :: TestTree
+test_multiStoreScanPureBorrowEvidence =
+  testCase "all attribution and ownership shapes preserve the frozen output" do
+    let direct = multiStoreScanDirectRoot multiStoreScanDirectInput
+        directOutput =
+          multiStoreScanDirectBenchmarkRoot multiStoreScanDirectInput
+    multiStoreScanPureBorrowDirectRoot multiStoreScanDirectInput
+      @?= direct
+    multiStoreScanPureBorrowNestedRoot multiStoreScanDirectInput
+      @?= direct
+    multiStoreScanDirectHeaderMatchedBenchmarkRoot multiStoreScanDirectInput
+      @?= directOutput
+    multiStoreScanPureBorrowOwningBenchmarkRoot multiStoreScanDirectInput
+      @?= directOutput
+    multiStoreScanPureBorrowFixedUnrestrictedBenchmarkRoot multiStoreScanDirectInput
+      @?= directOutput
+    multiStoreScanPureBorrowDirectBenchmarkRoot multiStoreScanDirectInput
+      @?= directOutput
+    multiStoreScanPureBorrowNestedBenchmarkRoot multiStoreScanDirectInput
+      @?= directOutput
+
+test_multiStoreScanRejectsInvalidInputs :: TestTree
+test_multiStoreScanRejectsInvalidInputs =
+  testCase "all-unrestricted Pure Borrow shapes reject invalid inputs" do
+    let standard = multiStoreScanDirectInput
+        expectedDiagnostic =
+          "multi-store scan requires six 4096-element vectors, in-range next indices, and zero links"
+        invalidInputs =
+          [ standard {inputNext = U.replicate 4095 0}
+          , standard {inputWeight = U.replicate 4097 0}
+          , standard {inputMark = U.replicate 4095 0}
+          , standard {inputPayload = V.replicate 4097 (0, 0)}
+          , standard {inputScore = U.replicate 4095 0}
+          , standard {inputLink = U.replicate 4097 0}
+          , standard {inputNext = U.replicate 4096 (-1)}
+          , standard {inputNext = U.replicate 4096 4096}
+          , standard {inputLink = U.replicate 4096 1}
+          ]
+        roots =
+          [ multiStoreScanPureBorrowDirectRoot
+          , multiStoreScanPureBorrowNestedRoot
+          ]
+    mapM_
+      ( \root ->
+          mapM_
+            ( \input -> do
+                outcome <-
+                  try @SomeException (evaluate (root input))
+                case outcome of
+                  Left exception ->
+                    let diagnostic = displayException exception
+                     in assertBool
+                          ("unexpected invalid-input diagnostic: " <> diagnostic)
+                          (expectedDiagnostic `isInfixOf` diagnostic)
+                  Right _ ->
+                    assertFailure "invalid multi-store input was accepted"
+            )
+            invalidInputs
+      )
+      roots

--- a/test/PureBorrow/Internal/Bench/Worklist/ResumeSpec.hs
+++ b/test/PureBorrow/Internal/Bench/Worklist/ResumeSpec.hs
@@ -1,0 +1,227 @@
+{-# LANGUAGE BlockArguments #-}
+
+module PureBorrow.Internal.Bench.Worklist.ResumeSpec (
+  module PureBorrow.Internal.Bench.Worklist.ResumeSpec,
+) where
+
+import Data.Vector.Unboxed qualified as U
+import PureBorrow.Internal.Bench.Worklist.Resume
+import Test.Tasty (TestTree)
+import Test.Tasty.HUnit
+
+test_worklistOpenOnceEvidence :: TestTree
+test_worklistOpenOnceEvidence =
+  testCase "open-once traversal preserves the frozen trace and direct output" do
+    mapM_
+      ( \target -> do
+          let direct = worklistDirectOpenOnceRoot target
+          summary direct @?= expectedSummary target 4 0 0 0
+          assertFrozenOutput target direct
+          worklistPureBorrowOpenOnceRoot target @?= direct
+      )
+      [minBound .. maxBound]
+
+test_worklistReopenEvidence :: TestTree
+test_worklistReopenEvidence =
+  testCase "flat and nested reopen shapes preserve every frozen growth trace" do
+    mapM_
+      ( \(growth, target, flatOpens, nestedOpens, resumes, updates, growths) -> do
+          let directFlat =
+                worklistDirectReopenRoot FlatReopen growth target
+              directNested =
+                worklistDirectReopenRoot NestedReopen growth target
+          summary directFlat
+            @?= expectedSummary
+              target
+              flatOpens
+              resumes
+              updates
+              growths
+          summary directNested
+            @?= expectedSummary
+              target
+              nestedOpens
+              resumes
+              updates
+              growths
+          assertFrozenOutput target directFlat
+          assertSameTraversalOutput directFlat directNested
+          worklistPureBorrowFlatReopenRoot growth target
+            @?= directFlat
+          worklistPureBorrowNestedReopenRoot growth target
+            @?= directNested
+      )
+      reopenCases
+    mapM_
+      ( \(target, noGrowth, growth) ->
+          assertSameTraversalOutput
+            (worklistDirectReopenRoot NestedReopen noGrowth target)
+            (worklistDirectReopenRoot NestedReopen growth target)
+      )
+      [ (target, noGrowth, growth)
+      | target <- [minBound .. maxBound]
+      , (noGrowth, growth) <-
+          [ (NoGrowthBatch64, SparseGrowth)
+          , (NoGrowthBatch8, DenseGrowth)
+          ]
+      ]
+
+test_worklistSeededEvidence :: TestTree
+test_worklistSeededEvidence =
+  testCase "fresh-run seeds preserve direct and Pure Borrow equivalence" do
+    mapM_
+      ( \seed ->
+          mapM_
+            ( \target ->
+                worklistPureBorrowOpenOnceRootWithSeed seed target
+                  @?= worklistDirectOpenOnceRootWithSeed seed target
+            )
+            [minBound .. maxBound]
+      )
+      [1, 37]
+    mapM_
+      ( \(label, root) -> do
+          let seed1 = root 1
+              seed37 = root 37
+          assertBool
+            (label <> " must include the seed in its digest")
+            (finalDigest (summary seed1) /= finalDigest (summary seed37))
+          root 1 @?= seed1
+          root 37 @?= seed37
+          root 1 @?= seed1
+      )
+      [ ("open-once", \seed -> worklistPureBorrowOpenOnceRootWithSeed seed Drain)
+      ,
+        ( "dense nested reopen"
+        , \seed ->
+            worklistPureBorrowNestedReopenRootWithSeed
+              seed
+              DenseGrowth
+              Drain
+        )
+      ]
+    mapM_
+      ( \seed ->
+          mapM_
+            ( \(growth, target) -> do
+                worklistPureBorrowFlatReopenRootWithSeed seed growth target
+                  @?= worklistDirectReopenRootWithSeed
+                    seed
+                    FlatReopen
+                    growth
+                    target
+                worklistPureBorrowNestedReopenRootWithSeed seed growth target
+                  @?= worklistDirectReopenRootWithSeed
+                    seed
+                    NestedReopen
+                    growth
+                    target
+            )
+            [ (growth, target)
+            | growth <- [minBound .. maxBound]
+            , target <- [minBound .. maxBound]
+            ]
+      )
+      [1, 37]
+
+reopenCases ::
+  [ ( WorklistGrowth
+    , WorklistTarget
+    , Int
+    , Int
+    , Int
+    , Int
+    , Int
+    )
+  ]
+reopenCases =
+  [ (NoGrowth, Drain, 84, 44, 20, 41, 0)
+  , (NoGrowth, StopEarly, 44, 24, 10, 22, 0)
+  , (NoGrowthBatch64, Drain, 272, 138, 67, 131, 0)
+  , (NoGrowthBatch64, StopEarly, 100, 52, 24, 50, 0)
+  , (NoGrowthBatch8, Drain, 2056, 1030, 513, 934, 0)
+  , (NoGrowthBatch8, StopEarly, 692, 348, 172, 346, 0)
+  , (SparseGrowth, Drain, 272, 138, 67, 131, 8)
+  , (SparseGrowth, StopEarly, 100, 52, 24, 50, 7)
+  , (DenseGrowth, Drain, 2056, 1030, 513, 934, 21)
+  , (DenseGrowth, StopEarly, 692, 348, 172, 346, 19)
+  ]
+
+expectedSummary ::
+  WorklistTarget ->
+  Int ->
+  Int ->
+  Int ->
+  Int ->
+  WorklistSummary
+expectedSummary target opens resumes updates growths =
+  case target of
+    Drain ->
+      WorklistSummary
+        { outcome = Drained
+        , visitedNodes = 4096
+        , enqueueTransitions = 4095
+        , offsetReads = 8192
+        , adjacencyReads = 12288
+        , payloadReads = 12288
+        , markReads = 12288
+        , markWrites = 4095
+        , queueReads = 4096
+        , queueWrites = 4095
+        , logWrites = 4096
+        , contentOpens = opens
+        , resumeBoundaries = resumes
+        , headerUpdates = updates
+        , bufferGrowths = growths
+        , finalDigest = 2728622868939553119
+        }
+    StopEarly ->
+      WorklistSummary
+        { outcome = Stopped
+        , visitedNodes = 1365
+        , enqueueTransitions = 2888
+        , offsetReads = 2730
+        , adjacencyReads = 4095
+        , payloadReads = 4095
+        , markReads = 4095
+        , markWrites = 2888
+        , queueReads = 1365
+        , queueWrites = 2888
+        , logWrites = 1365
+        , contentOpens = opens
+        , resumeBoundaries = resumes
+        , headerUpdates = updates
+        , bufferGrowths = growths
+        , finalDigest = 5952155574826728904
+        }
+
+assertFrozenOutput :: WorklistTarget -> WorklistOutput -> Assertion
+assertFrozenOutput target result = do
+  let resultSummary = summary result
+      visits = visitedNodes resultSummary
+      enqueues = enqueueTransitions resultSummary
+  U.sum (finalMarks result) @?= enqueues + 1
+  finalState result
+    @?= U.fromList
+      [ visits
+      , enqueues + 1
+      , visits
+      , enqueues
+      , visits
+      ]
+  U.length (finalQueue result) @?= enqueues + 1
+  U.length (finalLog result) @?= visits
+  outcome resultSummary
+    @?= case target of
+      Drain -> Drained
+      StopEarly -> Stopped
+
+assertSameTraversalOutput ::
+  WorklistOutput ->
+  WorklistOutput ->
+  Assertion
+assertSameTraversalOutput left right = do
+  finalMarks left @?= finalMarks right
+  finalState left @?= finalState right
+  finalQueue left @?= finalQueue right
+  finalLog left @?= finalLog right


### PR DESCRIPTION
Two micro-benchmarks that isolate costs the whole-algorithm suites
average away, both in `lib:test-bench-common` because
`pure-borrow-test` and `pure-borrow-inspection` exercise the same
kernels.

`multi-store-scan` measures a read-only scan across several containers
held at once — the case the `subShare` guidance in the tutorial is
about. Each pure-borrow variant is paired with a direct `vector`
baseline and with an all-unrestricted variant, so the remaining gap is
attributable rather than just observed.

`worklist-resume` measures resuming work against a borrowed structure:
a loop that repeatedly suspends and resumes over the same borrow, with
the resume overhead isolated from the work itself so the two can move
independently in the numbers.

Both come with specs asserting the pure-borrow kernels agree with their
baselines, and with inspection tests pinning the optimized Core, so a
regression in specialization shows up as a test failure rather than as
a slow benchmark.

Allocation figures come from tasty-bench's own `-T` metrics rather than
from separate allocation-only executables and paired-run scripts.
Part of #14.