### PR TITLE
perf: erase the sublifetime in the four borrow scopes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -219,7 +219,7 @@ Includes a demonstrative in-place parallel `qsort` (budgeted `parBO`; the heavie
   `-Wunused-packages` means a now-unused `build-depends` entry breaks the build — drop deps you stop using.
 - **Flags:** both are `manual` and default `False`.
   - `examples` — demo executables + `demo-impl` lib; enabled locally via `cabal.project`.
-  - `slow` — restores the previous, sublifetime-allocating implementations of `sharing_`, `reborrowing_` and `copyAtMut`, behind `-DPURE_BORROW_SLOW_SCOPES`.
+  - `slow` — restores the previous, sublifetime-allocating implementations of the borrow scopes (`sharing`, `sharing'`, `sharing_`, `reborrowing`, `reborrowing'`, `reborrowing_`), of `srunBO`/`srunBO_` and of `copyAtMut`, behind `-DPURE_BORROW_SLOW_SCOPES`.
     The two variants must stay observationally equivalent: the same test suites run under both, and CI builds `+slow` on the pinned GHC.
     Use it to A/B the erased scopes, or to check whether a suspected miscompilation is attributable to them.
     ```bash

--- a/pure-borrow.cabal
+++ b/pure-borrow.cabal
@@ -36,7 +36,8 @@ flag examples
 flag slow
   description:
     Restore the previous, sublifetime-allocating implementations of the
-    result-discarding borrow scopes (`sharing_`, `reborrowing_`) and of
+    borrow scopes (`sharing`, `sharing'`, `sharing_`, `reborrowing`,
+    `reborrowing'`, `reborrowing_`), of `srunBO`/`srunBO_` and of
     `copyAtMut`. These open a real sublifetime with a runtime token and a
     lender, which the default implementations statically erase. Enable to
     A/B the two against each other, or to check whether a suspected

--- a/src/Control/Monad/Borrow/Pure.hs
+++ b/src/Control/Monad/Borrow/Pure.hs
@@ -413,19 +413,17 @@ Hence, if you see @'Borrow' bk α a@ in a function, it can be either 'Mut' or 'S
 
 == Performance-sensitive loops
 
-Choose the loop structure that performs the least algorithmic work first. With
-the surrounding functions properly inlined, one 'sharing' or 'reborrowing' per
-iteration is normally cheap. For an otherwise read-only loop, however, prefer
-sharing once outside the loop and shortening that shared borrow inside each
-iteration with 'subShare':
+Choose the loop structure that performs the least algorithmic work first.
+The sublifetime that a 'sharing' or a 'reborrowing' delimits is erased at compile time, so with the surrounding functions properly inlined one of them per iteration costs nothing beyond the borrow it hands to the body.
+For an otherwise read-only loop, however, prefer sharing once outside the loop and shortening that shared borrow inside each iteration with 'subShare':
 
 @
 'share' resource \& \('Ur' shared) ->
   ... 'subShare' shared ...
 @
 
-This avoids opening and reclaiming a sublifetime merely to read the same
-resource. Functions containing hot loops over operations that return
+That way the body never has to give the borrow back, so no @(r, 'Mut' α a)@ pair is built and taken apart on every iteration.
+Functions containing hot loops over operations that return
 @(Ur a, container)@ should themselves be @INLINE@, @INLINABLE@, or specialised.
 That lets GHC eliminate the transient tuple and 'Ur' constructors; without
 cross-module inlining those constructors can allocate on every read.

