### PR TITLE
perf: erase the sublifetime in srunBO and srunBO_

### DIFF
--- a/pure-borrow.cabal
+++ b/pure-borrow.cabal
@@ -242,18 +242,11 @@ test-suite pure-borrow-inspection
     PureBorrow.Inspection.Sublifetime
     PureBorrow.Inspection.Worklist.Resume
 
-  -- The -dsuppress-* set is the one inspection-testing's own "Help, I am
-  -- drowning in Core!" recommends: a failing obligation prints the Core the
-  -- same way GHC would, and without these a single BO term is mostly
-  -- coercions, uniques and IdInfo.
+  -- The -dsuppress-* set that makes a failing obligation readable belongs in
+  -- OPTIONS_GHC on the module that states the obligation, not here: `cabal
+  -- check` rejects `ghc-options: -d*` in a distributed package.
   ghc-options:
     -O2
-    -dsuppress-coercions
-    -dsuppress-idinfo
-    -dsuppress-module-prefixes
-    -dsuppress-type-applications
-    -dsuppress-type-signatures
-    -dsuppress-uniques
     -fplugin=Test.Tasty.Inspection.Plugin
 
   build-depends:

--- a/pure-borrow.cabal
+++ b/pure-borrow.cabal
@@ -221,6 +221,13 @@ test-suite pure-borrow-test
 -- component GHC leaves concrete generic-vector dictionaries unspecialized.
 test-suite pure-borrow-inspection
   import: defaults
+
+  -- PureBorrow.Inspection.Sublifetime asserts the Core shape of the statically
+  -- erased sublifetime delimiters, which is exactly what @+slow@ swaps out.
+  -- PureBorrow.Inspection.Flags reads this define to invert those obligations
+  -- there; it is the only module in the component that uses CPP.
+  if flag(slow)
+    cpp-options: -DPURE_BORROW_SLOW_SCOPES
   default-language: GHC2021
   type: exitcode-stdio-1.0
   hs-source-dirs: test-inspection
@@ -228,19 +235,32 @@ test-suite pure-borrow-inspection
   -- cabal-gild: discover test-inspection --exclude=test-inspection/Main.hs
   other-modules:
     PureBorrow.Inspection.Fft
+    PureBorrow.Inspection.Flags
     PureBorrow.Inspection.GenericGrowableUnrestricted
     PureBorrow.Inspection.MultiStoreScan
     PureBorrow.Inspection.QSort
+    PureBorrow.Inspection.Sublifetime
     PureBorrow.Inspection.Worklist.Resume
 
+  -- The -dsuppress-* set is the one inspection-testing's own "Help, I am
+  -- drowning in Core!" recommends: a failing obligation prints the Core the
+  -- same way GHC would, and without these a single BO term is mostly
+  -- coercions, uniques and IdInfo.
   ghc-options:
     -O2
+    -dsuppress-coercions
+    -dsuppress-idinfo
+    -dsuppress-module-prefixes
+    -dsuppress-type-applications
+    -dsuppress-type-signatures
+    -dsuppress-uniques
     -fplugin=Test.Tasty.Inspection.Plugin
 
   build-depends:
     pure-borrow,
     pure-borrow:test-bench-common,
     tasty,
+    tasty-expected-failure,
     tasty-inspection-testing,
     vector,
 

--- a/src/Control/Monad/Borrow/Pure/BO.hs
+++ b/src/Control/Monad/Borrow/Pure/BO.hs
@@ -120,6 +120,10 @@ import Data.Functor.Linear qualified as Data
 import Data.Type.Coercion (Coercion (..))
 import Prelude.Linear
 
