### PR TITLE
ci: upgrade run-fourmolu to v13 and checkout to v4

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -19,7 +19,7 @@ jobs:
     outputs:
       plan: ${{steps.list-ci.outputs.plan}}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{github.event.pull_request.head.sha || github.sha}}
       - name: Enumerate CI plans
@@ -59,7 +59,7 @@ jobs:
       tests: ${{steps.list-bins.outputs.tests}}
       artifact: "artifact-${{matrix.plan.name}}"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{github.event.pull_request.head.sha || github.sha}}
       - name: Calculate hash keys
@@ -138,7 +138,7 @@ jobs:
       cabal: "cabal --project-file=ci/configs/ghc-9.14.1.project"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{github.event.pull_request.head.sha || github.sha}}
       - name: Calculate hash keys
@@ -202,7 +202,7 @@ jobs:
       - name: Fail when Corresponding Build didn't succeed
         if: ${{needs.build.result != 'success' }}
         run: echo "BUILD FAILED" >&2; exit 1
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{github.event.pull_request.head.sha || github.sha}}
       - name: Download artifacts
@@ -233,9 +233,9 @@ jobs:
     name: Fourmolu
     runs-on: ubuntu-latest
     steps:
-      # Note that you must checkout your code before running fourmolu/fourmolu-action
-      - uses: actions/checkout@v2
-      - uses: fourmolu/fourmolu-action@v10
+      # Note that you must checkout your code before running haskell-actions/run-fourmolu
+      - uses: actions/checkout@v4
+      - uses: haskell-actions/run-fourmolu@v13
         with:
           version: 0.20.0.0
           pattern: |
@@ -248,7 +248,7 @@ jobs:
     name: Cabal Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: haskell-actions/setup@v2
         with:
           cabal-version: ${{env.cabal-version}}
@@ -267,7 +267,7 @@ jobs:
           RELEASE=$(echo ${{github.ref_name}} | sed 's/^v//')
           echo "RELEASE=${RELEASE}" >> "${GITHUB_ENV}"
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Creates Tarball
         run: cabal sdist
       - name: Download Haddock


### PR DESCRIPTION
The **Fourmolu** job has been red on every `main` push since 2026-08-01, while every other job is green. The cause is not a formatting problem in the repository.

## Root cause

`afd755b` bumped the pinned formatter to `version: 0.20.0.0` but left the action at `fourmolu/fourmolu-action@v10`.

fourmolu **0.20.0.0 changed its release artifact format**: `0.19.0.0` and earlier ship a bare executable (`fourmolu-0.19.0.0-linux-x86_64`), while `0.20.0.0` ships zip archives (`fourmolu-0.20.0.0-linux-x86_64.zip`). Action `v10` only knows the bare-binary format, so it downloads the zip, cannot execute it, and reports a generic `##[error]fourmolu detected unformatted files`.

Upstream says so explicitly in the run-fourmolu v13 changelog:

> NOTE THAT USERS MUST UPGRADE `run-fourmolu` TO `>= v13` IF YOU WANT TO USE `fourmolu >= 0.20.0.0`.

Two things confirm no source file is actually misformatted:

- The failing step lasts **0.18s** and emits **no diff**. A real `--mode check` failure prints a unified diff, and checking 97 files cannot finish that fast.
- Running the exact pinned version locally — `fourmolu 0.20.0.0` — over all 97 tracked `.hs` files exits `0`.

## Changes

- `fourmolu/fourmolu-action@v10` → `haskell-actions/run-fourmolu@v13` (the action repo was also renamed; the old path only resolved via a redirect). `version: 0.20.0.0` and the `pattern:` block are unchanged — `v13` is a drop-in, adding only an optional `working-directory`.
- All seven `actions/checkout` pins (6x `v3`, 1x `v2`) → `v4`, clearing the Node 20 deprecation annotations.

`actions/github-script` and `actions/cache` are left alone deliberately: bumping those majors is a behavioural change and does not belong in a CI fix.

## Verification

`git ls-files '*.hs' | xargs fourmolu --mode check` exits `0` locally on the pinned 0.20.0.0.

The real check is CI here, since the bug is in artifact download and only reproduces on a runner. The Fourmolu step should now take seconds rather than 0.18s — evidence it actually downloaded, unpacked, and ran the formatter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)