--- a/src/Control/Monad/Borrow/Pure/BO.hs
+++ b/src/Control/Monad/Borrow/Pure/BO.hs
@@ -200,7 +200,11 @@ sharing ::
   (forall β. Share (β /\ α) a -> BO (β /\ α') r) %1 ->
   BO α' (r, Mut α a)
 {-# INLINE sharing #-}
+#ifdef PURE_BORROW_SLOW_SCOPES
 sharing v k = sharing' v (\mut -> Control.pure Control.<$> k mut)
+#else
+sharing = unsafeBorrowScope
+#endif
 
 -- | Flipped infix version of 'sharing', smoewhat analgous to '(Control.<$>)' and @(<%~)@ in @lens@ package.
 (<$~) ::
@@ -222,11 +226,15 @@ sharing' ::
   (forall β. Share (β /\ α) a -> BO (β /\ α') (After β r)) %1 ->
   BO α' (r, Mut α a)
 {-# INLINE sharing' #-}
+#ifdef PURE_BORROW_SLOW_SCOPES
 sharing' v k = DataFlow.do
   srunBO DataFlow.do
     (v, lend) <- reborrow v
     share v & \(Ur v) -> Control.do
       k v Control.<&> \v -> (,) Control.<$> v Control.<*> upcast (reclaim' lend)
+#else
+sharing' = unsafeBorrowScope'
+#endif
 
 {- | Executes an operation on 'Mut'able borrow in sub lifetime.
 You may need @-XImpredicativeTypes@ extension to use this function.
@@ -238,11 +246,15 @@ reborrowing' ::
   (forall β. Mut (β /\ α) a %1 -> BO (β /\ α') (After β r)) %1 ->
   BO α' (r, Mut α a)
 {-# INLINE reborrowing' #-}
+#ifdef PURE_BORROW_SLOW_SCOPES
 reborrowing' v k = srunBO DataFlow.do
   (v, lend) <- reborrow v
   Control.do
     v <- k v
     Control.pure $ (,) Control.<$> v Control.<*> upcast (reclaim' lend)
+#else
+reborrowing' = unsafeBorrowScope'
+#endif
 
 {- | A variant of 'reborrowing'' that returns the direct value of the operation on the reborrowed mutable borrow.
 There is also a flipped infix version '(<%~)'.
@@ -254,7 +266,11 @@ reborrowing ::
   (forall β. Mut (β /\ α) a %1 -> BO (β /\ α') r) %1 ->
   BO α' (r, Mut α a)
 {-# INLINE reborrowing #-}
+#ifdef PURE_BORROW_SLOW_SCOPES
 reborrowing mutα k = reborrowing' mutα (\mut -> Control.pure Control.<$> k mut)
+#else
+reborrowing = unsafeBorrowScope
+#endif
 
 -- | Flipped infix version of 'reborrowing', smoewhat analgous to '(Control.<$>)' and @(<%~)@ in @lens@ package.
 (<%~) ::

--- a/src/Control/Monad/Borrow/Pure/BO/Internal.hs
+++ b/src/Control/Monad/Borrow/Pure/BO/Internal.hs
@@ -266,6 +266,22 @@ newtype Alias ak a = UnsafeAlias a
 unsafeUnalias :: Alias ak a %1 -> a
 unsafeUnalias (UnsafeAlias x) = x
 
+{- |
+Retags an alias with another 'AliasKind', leaving the aliased resource alone.
+
+The role annotation below makes @ak@ nominal precisely so that this retagging is
+not derivable, so every use is a proof obligation about the kind being moved to:
+a 'Share' must not be widened into a 'Mut', a borrower must not become a lender,
+and the lifetime it is retagged to must be one throughout which the resource is
+really borrowed.
+
+This is a coercion, not a coincidence of representation: 'Alias' is a newtype
+over the resource, so the retagged alias is the very same value.
+-}
+unsafeCastAlias :: Alias ak a %1 -> Alias ak' a
+{-# INLINE unsafeCastAlias #-}
+unsafeCastAlias = coerceLin
+
 type role Alias nominal representational
 
 -- | Alias kind.
@@ -413,8 +429,51 @@ unsafeBorrowScope_ ::
 {-# INLINE unsafeBorrowScope_ #-}
 unsafeBorrowScope_ = Unsafe.toLinear2 \mut k ->
   unsafeSrunBO_ $
-    k (Unsafe.coerce mut) Control.<&> \r ->
+    k (unsafeCastAlias mut) Control.<&> \r ->
       consume r `lseq` mut
+
+{- |
+Run a continuation with a representation-identical borrow narrowed to a fresh
+sublifetime, then, on normal return, restore the original mutable borrow
+alongside the continuation's result.
+
+This is the trusted delimiter used by the scalar public result-returning
+combinators, and every obligation discharged in 'unsafeBorrowScope_' is
+discharged here in the same way. The result type is fixed by the caller, so it
+cannot mention the private @β@ and no borrow at @β@ escapes in it.
+-}
+unsafeBorrowScope ::
+  forall bk α α' a r.
+  Mut α a %1 ->
+  (forall β. Borrow bk (β /\ α) a %(BorrowMultiplicity bk) -> BO (β /\ α') r) %1 ->
+  BO α' (r, Mut α a)
+{-# INLINE unsafeBorrowScope #-}
+unsafeBorrowScope = Unsafe.toLinear2 \mut k ->
+  unsafeSrunBO_ $
+    k (unsafeCastAlias mut) Control.<&> \r ->
+      (r, mut)
+
+{- |
+The finalizing variant of 'unsafeBorrowScope': the continuation returns its
+result 'After' the sublifetime, and this discharges that 'After' before
+restoring the original mutable borrow.
+
+Beyond the obligations of 'unsafeBorrowScope', the 'EndToken' supplied to
+'withEnd' is the runtime-erased one. That is sound for the same reason it is in
+'Control.Monad.Borrow.Pure.BO.srunBO': the continuation has already returned, so
+the sublifetime it was typechecked in is over by the time the token is applied,
+and the caller-fixed result type cannot mention that lifetime.
+-}
+unsafeBorrowScope' ::
+  forall bk α α' a r.
+  Mut α a %1 ->
+  (forall β. Borrow bk (β /\ α) a %(BorrowMultiplicity bk) -> BO (β /\ α') (After β r)) %1 ->
+  BO α' (r, Mut α a)
+{-# INLINE unsafeBorrowScope' #-}
+unsafeBorrowScope' = Unsafe.toLinear2 \mut k ->
+  unsafeSrunBO_ $
+    k (unsafeCastAlias mut) Control.<&> \after ->
+      (withEnd UnsafeEnd after, mut)
 
 type BorrowMultiplicity :: BorrowKind -> Multiplicity
 type family BorrowMultiplicity bk where

--- a/src/Control/Monad/Borrow/Pure/BO/Unsafe.hs
+++ b/src/Control/Monad/Borrow/Pure/BO/Unsafe.hs
@@ -23,6 +23,7 @@ module Control.Monad.Borrow.Pure.BO.Unsafe (
   Alias (..),
   unsafeUnalias,
   unsafeMapAlias,
+  unsafeCastAlias,
 
   -- * Conversions from/to 'BO' monad.
   unsafeBOToLinIO,

--- a/test-inspection/PureBorrow/Inspection/Sublifetime.hs
+++ b/test-inspection/PureBorrow/Inspection/Sublifetime.hs
@@ -34,7 +34,13 @@ module PureBorrow.Inspection.Sublifetime (
   srunBO_At,
   idBOAt,
   reborrowingRefAt,
+  reborrowingValueRefAt,
+  bumpRefAt,
+  bumpRefAfterAt,
   sharingRefAt,
+  sharingValueRefAt,
+  copyRefAt,
+  copyRefAfterAt,
 ) where
 
 import Control.Functor.Linear qualified as Control
@@ -82,20 +88,93 @@ idBOAt :: BO β Int %1 -> BO β Int
 {-# NOINLINE idBOAt #-}
 idBOAt bo = bo
 
--- | A client-level probe: 'reborrowing'' is one of the two public combinators built on 'srunBO', so the erasure has to reach through it too.
-reborrowingRefAt :: Mut α (Ref Int) %1 -> BO α (Int, Mut α (Ref Int))
-{-# NOINLINE reborrowingRefAt #-}
-reborrowingRefAt ref = reborrowing' ref \borrowed -> Control.do
-  (old, spent) <-
-    Ref.update (\x -> dup2 x & \(seen, next) -> Control.pure (seen, next + 1)) borrowed
-  spent `lseq` Control.pure (After old)
+{- | The body every mutable-side probe below delimits: read the reference, put back its successor, and report what was there.
 
--- | The other 'srunBO' client, on the shared side.
-sharingRefAt :: Mut α (Ref Int) %1 -> BO α (Int, Mut α (Ref Int))
+Sharing it between the probes and their specification is what makes the equalities statements about the delimiter alone.
+-}
+bumpRef :: (α >= β) => Mut α (Ref Int) %1 -> BO β (Int, Mut α (Ref Int))
+{-# INLINE bumpRef #-}
+bumpRef = Ref.update \x -> dup2 x & \(seen, next) -> Control.pure (seen, next + 1)
+
+{- | A client-level probe: 'reborrowing'' is one of the two public combinators built on 'srunBO', so the erasure has to reach through it too.
+
+The restored borrow is dropped rather than returned, because a delimiter-free specification cannot both operate on the caller's 'Mut' and hand it back — handing it back is precisely the service the delimiter provides.
+Returning it would compare a probe that gives back the box it was handed against a specification that rebuilds one, and the two differ in worker/wrapper shape for a reason that has nothing to do with the sublifetime.
+-}
+reborrowingRefAt :: Mut α (Ref Int) %1 -> BO α Int
+{-# NOINLINE reborrowingRefAt #-}
+reborrowingRefAt ref =
+  reborrowing'
+    ref
+    ( \borrowed -> Control.do
+        (old, spent) <- bumpRef borrowed
+        spent `lseq` Control.pure (After old)
+    )
+    Control.<&> \(old, mut) -> mut `lseq` old
+
+-- | 'reborrowing', the same probe with the result returned directly instead of 'After' the sublifetime.
+reborrowingValueRefAt :: Mut α (Ref Int) %1 -> BO α Int
+{-# NOINLINE reborrowingValueRefAt #-}
+reborrowingValueRefAt ref =
+  reborrowing
+    ref
+    ( \borrowed -> Control.do
+        (old, spent) <- bumpRef borrowed
+        spent `lseq` Control.pure old
+    )
+    Control.<&> \(old, mut) -> mut `lseq` old
+
+{- | The specification 'reborrowingValueRefAt' must meet: 'bumpRef' on the caller's own borrow, with no sublifetime anywhere.
+
+Note the signature — no rank-2 argument and no @/\\@ — so an equality says the reborrow left no residue at all, not merely that it allocated no token.
+-}
+bumpRefAt :: Mut α (Ref Int) %1 -> BO α Int
+{-# NOINLINE bumpRefAt #-}
+bumpRefAt ref = Control.do
+  (old, spent) <- bumpRef ref
+  spent `lseq` Control.pure old
+
+{- | The specification 'reborrowingRefAt' must meet: 'bumpRefAt', plus the application that hands the runtime-erased 'EndToken' to the 'After' the continuation returned.
+
+That application is the one thing a delimiter taking an @'After' β r@ cannot drop, and 'srunBO' pays it too — see 'endTokenAt'.
+-}
+bumpRefAfterAt :: forall α. Mut α (Ref Int) %1 -> BO α Int
+{-# NOINLINE bumpRefAfterAt #-}
+bumpRefAfterAt ref = Control.do
+  (old, spent) <- bumpRef ref
+  spent `lseq` Control.pure (withEnd (UnsafeEnd @α) (After old))
+
+-- | The other 'srunBO' client, on the shared side, with the restored borrow dropped as above.
+sharingRefAt :: Mut α (Ref Int) %1 -> BO α Int
 {-# NOINLINE sharingRefAt #-}
-sharingRefAt ref = sharing' ref \shared -> Control.do
-  seen <- Ref.copyRef shared
-  Control.pure (After seen)
+sharingRefAt ref =
+  sharing'
+    ref
+    ( \shared -> Control.do
+        seen <- Ref.copyRef shared
+        Control.pure (After seen)
+    )
+    Control.<&> \(seen, mut) -> mut `lseq` seen
+
+-- | 'sharing', the same probe with the result returned directly instead of 'After' the sublifetime.
+sharingValueRefAt :: Mut α (Ref Int) %1 -> BO α Int
+{-# NOINLINE sharingValueRefAt #-}
+sharingValueRefAt ref =
+  sharing ref (\shared -> Ref.copyRef shared) Control.<&> \(seen, mut) -> mut `lseq` seen
+
+{- | The specification 'sharingValueRefAt' must meet: read through the caller's own borrow, with no sublifetime anywhere.
+
+'Data.Ref.Linear.Borrow.copyRef' reads through a borrow of either kind, so the 'Mut' serves here where the probes pass a 'Share' narrowed to the sublifetime.
+-}
+copyRefAt :: Mut α (Ref Int) %1 -> BO α Int
+{-# NOINLINE copyRefAt #-}
+copyRefAt ref = Ref.copyRef ref
+
+-- | The specification 'sharingRefAt' must meet: 'copyRefAt' plus the end-token application, as 'bumpRefAfterAt' is to 'bumpRefAt'.
+copyRefAfterAt :: forall α. Mut α (Ref Int) %1 -> BO α Int
+{-# NOINLINE copyRefAfterAt #-}
+copyRefAfterAt ref =
+  Ref.copyRef ref Control.<&> \seen -> withEnd (UnsafeEnd @α) (After seen)
 
 {- | Every obligation below describes the statically erased delimiters, so under @+slow@ — where the sublifetime is a genuine runtime token by construction — each one is expected to fail rather than to be skipped.
 That inversion is what keeps them honest: an obligation that also holds of the allocating implementation is no evidence about this one, and turns the group red under @+slow@ until it is either sharpened or dropped.
@@ -172,6 +251,34 @@ tests =
              ( (doesNotUse 'sharingRefAt 'askLinearly)
                  { testName =
                      Just "sharing' does not reach for the ambient Linearly"
+                 }
+             )
+         )
+      , $( inspectTest
+             ( ('reborrowingRefAt ==- 'bumpRefAfterAt)
+                 { testName =
+                     Just "reborrowing' only supplies the erased end token"
+                 }
+             )
+         )
+      , $( inspectTest
+             ( ('reborrowingValueRefAt ==- 'bumpRefAt)
+                 { testName =
+                     Just "reborrowing costs nothing over the update it delimits"
+                 }
+             )
+         )
+      , $( inspectTest
+             ( ('sharingRefAt ==- 'copyRefAfterAt)
+                 { testName =
+                     Just "sharing' only supplies the erased end token"
+                 }
+             )
+         )
+      , $( inspectTest
+             ( ('sharingValueRefAt ==- 'copyRefAt)
+                 { testName =
+                     Just "sharing costs nothing over the read it delimits"
                  }
              )
          )


### PR DESCRIPTION
`sharing`, `sharing'`, `reborrowing` and `reborrowing'` opened a real sublifetime: a runtime token from `newLifetime`, a `reborrow`/`reclaim'` lender pair, and the applicative `After` plumbing that recombines the two.
None of it is observable, since the lifetime indices are runtime-erased and the private lifetime is inaccessible to the rank-2 continuation, so the delimiters now compile to the body they delimit.
This follows #35, which did the same for `srunBO`/`srunBO_`.

## What changed

- Two trusted delimiters next to the existing `unsafeBorrowScope_`: `unsafeBorrowScope` for the result-returning combinators, and `unsafeBorrowScope'` for the ones taking an `After β r`, which discharges it with the runtime-erased `EndToken` exactly as `srunBO` does. Each documents the obligation it discharges.
- Retagging a borrow now goes through `unsafeCastAlias :: Alias ak a %1 -> Alias ak' a` rather than a bare `Unsafe.coerce`, so the operation names what it does and carries its own proof obligation. It is a `coerceLin`, so no `unsafeCoerce#` is involved at all; `Alias`'s nominal role on `ak` is the only reason the retagging is not derivable. Re-exported from `Control.Monad.Borrow.Pure.BO.Unsafe` alongside `unsafeMapAlias`.
- The previous, token-allocating bodies are preserved verbatim behind `+slow`, as `srunBO` and `copyAtMut` already are, and the same suites run under both.
- The tutorial's performance note no longer explains the `subShare` advice by the cost of opening and reclaiming a sublifetime.

## Core

Client-side probe at `Mut α (Ref Int)`, read-and-increment on the mutable side, `copyRef` on the shared side, `-O2`. Worker only; the wrapper is the same 13-term unboxing shim in each case.

`reborrowing` — 25 terms, 15 coercions, the body alone:

```
$wreborrowingAt
  = \ @α ref eta2 ->
      case ref `cast` <Co:6> :: Alias ('Borrow 'Mut α) (Ref Int) ~R# Ref Int
      of wild { Ref v ->
      case unsafeReadRef# v of { (# ipv, ipv1 #) ->
      case ipv of a1 { I# ipv2 ->
      case (unsafeWriteRef# ipv1 (I# (+# ipv2 1#)))
           `cast` <Co:2> :: Ref# Int ~R# MutVar# RealWorld Int
      of { __DEFAULT ->
      (# eta2, a1, wild `cast` <Co:7> :: Ref Int ~R# Alias ('Borrow 'Mut α) (Ref Int) #)
      }}}}
```

`reborrowing'` — 30 terms, 21 coercions, the same term plus the end-token application:

```
      (# eta2,
         nospec withDict (lvl `cast` … ~R# WithDict (End α) (EndToken α))
           UnsafeEnd (\ _ -> a1),
         wild `cast` <Co:7> :: Ref Int ~R# Alias ('Borrow 'Mut α) (Ref Int) #)
```

`sharing` — 17 terms, 13 coercions. `sharing'` — 22 terms, 19 coercions, again differing only by that application.

Under `+slow` the same probes are 44/44/36/36 terms and 67/67/65/65 coercions: the witness is fetched (`askLinearly`, `UnsafeLinearly`), the sublifetime is a real `Al (ZonkAny 0)`, the result pair is built inside the end-token continuation and cased apart again, and no worker/wrapper split happens, so the pair comes back boxed.

## Tests

Four Core obligations join the sublifetime group. `reborrowing` and `sharing` must be Core-equal to the delimiter-free body; `reborrowing'` and `sharing'` to that body plus the end-token application.

The probes return the value and drop the restored borrow. No delimiter-free specification can both operate on the caller's `Mut` and hand it back — that is the service the delimiter provides — and keeping it would compare a probe that returns the box it was handed against a specification that rebuilds one, a worker/wrapper difference having nothing to do with the sublifetime.

Verified on ghc-9.12.4 at `-O2` both ways: all thirteen obligations in the group pass with the flag off and fail under `+slow`, so each one discriminates between the two implementations. `cabal build all` and `cabal test` are green under both flag settings (294 tasty / doctests / 35 inspection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)