### PR TITLE
fix(borrows): forbid discarding a plural lender bundle

### DIFF
--- a/pure-borrow.cabal
+++ b/pure-borrow.cabal
@@ -178,6 +178,8 @@ test-suite pure-borrow-test
     Control.Concurrent.DivideConquer.LinearSpec
     Control.Monad.Borrow.Pure.BOSpec
     Control.Monad.Borrow.Pure.CopyableSpec
+    Control.Monad.Borrow.Pure.Experimental.Borrows.TypingCases
+    Control.Monad.Borrow.Pure.Experimental.BorrowsSpec
     Control.Monad.Borrow.Pure.Lifetime.TypingCases
     Control.Monad.Borrow.Pure.LifetimeSpec
     Data.Vector.Generic.Mutable.Growable.Linear.Borrow.Unrestricted.TypingCases

--- a/src/Control/Monad/Borrow/Pure/Experimental/Borrows.hs
+++ b/src/Control/Monad/Borrow/Pure/Experimental/Borrows.hs
@@ -69,7 +69,12 @@ type Muts α = Borrows 'Mut α
 type Shares :: Lifetime -> [Type] -> Type
 type Shares α = Borrows 'Share α
 
-instance Affine (Aliases α xs) where
+{- |
+Only borrow bundles are affine; a @'Lends' α xs@ must not be discardable.
+Dropping a bundle of lenders would abandon the owners it holds, and a lender is the sole capability to 'reclaim' one.
+The @k ~ \'Borrow bk α@ constraint therefore excludes @\'Lend α@, exactly as the scalar @'Affine' ('Alias' ak a)@ instance does.
+-}
+instance (k ~ 'Borrow bk α) => Affine (Aliases k xs) where
   aff = unsafeAff
   {-# INLINE aff #-}
 

--- a/test/Control/Monad/Borrow/Pure/Experimental/Borrows/TypingCases.hs
+++ b/test/Control/Monad/Borrow/Pure/Experimental/Borrows/TypingCases.hs
@@ -1,0 +1,77 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE ImpredicativeTypes #-}
+{-# LANGUAGE QualifiedDo #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# OPTIONS_GHC -O0 #-}
+{-# OPTIONS_GHC -fdefer-type-errors -Wno-deferred-type-errors #-}
+
+{- |
+Cases that must /not/ typecheck: a lender may never be discarded in safe code.
+
+A 'Lend' is the sole capability to recover the borrowed owner, so dropping one strands that owner forever.
+The scalar 'Affine' instance excludes the @\'Lend@ alias kind by construction, and 'Lends' — a bundle of lenders — must behave identically.
+Both forms are exercised here so the pair stays symmetric.
+-}
+module Control.Monad.Borrow.Pure.Experimental.Borrows.TypingCases (
+  module Control.Monad.Borrow.Pure.Experimental.Borrows.TypingCases,
+) where
+
+import Control.Functor.Linear qualified as Control
+import Control.Monad.Borrow.Pure.Affine
+import Control.Monad.Borrow.Pure.BO
+import Control.Monad.Borrow.Pure.Experimental.Borrows
+import Prelude.Linear
+
+-- | A bundle of lenders is not 'Affine', so it cannot be popped away.
+badLendsAff :: Lends α xs %1 -> ()
+badLendsAff bundle = pop (aff bundle)
+
+-- | A bundle of lenders is not 'Consumable' either.
+badLendsConsume :: Lends α xs %1 -> ()
+badLendsConsume = consume
+
+-- | The scalar reference: a single lender is not 'Affine'.
+badLendAff :: Lend α a %1 -> ()
+badLendAff lend = pop (aff lend)
+
+-- | The scalar reference: a single lender is not 'Consumable'.
+badLendConsume :: Lend α a %1 -> ()
+badLendConsume = consume
+
+badLendsAffCase :: Int
+badLendsAffCase = discardingLenders badLendsAff
+
+badLendsConsumeCase :: Int
+badLendsConsumeCase = discardingLenders badLendsConsume
+
+badLendAffCase :: Int
+badLendAffCase = discardingLender badLendAff
+
+badLendConsumeCase :: Int
+badLendConsumeCase = discardingLender badLendConsume
+
+{- |
+Borrow an owner, throw away the mutable borrow, and hand the resulting one-element
+'Lends' bundle to @abandon@ instead of reclaiming through it.
+-}
+discardingLenders :: (forall α. Lends α '[Int] %1 -> ()) -> Int
+discardingLenders abandon =
+  linearly \linear ->
+    runBO_ linear Control.do
+      (mut, lend) <- borrowM (42 :: Int)
+      let
+        !() = consume mut
+        !() = abandon (lend :- BNil)
+      Control.pure 0
+
+-- | The scalar counterpart of 'discardingLenders'.
+discardingLender :: (forall α. Lend α Int %1 -> ()) -> Int
+discardingLender abandon =
+  linearly \linear ->
+    runBO_ linear Control.do
+      (mut, lend) <- borrowM (42 :: Int)
+      let
+        !() = consume mut
+        !() = abandon lend
+      Control.pure 0

--- a/test/Control/Monad/Borrow/Pure/Experimental/BorrowsSpec.hs
+++ b/test/Control/Monad/Borrow/Pure/Experimental/BorrowsSpec.hs
@@ -1,0 +1,90 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE LinearTypes #-}
+{-# LANGUAGE QualifiedDo #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module Control.Monad.Borrow.Pure.Experimental.BorrowsSpec (
+  module Control.Monad.Borrow.Pure.Experimental.BorrowsSpec,
+) where
+
+import Control.Exception qualified as Exception
+import Control.Functor.Linear qualified as Control
+import Control.Monad.Borrow.Pure
+import Control.Monad.Borrow.Pure.Experimental.Borrows
+import Control.Monad.Borrow.Pure.Experimental.Borrows.TypingCases
+import Data.List qualified as List
+import Prelude.Linear
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit
+
+-- | A bundle of mutable borrows stays discardable; the owners survive it.
+discardMutsBundle :: (Int, Int)
+discardMutsBundle =
+  linearly \linear ->
+    runBO linear Control.do
+      (mutA, lendA) <- borrowM (1 :: Int)
+      (mutB, lendB) <- borrowM (2 :: Int)
+      let !() = consume (mutA :- mutB :- BNil)
+      pureAfter (reclaim lendA, reclaim lendB)
+
+-- | The same for a bundle of shared borrows.
+discardSharesBundle :: Int
+discardSharesBundle =
+  linearly \linear ->
+    runBO linear Control.do
+      (mut, lend) <- borrowM (3 :: Int)
+      share mut & \(Ur shared) -> Control.do
+        let !() = consume (shared :- BNil)
+        pureAfter (reclaim lend)
+
+test_bundleDiscarding :: TestTree
+test_bundleDiscarding =
+  testGroup
+    "alias bundle discarding"
+    [ testCase "a Muts bundle can be discarded without losing its owners" do
+        discardMutsBundle @?= (1, 2)
+    , testCase "a Shares bundle can be discarded without losing its owner" do
+        discardSharesBundle @?= 3
+    ]
+
+{- |
+Discarding a lender is rejected for bundles exactly as it is for a scalar 'Lend'.
+
+@Lends@ used to be unconditionally @Affine@, which let safe code abandon a whole bundle of lenders and strand the owners it held.
+These cases freeze the plural and the scalar behaviours as identical.
+-}
+test_lenderDiscardingIsRejected :: TestTree
+test_lenderDiscardingIsRejected =
+  testGroup
+    "typing boundaries"
+    [ expectDeferredTypeError
+        "a Lends bundle is not Affine"
+        badLendsAffCase
+    , expectDeferredTypeError
+        "a Lends bundle is not Consumable"
+        badLendsConsumeCase
+    , expectDeferredTypeError
+        "a scalar Lend is not Affine"
+        badLendAffCase
+    , expectDeferredTypeError
+        "a scalar Lend is not Consumable"
+        badLendConsumeCase
+    ]
+  where
+    -- Every case fails the same way: the alias kind is 'Lend, and both the scalar and the plural instances accept only a 'Borrow kind.
+    expectedFragments = ["Couldn't match type", "Lend", "Borrow"]
+    describeFragments = List.intercalate ", " expectedFragments
+    expectDeferredTypeError description value =
+      testCase description do
+        result <- Exception.try @Exception.SomeException (Exception.evaluate value)
+        case result of
+          Left exception ->
+            let rendered = Exception.displayException exception
+             in assertBool
+                  ("unexpected deferred type error: " <> rendered)
+                  (List.all (`List.isInfixOf` rendered) expectedFragments)
+          Right _ ->
+            assertFailure
+              ("expected deferred type error containing " <> describeFragments)


### PR DESCRIPTION
## What

`instance Affine (Aliases α xs)` in `Control.Monad.Borrow.Pure.Experimental.Borrows` was unconditional in the alias kind.
It is now constrained exactly as the scalar instance in `Control.Monad.Borrow.Pure.BO.Internal` is:

```haskell
instance (k ~ 'Borrow bk α) => Affine (Aliases k xs) where
```

## Why

`type Lends α = Aliases ('Lend α)`, so the unconstrained instance made a bundle of lenders discardable in safe code, whereas a scalar `Lend α a` is not:

```haskell
dropLends :: Lends α xs %1 -> ()
dropLends l = pop (aff l)          -- compiled before this change

dropLend :: Lend α a %1 -> ()
dropLend l = pop (aff l)           -- always rejected
```

A lender is the sole capability to `reclaim` its owner, so abandoning a bundle strands every owner it held.
The exactly-once owner-recovery discipline that the scalar API enforces by typing was simply absent for bundles.
This looks like an oversight rather than a deliberate difference — the scalar behaviour is the correct one.

The derived `Consumable (Aliases k xs)` instance already carried `k ~ 'Borrow bk α`, so `consume` was fine; only the `aff`/`pop` route leaked.

## Impact

None.
`cabal build all` compiles clean across `src/`, `test/`, `internal-src/`, `bench/`, `test-inspection/` and the demo executables — no call site relied on the wider instance.

## Tests

GHC reports the rejection as a **deferrable equality error**, not a linear-multiplicity error:

```
• Couldn't match type: 'Lend α
                 with: 'Borrow bk1 α1
    arising from a use of 'aff'
```

So the negative fixtures live in a `TypingCases` module (compiled with `-fdefer-type-errors -Wno-deferred-type-errors`) rather than in `test/typing-fail/`, and the spec observes the deferred error at runtime via `try`/`evaluate` — the pattern the vector specs already use.
Per the repository policy, no `expectFail` wrapper: rejection *is* the specification here.

- `test/Control/Monad/Borrow/Pure/Experimental/Borrows/TypingCases.hs` — `aff` and `consume` applied to a one-element `Lends α '[Int]` bundle, plus the scalar `Lend α Int` counterparts. Each is wrapped in a fully-applied `… :: Int` case value so forcing to WHNF actually reaches the deferred error.
- `test/Control/Monad/Borrow/Pure/Experimental/BorrowsSpec.hs` — asserts each case throws with `Couldn't match type`, `Lend` and `Borrow` in the message, and adds two positive cases confirming the constraint did not over-restrict: `Muts` and `Shares` bundles still discard, and their owners are still reclaimable afterwards.

`pure-borrow.cabal` picked both modules up through the existing `-- cabal-gild: discover` pragma.

**The negative test was checked to bite.**
With the instance temporarily reverted to unconstrained, `a Lends bundle is not Affine` fails with `expected deferred type error containing …` while the other five cases stay green — it fails on exactly this bug and nothing else.

## Validation

Pinned `ghc-9.12.4` at the project's `-O2`, `cabal build all` followed by `cabal test`:

- `pure-borrow-test` — 292 tests, PASS
- `pure-borrow-inspection` — 22 tests, PASS
- `pure-borrow-doctests` — PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)