### PR TITLE
docs(vector): document projection placement in branching transactions

### DIFF
--- a/src/Data/Vector/Generic/Mutable/Growable/Linear/Borrow/Unrestricted/Internal.hs
+++ b/src/Data/Vector/Generic/Mutable/Growable/Linear/Borrow/Unrestricted/Internal.hs
@@ -787,6 +787,18 @@ The result preserves the borrow kind and lifetime and exposes neither spare
 capacity nor growth. A mutable result may be split with the fixed unrestricted
 vector API. The growable borrow becomes recoverable only after all resulting
 fixed borrows have ended.
+
+Each call performs one header read. Where a transaction branches, prefer
+projecting once at its entry --
+
+@
+let %1 !content = 'getContents' borrow
+@
+
+-- over projecting separately inside each branch. Both are correct and consume
+the growable occurrence exactly once; the entry form simply gives the
+optimizer one read to place rather than one per surviving branch, which
+matters for code size in transactions with several control exits.
 -}
 getContents ::
   (G.Vector v a) =>

--- a/src/Data/Vector/Mutable/Growable/Linear/Borrow/Internal.hs
+++ b/src/Data/Vector/Mutable/Growable/Linear/Borrow/Internal.hs
@@ -824,6 +824,12 @@ capacity nor growth. A mutable result may be split using the fixed-vector API;
 the mutable growable owner becomes recoverable only after every resulting
 fixed borrow has ended. A shared input follows the ordinary unrestricted
 'Share' rules.
+
+Where a transaction branches, prefer projecting once at its entry --
+@let %1 !content = 'getContents' borrow@ -- over projecting separately inside
+each branch. Both are correct and consume the growable occurrence exactly
+once; the entry form simply gives the optimizer one header read to place
+rather than one per surviving branch.
 -}
 getContents ::
   Borrow bk α (GrowableVector a) %1 ->

--- a/src/Data/Vector/Unboxed/Mutable/Growable/Linear/Borrow/Internal.hs
+++ b/src/Data/Vector/Unboxed/Mutable/Growable/Linear/Borrow/Internal.hs
@@ -745,6 +745,12 @@ checkedAdd operation left right
 
 The projection preserves borrow kind and lifetime and exposes no spare
 capacity or growth operation.
+
+Where a transaction branches, prefer projecting once at its entry --
+@let %1 !content = 'getContents' borrow@ -- over projecting separately inside
+each branch. Both are correct and consume the growable occurrence exactly
+once; the entry form simply gives the optimizer one header read to place
+rather than one per surviving branch.
 -}
 getContents ::
   (U.Unbox a) =>


### PR DESCRIPTION
Downstream observed three logical growable headers expanding to 39 header
reads after branch duplication, under continuation-shaped projections.
Document the placement rule the projection has always had: in a branching
transaction, project once at entry —

```haskell
let %1 !content = getContents borrow
```

— rather than separately per branch.

Both shapes are correct and consume the growable occurrence exactly once. The
difference is only how many reads the optimizer has to place, which matters
for code size when a transaction has several control exits.

No behaviour change; Haddock only.

> An earlier revision of this PR also added an "ORDERING OBLIGATION" comment
> to all three growable families, claiming that nothing ordered the header
> read against the `unsafeWriteRef#` by which growth publishes a replacement
> header, and citing `unsafeReadRef#`'s missing `NOINLINE` as evidence. Both
> halves were wrong. `readMutVar#` is classified `effect = ReadWriteEffect`,
> and GHC's transformation matrix in `Note [Classifying primop effects]`
> forbids Discard, Speculate, and Duplicate for that class — so the sharing
> direction is already foreclosed. And `NOINLINE` governs inlining, not CSE,
> so the pragma could not have borne on the concern in either direction; the
> asymmetry with `newRef#` is explained by allocation needing CSE protection,
> which does not transfer to a read. Those comments have been removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)