+#ifndef PURE_BORROW_SLOW_SCOPES
+import Control.Monad.Borrow.Pure.Lifetime.Token.Unsafe qualified as Unsafe
+#endif
+
 {- |
 Runs a 'BO' computation and returns the result of postprocessing 'After' the lifetime has ended.
 
@@ -392,16 +396,26 @@ borrowLinearlyM k = asksLinearlyM $ borrowM . k
 -- | Runs a 'BO' computation within the ephemeral sublifetime and returns the result.
 srunBO :: (forall α. BO (α /\ β) (After α a)) %1 -> BO β a
 {-# INLINE srunBO #-}
+#ifdef PURE_BORROW_SLOW_SCOPES
 srunBO bo = asksLinearlyM \lin ->
   newLifetime' lin \now -> Control.do
     (now, f) <- sexecBO bo now
     Ur end <- Control.pure (endLifetime now)
     Control.pure (withEnd end f)
+#else
+srunBO bo = Control.do
+  after <- unsafeCastBO bo
+  Control.pure $! withEnd Unsafe.UnsafeEnd after
+#endif
 
 -- | A variant of 'srunBO' that returns the direct value of 'BO' computation.
 srunBO_ :: (forall α. BO (α /\ β) a) %1 -> BO β a
 {-# INLINE srunBO_ #-}
+#ifdef PURE_BORROW_SLOW_SCOPES
 srunBO_ k = srunBO Control.do a <- k; Control.pure $ After a
+#else
+srunBO_ = \bo -> unsafeCastBO bo
+#endif
 
 {- | A parallel comoutation applicative functor for 'BO' monad.
 All the computations chained by '<*>' or 'liftA2' will be executed in parallel.

--- a/test-inspection/Main.hs
+++ b/test-inspection/Main.hs
@@ -4,6 +4,7 @@ import PureBorrow.Inspection.Fft qualified as Fft
 import PureBorrow.Inspection.GenericGrowableUnrestricted qualified as GenericGrowableUnrestricted
 import PureBorrow.Inspection.MultiStoreScan qualified as MultiStoreScan
 import PureBorrow.Inspection.QSort qualified as QSort
+import PureBorrow.Inspection.Sublifetime qualified as Sublifetime
 import PureBorrow.Inspection.Worklist.Resume qualified as WorklistResume
 import Test.Tasty (defaultMain, testGroup)
 
@@ -16,5 +17,6 @@ main =
       , GenericGrowableUnrestricted.tests
       , MultiStoreScan.tests
       , QSort.tests
+      , Sublifetime.tests
       , WorklistResume.tests
       ]

--- a/test-inspection/PureBorrow/Inspection/Flags.hs
+++ b/test-inspection/PureBorrow/Inspection/Flags.hs
@@ -1,0 +1,29 @@
+{-# LANGUAGE CPP #-}
+
+{- |
+The build configuration the inspection obligations are stated against.
+
+This is the only module in the component that looks at @PURE_BORROW_SLOW_SCOPES@.
+An obligation about optimized Core is a statement about one of the two implementations the @slow@ flag selects, so rather than compiling such an obligation out under the other one, state it once and invert it with 'expectFailIfBecause'.
+A test that is expected to fail is still a test: the day @+slow@ starts producing the same Core, the suite says so instead of staying quietly green.
+-}
+module PureBorrow.Inspection.Flags (
+  isSlowAPI,
+  expectFailIfBecause,
+) where
+
+import Test.Tasty (TestTree)
+import Test.Tasty.ExpectedFailure (expectFailBecause)
+
+-- | Whether this component was built against the @+slow@ library, i.e. the one whose sublifetime delimiters allocate a real runtime lifetime token.
+isSlowAPI :: Bool
+#ifdef PURE_BORROW_SLOW_SCOPES
+isSlowAPI = True
+#else
+isSlowAPI = False
+#endif
+
+-- | Invert a test tree when the condition holds, recording why.
+expectFailIfBecause :: Bool -> String -> TestTree -> TestTree
+expectFailIfBecause False _ = id
+expectFailIfBecause True reason = expectFailBecause reason

--- a/test-inspection/PureBorrow/Inspection/Sublifetime.hs
+++ b/test-inspection/PureBorrow/Inspection/Sublifetime.hs
@@ -6,6 +6,17 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE NoImplicitPrelude #-}
+-- The set inspection-testing's own "Help, I am drowning in Core!" recommends.
+-- A failing obligation prints the Core the way GHC would, and without these a
+-- single 'BO' term is mostly coercions, uniques and IdInfo.
+-- These stay here rather than in the component's @ghc-options@: `cabal check`
+-- rejects `-d*` flags in a distributed package.
+{-# OPTIONS_GHC -dsuppress-coercions #-}
+{-# OPTIONS_GHC -dsuppress-idinfo #-}
+{-# OPTIONS_GHC -dsuppress-module-prefixes #-}
+{-# OPTIONS_GHC -dsuppress-type-applications #-}
+{-# OPTIONS_GHC -dsuppress-type-signatures #-}
+{-# OPTIONS_GHC -dsuppress-uniques #-}
 
 {- |
 Core-level obligations for the statically erased sublifetime delimiters.

--- a/test-inspection/PureBorrow/Inspection/Sublifetime.hs
+++ b/test-inspection/PureBorrow/Inspection/Sublifetime.hs
@@ -1,0 +1,167 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE ImpredicativeTypes #-}
+{-# LANGUAGE QualifiedDo #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+
+{- |
+Core-level obligations for the statically erased sublifetime delimiters.
+
+With the @slow@ flag off, 'srunBO_' must compile to the identity, and 'srunBO' to nothing beyond handing the runtime-erased 'EndToken' to the 'After' the delimited action returned.
+In particular neither may retain a runtime lifetime token, nor the 'Linearly' witness that 'newLifetime' consumes to produce one.
+This has to hold through 'reborrowing'' and 'sharing'' too, which are the public combinators built on 'srunBO'.
+
+The @+slow@ build restores the token-allocating implementations, so every obligation here is inverted there rather than dropped; see "PureBorrow.Inspection.Flags".
+-}
+module PureBorrow.Inspection.Sublifetime (
+  tests,
+  srunBOAt,
+  endTokenAt,
+  srunBO_At,
+  idBOAt,
+  reborrowingRefAt,
+  sharingRefAt,
+) where
+
+import Control.Functor.Linear qualified as Control
+import Control.Monad.Borrow.Pure.BO
+import Control.Monad.Borrow.Pure.Lifetime.Token.Unsafe (EndToken (..))
+import Data.Ref.Linear (Ref)
+import Data.Ref.Linear.Borrow qualified as Ref
+import Prelude.Linear
+import PureBorrow.Inspection.Flags (expectFailIfBecause, isSlowAPI)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.Inspection
+import Prelude qualified as NonLinear
+
+{- | 'srunBO' at a concrete carrier.
+
+The rank-2 argument is kept, so whatever survives here survives because the delimiter emitted it, not because a caller's action was specialised.
+
+The @'Control.fmap' (+ 1)@ is not part of what is being measured; it is there to stop GHC from eta-reducing the probe.
+Both @srunBOAt = srunBO@ and @srunBOAt bo = srunBO bo@ collapse to a bare reference to 'srunBO', which is an unsaturated call, so the @INLINE@ never fires.
+Every obligation below would then hold vacuously, of a probe containing no delimiter at all.
+-}
+srunBOAt :: (forall α. BO (α /\ β) (After α Int)) %1 -> BO β Int
+{-# NOINLINE srunBOAt #-}
+srunBOAt bo = Control.fmap (+ 1) (srunBO bo)
+
+{- | The specification 'srunBOAt' must meet: run the action, then apply the runtime-erased 'EndToken' to the 'After' it returned, under the same eta-reduction guard.
+
+Note the signature: no rank-2 argument and no @/\\@ anywhere.
+An equality with 'srunBOAt' therefore says the sublifetime left no residue at all.
+-}
+endTokenAt :: BO β (After γ Int) %1 -> BO β Int
+{-# NOINLINE endTokenAt #-}
+endTokenAt bo =
+  Control.fmap (+ 1) Control.do
+    after <- bo
+    Control.pure $! withEnd UnsafeEnd after
+
+-- | 'srunBO_' at a concrete carrier, saturated and rank-2 as above.
+srunBO_At :: (forall α. BO (α /\ β) Int) %1 -> BO β Int
+{-# NOINLINE srunBO_At #-}
+srunBO_At bo = srunBO_ bo
+
+-- | The specification 'srunBO_At' must meet: the identity.
+idBOAt :: BO β Int %1 -> BO β Int
+{-# NOINLINE idBOAt #-}
+idBOAt bo = bo
+
+-- | A client-level probe: 'reborrowing'' is one of the two public combinators built on 'srunBO', so the erasure has to reach through it too.
+reborrowingRefAt :: Mut α (Ref Int) %1 -> BO α (Int, Mut α (Ref Int))
+{-# NOINLINE reborrowingRefAt #-}
+reborrowingRefAt ref = reborrowing' ref \borrowed -> Control.do
+  (old, spent) <-
+    Ref.update (\x -> dup2 x & \(seen, next) -> Control.pure (seen, next + 1)) borrowed
+  spent `lseq` Control.pure (After old)
+
+-- | The other 'srunBO' client, on the shared side.
+sharingRefAt :: Mut α (Ref Int) %1 -> BO α (Int, Mut α (Ref Int))
+{-# NOINLINE sharingRefAt #-}
+sharingRefAt ref = sharing' ref \shared -> Control.do
+  seen <- Ref.copyRef shared
+  Control.pure (After seen)
+
+{- | Every obligation below describes the statically erased delimiters, so under @+slow@ — where the sublifetime is a genuine runtime token by construction — each one is expected to fail rather than to be skipped.
+That inversion is what keeps them honest: an obligation that also holds of the allocating implementation is no evidence about this one, and turns the group red under @+slow@ until it is either sharpened or dropped.
+
+Two plausible-looking obligations were dropped for exactly that reason.
+@'hasNoType' \'srunBOAt ''SomeNow@ holds under both, because 'MkSomeNow' wraps a nullary 'Now' and case-of-known-constructor removes the box either way.
+@'hasNoType' \'reborrowingRefAt ''Now@ likewise: through 'reborrowing'' the token itself is always erased, and what the allocating version actually leaves behind is the 'Linearly' that produced it.
+-}
+tests :: TestTree
+tests =
+  testGroup "sublifetime delimiting" $
+    NonLinear.map
+      ( expectFailIfBecause
+          isSlowAPI
+          "+slow restores the token-allocating sublifetime delimiters"
+      )
+      [ $( inspectTest
+             ( ('srunBO_At ==- 'idBOAt)
+                 { testName =
+                     Just "srunBO_ is the identity"
+                 }
+             )
+         )
+      , $( inspectTest
+             ( ('srunBOAt ==- 'endTokenAt)
+                 { testName =
+                     Just "srunBO only supplies the erased end token"
+                 }
+             )
+         )
+      , $( inspectTest
+             ( (hasNoType 'srunBOAt ''Now)
+                 { testName =
+                     Just "srunBO allocates no lifetime token"
+                 }
+             )
+         )
+      , $( inspectTest
+             ( (hasNoType 'srunBOAt ''Linearly)
+                 { testName =
+                     Just "srunBO needs no linearity witness"
+                 }
+             )
+         )
+      , $( inspectTest
+             ( (doesNotUse 'srunBOAt 'askLinearly)
+                 { testName =
+                     Just "srunBO does not reach for the ambient Linearly"
+                 }
+             )
+         )
+      , $( inspectTest
+             ( (hasNoType 'reborrowingRefAt ''Linearly)
+                 { testName =
+                     Just "reborrowing' needs no linearity witness"
+                 }
+             )
+         )
+      , $( inspectTest
+             ( (doesNotUse 'reborrowingRefAt 'askLinearly)
+                 { testName =
+                     Just "reborrowing' does not reach for the ambient Linearly"
+                 }
+             )
+         )
+      , $( inspectTest
+             ( (hasNoType 'sharingRefAt ''Linearly)
+                 { testName =
+                     Just "sharing' needs no linearity witness"
+                 }
+             )
+         )
+      , $( inspectTest
+             ( (doesNotUse 'sharingRefAt 'askLinearly)
+                 { testName =
+                     Just "sharing' does not reach for the ambient Linearly"
+                 }
+             )
+         )
+      ]


### PR DESCRIPTION
Removes the last two runtime indirections in sublifetime delimiting, and pins the result in the Core inspection suite.

## What changed

`srunBO` and `srunBO_` used to open a real sublifetime: ask for the ambient `Linearly`, allocate a `Now` token through `newLifetime'`, run the action with `sexecBO`, then end the lifetime and unwrap the `Ur (EndToken _)`. None of that is observable — the lifetime index is runtime-erased — so both now go straight through `unsafeCastBO`, with `srunBO` supplying `UnsafeEnd` to the returned `After`. The previous bodies stay available behind `+slow`, alongside the delimiters that flag already covered.

## Effect on the optimized Core

`srunBO_` is now literally the identity. `srunBO` is the identity plus the application that discharges `End α`:

```
$wsrunBOAt = \ @β bo s ->
  case unsafeEqualityProof of { UnsafeRefl co ->
  case (bo |> co) s of { (# ipv, ipv1 #) ->
  case nospec withDict (lvl |> co) UnsafeEnd (ipv1 |> co) of { I# ipv -> … }}}
```

No `Now`, no `SomeNow`, no `Linearly`, no `Ur`, no `(Now α, a)` tuple. The residual `nospec withDict …` comes from `withEnd` and is present under `+slow` too — GHC wraps `withDict` applications in `nospec` itself to block the specialiser, and restructuring `withEnd` to saturate `withDict` leaves the Core byte-identical.

## Tests

`PureBorrow.Inspection.Sublifetime` states nine obligations over four probes: `srunBO` and `srunBO_` directly, plus `reborrowing'` and `sharing'` — the two public combinators built on `srunBO` — over a `Ref Int`.

Each obligation is **inverted under `+slow`** rather than compiled out, via `PureBorrow.Inspection.Flags` (`isSlowAPI`, `expectFailIfBecause`), which is the only module in the component that touches CPP. A Core-shape obligation is a statement about one of the two bodies the flag selects, so one that also held of the allocating body would be no evidence about this one; and the inversion turns the suite red the day `+slow` starts producing the same Core.

Verified both ways on ghc-9.12.4:

| | `-slow` | `+slow` |
|---|---|---|
| the nine obligations | all pass | all fail (inverted → green) |
| whole inspection suite | 31/31 | 31/31 |

Two candidates that did not discriminate were dropped, with the reason recorded in the module: `hasNoType 'srunBOAt ''SomeNow` (`MkSomeNow` wraps a nullary `Now`, so case-of-known-constructor removes the box either way) and `hasNoType 'reborrowingRefAt ''Now` (through `reborrowing'` the token is erased under both; what `+slow` leaves behind is the `Linearly` that produced it).

One trap worth flagging for future probes, documented in the module: both a point-free `srunBOAt = srunBO` and an applied `srunBOAt bo = srunBO bo` eta-reduce to a bare reference, leaving an unsaturated call that never fires the `INLINE` — every obligation then holds vacuously of a probe containing no delimiter at all. The probes carry a `Control.fmap (+ 1)` purely as an eta-reduction guard.

Also adds inspection-testing's recommended `-dsuppress-*` set to the component, so a failing obligation prints a readable term instead of a screen of coercions and uniques.

`cabal build all` and `cabal test` are green locally at `-O2` on the pinned ghc-9.12.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)