### PR TITLE
fix(bo): restore a borrow scope's borrow through an opaque barrier

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -248,6 +248,11 @@ Includes a demonstrative in-place parallel `qsort` (budgeted `parBO`; the heavie
 - **One sentence per line.** Never fold a line in the middle of a sentence — insert a newline only at a sentence boundary, and let the editor soft-wrap whatever is long.
   This governs every kind of prose you write: Markdown files, Haddock and ordinary source comments, and commit-message bodies.
   It keeps diffs sentence-scoped, so rewording one sentence never reflows the paragraph around it.
+- **`Note [...]` blocks are dev notes, never Haddock.** The convention is GHC's: a note is a named, cross-referenced explanation addressed to whoever maintains the code, and it is cited from elsewhere as ``See Note [Its name]``.
+  Write one in a plain block comment — `{- ... -}`, not `{- | ... -}` and not `-- |` — with the name on its own line underlined by `~`, and place it at the top level near what it explains rather than attached to a binding.
+  It is not part of the published API: a note explains why the implementation is the way it is, whereas Haddock tells a user what a function does and what they must guarantee.
+  Folding one into a Haddock comment publishes internal reasoning on Hackage and makes the note impossible to cite from a second site, since a Haddock comment belongs to exactly one binding.
+  Keep the user-facing obligation in the Haddock and cite the note from there.
 - **Lifetime parameter names:** quantify lifetime parameters as `α`, `β`, `γ`, using primes or numeric suffixes when more are needed.
   Do not use prose names such as `lifetime`, `scope`, or `inner` for lifetime type variables.
 - **Multiplicity determines ownership:** data bound nonlinearly (through an ordinary arrow / `%Many`) is GC-owned.

--- a/src/Control/Monad/Borrow/Pure.hs
+++ b/src/Control/Monad/Borrow/Pure.hs
@@ -414,15 +414,16 @@ Hence, if you see @'Borrow' bk α a@ in a function, it can be either 'Mut' or 'S
 == Performance-sensitive loops
 
 Choose the loop structure that performs the least algorithmic work first.
-The sublifetime that a 'sharing' or a 'reborrowing' delimits is erased at compile time, so with the surrounding functions properly inlined one of them per iteration costs nothing beyond the borrow it hands to the body.
-For an otherwise read-only loop, however, prefer sharing once outside the loop and shortening that shared borrow inside each iteration with 'subShare':
+The sublifetime that a 'sharing' or a 'reborrowing' delimits is erased at compile time: no lifetime token is allocated, no lender is created, and no @After@ plumbing survives.
+What does remain is one opaque call at each scope exit, through which the borrow is handed back, and it allocates nothing.
+For an otherwise read-only loop, prefer sharing once outside the loop and shortening that shared borrow inside each iteration with 'subShare':
 
 @
 'share' resource \& \('Ur' shared) ->
   ... 'subShare' shared ...
 @
 
-That way the body never has to give the borrow back, so no @(r, 'Mut' α a)@ pair is built and taken apart on every iteration.
+That way the body never has to give the borrow back, so neither the @(r, 'Mut' α a)@ pair nor the restoring call is paid on every iteration.
 Functions containing hot loops over operations that return
 @(Ur a, container)@ should themselves be @INLINE@, @INLINABLE@, or specialised.
 That lets GHC eliminate the transient tuple and 'Ur' constructors; without

--- a/src/Control/Monad/Borrow/Pure/BO/Internal.hs
+++ b/src/Control/Monad/Borrow/Pure/BO/Internal.hs
@@ -282,6 +282,55 @@ unsafeCastAlias :: Alias ak a %1 -> Alias ak' a
 {-# INLINE unsafeCastAlias #-}
 unsafeCastAlias = coerceLin
 
+{-
+Note [Restoring a borrow must break its Core identity]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Not every read of a borrowed resource is threaded through this monad's state token.
+A growable vector keeps its length and its backing buffer behind a `Data.Ref.Linear.Ref`, and the reads that only project that header -- `size`, `capacity`, `getContents` and their neighbours -- go through `Data.Ref.Linear.unsafeReadRef`, an @INLINE@ pass-through to the `GHC.Magic.noinline`-wrapped `Data.Ref.Linear.Unlifted.unsafeReadRef#`, which opens its own `runRW#`.
+To GHC such a read is a plain function of the borrow.
+Two of them on the same borrow /variable/ are therefore the same Core expression, and common-subexpression elimination is entitled to serve the second from the first.
+
+What keeps that honest is that every operation which replaces the header writes through `Data.Ref.Linear.Unlifted.unsafeWriteRef#`, which is @NOINLINE@, and hands back the reference that write returned.
+The optimizer cannot see through it, so a read after a growth scrutinises a different expression than a read before it, and the two do not merge.
+The whole ordering guarantee for header traffic rests on that one data dependency.
+
+A delimiter that returns the borrow its caller passed in throws the dependency away.
+The restored borrow is then the caller's own binder, so a read after the scope is syntactically the read before it, and CSE deletes the later one -- serving a stale length and a stale buffer across every growth the scope performed.
+Writing through the stale buffer at an index the fresh length admits runs off the end of the allocation, which is how this last surfaced downstream: a SIGSEGV inside the collector, or silently wrong data under a nursery large enough that the damage is never traversed.
+
+So a delimiter restores its borrow through `reviveAlias`, and both of its properties are load-bearing.
+
+Do not weaken the @OPAQUE@ to @NOINLINE@.
+Measured on GHC 9.12.4 at -O2 a @NOINLINE@ version is an equally good barrier today, and for a knowable reason: the argument's demand comes out lazy and the result is already an unboxed tuple, so no worker/wrapper split occurs and no @$w@ worker is generated.
+But that is a property of one demand signature rather than a guarantee, and @OPAQUE@ is the one pragma GHC documents as suppressing inlining, worker/wrapper, specialisation and rules together.
+The barrier is the whole of the memory safety of these delimiters, so it should rest on a contract rather than on a coincidence.
+
+It lives in `BO` rather than being a pure function because a pure barrier depends on nothing the scope produced, so nothing would stop it -- or the reads that consume its result -- from floating above the scope body.
+Consuming the state token pins the restoration after the scope's effects.
+A pure @OPAQUE@ barrier also measures a few percent worse in a tight loop, but that is a side benefit and not the reason.
+
+The cost is one out-of-line call per scope exit, around 0.7ns on aarch64-darwin with GHC 9.12.4, plus whatever it costs that a loop-carried borrow can no longer be unboxed past the barrier: measured together at 14-20% of a tight L1-resident loop that does nothing but the scope, and unmeasurable in any benchmark this repository ships.
+No closure is allocated and the recursion remains a self tail call; what the call adds is a non-tail continuation and, in a loop, a boxed rather than unboxed loop-carried borrow.
+
+This is a statement about the delimiters, not about `Ref` in general.
+Threading the header reads through the state token, so that they are ordered like every other mutable operation and this whole hazard disappears, would be the durable fix; it is an API break and is not attempted here.
+The barrier is also one-directional -- it stops a post-scope read being served from a pre-scope one, but nothing stops a pre-scope read from sinking below the scope -- so that deferral should not drift indefinitely.
+-}
+
+{- | Return a borrow to the caller of a delimiter, through a barrier the optimizer cannot see through.
+
+Semantically this is `Control.pure` at 'Alias', and it carries no proof obligation of its own: its argument and result types are identical, so it cannot widen a 'Share' into a 'Mut', relabel a 'Lend', or lengthen a lifetime, and the `BO` index it returns at is as free as `Control.pure`'s already is.
+That is also why it comes with no @TypingCases@ entry: there is no program that should stop typechecking because of it.
+
+What it does carry is an obligation on /callers/.
+Any delimiter that runs a continuation and then hands the caller back the borrow it was given must restore it through this.
+Returning the caller's own occurrence instead lets common-subexpression elimination serve a post-scope read of the resource from a pre-scope one, across every write the scope performed.
+See Note [Restoring a borrow must break its Core identity] for why, and for why the @OPAQUE@ and the state token are both load-bearing.
+-}
+reviveAlias :: Alias ak a %1 -> BO α (Alias ak a)
+{-# OPAQUE reviveAlias #-}
+reviveAlias a = BO \s -> (# s, a #)
+
 type role Alias nominal representational
 
 -- | Alias kind.
@@ -419,6 +468,9 @@ function while the continuation runs. The continuation result is consumed
 before the outer borrow is restored. The continuation and state token are each
 consumed exactly once. Since the lifetime indices have runtime-erased
 representations, no runtime lifetime token or lender is required.
+
+The borrow is handed back through 'reviveAlias' rather than returned directly;
+see Note [Restoring a borrow must break its Core identity] there.
 -}
 unsafeBorrowScope_ ::
   forall bk α α' a r.
@@ -428,9 +480,12 @@ unsafeBorrowScope_ ::
   BO α' (Mut α a)
 {-# INLINE unsafeBorrowScope_ #-}
 unsafeBorrowScope_ = Unsafe.toLinear2 \mut k ->
-  unsafeSrunBO_ $
-    k (unsafeCastAlias mut) Control.<&> \r ->
-      consume r `lseq` mut
+  unsafeSrunBO_ Control.do
+    r <- k (unsafeCastAlias mut)
+    -- @consume r@ stays in the returned value rather than in the action, so it runs when the caller forces the restored borrow.
+    -- Sequencing it at scope exit instead would make this delimiter stricter than the one @+slow@ restores, and the two are required to stay observationally equivalent.
+    restored <- reviveAlias mut
+    Control.pure (consume r `lseq` restored)
 
 {- |
 Run a continuation with a representation-identical borrow narrowed to a fresh
@@ -449,9 +504,9 @@ unsafeBorrowScope ::
   BO α' (r, Mut α a)
 {-# INLINE unsafeBorrowScope #-}
 unsafeBorrowScope = Unsafe.toLinear2 \mut k ->
-  unsafeSrunBO_ $
-    k (unsafeCastAlias mut) Control.<&> \r ->
-      (r, mut)
+  unsafeSrunBO_ Control.do
+    r <- k (unsafeCastAlias mut)
+    (r,) Control.<$> reviveAlias mut
 
 {- |
 The finalizing variant of 'unsafeBorrowScope': the continuation returns its
@@ -471,9 +526,9 @@ unsafeBorrowScope' ::
   BO α' (r, Mut α a)
 {-# INLINE unsafeBorrowScope' #-}
 unsafeBorrowScope' = Unsafe.toLinear2 \mut k ->
-  unsafeSrunBO_ $
-    k (unsafeCastAlias mut) Control.<&> \after ->
-      (withEnd UnsafeEnd after, mut)
+  unsafeSrunBO_ Control.do
+    after <- k (unsafeCastAlias mut)
+    (withEnd UnsafeEnd after,) Control.<$> reviveAlias mut
 
 type BorrowMultiplicity :: BorrowKind -> Multiplicity
 type family BorrowMultiplicity bk where

--- a/src/Control/Monad/Borrow/Pure/BO/Unsafe.hs
+++ b/src/Control/Monad/Borrow/Pure/BO/Unsafe.hs
@@ -24,6 +24,7 @@ module Control.Monad.Borrow.Pure.BO.Unsafe (
   unsafeUnalias,
   unsafeMapAlias,
   unsafeCastAlias,
+  reviveAlias,
 
   -- * Conversions from/to 'BO' monad.
   unsafeBOToLinIO,

--- a/src/Control/Monad/Borrow/Pure/Experimental/Borrows.hs
+++ b/src/Control/Monad/Borrow/Pure/Experimental/Borrows.hs
@@ -111,17 +111,31 @@ instance Reborrowable (Muts α) where
 reborrows :: forall β α a. (α >= β) => Muts α a %1 -> (Muts β a, Lend β (Muts α a))
 reborrows = Unsafe.toLinear \v -> (unsafeCoerce v, unsafeCoerce v)
 
+{- | Return a bundle of borrows to the caller of a delimiter, through a barrier the optimizer cannot see through.
+
+This is the plural counterpart of 'Control.Monad.Borrow.Pure.BO.Unsafe.reviveAlias', and it exists for the same reason.
+See Note [Restoring a borrow must break its Core identity] in "Control.Monad.Borrow.Pure.BO.Internal".
+
+'reborrowings'' would otherwise restore the caller's own occurrence, since 'reborrows' hands the same value out as both borrow and lender and 'reclaim' is a newtype unwrap.
+It happens not to misbehave today, because 'reclaim'' is reached through 'withEnd', whose @withDict@ desugars through the wired-in @nospec@ and survives every Core-to-Core pass — but that is a coincidence of one desugaring, and it is exactly the kind of accident the Note argues a delimiter must not rest on.
+-}
+reviveAliases :: Aliases k xs %1 -> BO α (Aliases k xs)
+{-# OPAQUE reviveAliases #-}
+reviveAliases as = Control.pure as
+
 -- | A plural form of 'reborrowing''.
 reborrowings' ::
   Muts α a %1 ->
   (forall β. Muts (β /\ α) a %1 -> BO (β /\ α') (After β r)) %1 ->
   BO α' (r, Muts α a)
 {-# INLINE reborrowings' #-}
-reborrowings' v k = srunBO DataFlow.do
-  (v, lend) <- reborrows v
-  Control.do
-    v <- k v
-    Control.pure $ (,) Control.<$> v Control.<*> upcast (reclaim' lend)
+reborrowings' v k = Control.do
+  (r, restored) <- srunBO DataFlow.do
+    (v, lend) <- reborrows v
+    Control.do
+      v <- k v
+      Control.pure $ (,) Control.<$> v Control.<*> upcast (reclaim' lend)
+  (r,) Control.<$> reviveAliases restored
 
 reborrowings ::
   Muts α a %1 ->

--- a/src/Control/Monad/Borrow/Pure/Experimental/Reborrowable.hs
+++ b/src/Control/Monad/Borrow/Pure/Experimental/Reborrowable.hs
@@ -20,6 +20,7 @@ module Control.Monad.Borrow.Pure.Experimental.Reborrowable (
 
 import Control.Functor.Linear qualified as Control
 import Control.Monad.Borrow.Pure.BO
+import Control.Monad.Borrow.Pure.BO.Unsafe (reviveAlias)
 import Data.Kind (Constraint, Type)
 import Prelude.Linear
 
@@ -50,9 +51,13 @@ instance Reborrowable (Share α) where
   type LifetimeOf (Share α) = α
   type WithLifetime (Share α) β = Share β
   {-# SPECIALIZE instance Reborrowable (Share α) #-}
+
+  -- 'move' for a shared borrow is the identity, so @sh@ is the caller's own occurrence and returning it directly would carry the defect in Note [Restoring a borrow must break its Core identity].
+  -- Hand it back through 'reviveAlias' as the scalar delimiters do.
   locally' shr k = Control.do
     let %1 !(Ur sh) = move shr
-    (,sh) Control.<$> srunBO (k (upcast sh))
+    r <- srunBO (k (upcast sh))
+    (r,) Control.<$> reviveAlias sh
   {-# INLINE locally' #-}
 
 locally ::

--- a/src/Data/Vector/Generic/Mutable/Growable/Linear/Borrow/Unrestricted/Internal.hs
+++ b/src/Data/Vector/Generic/Mutable/Growable/Linear/Borrow/Unrestricted/Internal.hs
@@ -847,9 +847,10 @@ withContent =
     -- the result type cannot mention the fresh lifetime. Only then is the
     -- original growable occurrence restored. This is a normal-return
     -- guarantee; the module promises no owner recovery after an exception.
-    unsafeSrunBO_ $
-      action (getContents (Unsafe.coerce vector))
-        Control.<&> \result -> (result, vector)
+    -- The growable borrow is handed back through `reviveAlias`, as the scalar delimiters do: see Note [Restoring a borrow must break its Core identity] in "Control.Monad.Borrow.Pure.BO.Internal".
+    unsafeSrunBO_ Control.do
+      result <- action (getContents (Unsafe.coerce vector))
+      (result,) Control.<$> reviveAlias vector
 
 -- | A result-discarding variant of 'withContent'.
 withContent_ ::

--- a/src/Data/Vector/Mutable/Growable/Linear/Borrow/Internal.hs
+++ b/src/Data/Vector/Mutable/Growable/Linear/Borrow/Internal.hs
@@ -843,6 +843,16 @@ getContents =
           UnsafeAlias
             (Fixed.Internal.unsafeFromMutableSlice 0 logicalSize buffer)
 
+{-
+Note [Uniformly linear content callback]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Ideally the callback arrow would use @BorrowMultiplicity bk@, making a
+shared callback unrestricted. GHC 9.12 rejects that signature because type
+families cannot witness multiplicity equality (GHC #19517). Keep one linear
+callback occurrence for both borrow kinds until that limitation is removed;
+shared callers can use 'move' to recover unrestricted use.
+-}
+
 {- | Borrow the fixed initialized prefix in a rank-2 no-growth scope.
 
 The callback and returned growable borrow preserve the input borrow kind. The
@@ -851,13 +861,8 @@ content when unrestricted use is desired. For a mutable input, the growable
 borrow is restored only after the callback result is produced and the fixed
 view has ended.
 
-Note [Uniformly linear content callback]
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Ideally the callback arrow would use @BorrowMultiplicity bk@, making a
-shared callback unrestricted. GHC 9.12 rejects that signature because type
-families cannot witness multiplicity equality (GHC #19517). Keep one linear
-callback occurrence for both borrow kinds until that limitation is removed;
-shared callers can use 'move' to recover unrestricted use.
+See Note [Uniformly linear content callback] for why the callback stays linear
+for a shared borrow too.
 -}
 withContent ::
   Borrow bk α (GrowableVector a) %1 ->
@@ -869,9 +874,10 @@ withContent ::
 {-# INLINE withContent #-}
 withContent =
   Unsafe.toLinear2 \vector action ->
-    unsafeSrunBO_ $
-      action (getContents (Unsafe.coerce vector))
-        Control.<&> \result -> (result, vector)
+    -- The growable borrow is handed back through `reviveAlias`, as the scalar delimiters do: see Note [Restoring a borrow must break its Core identity] in "Control.Monad.Borrow.Pure.BO.Internal".
+    unsafeSrunBO_ Control.do
+      result <- action (getContents (Unsafe.coerce vector))
+      (result,) Control.<$> reviveAlias vector
 
 -- | A result-discarding variant of 'withContent'.
 withContent_ ::

--- a/src/Data/Vector/Unboxed/Mutable/Growable/Linear/Borrow/Internal.hs
+++ b/src/Data/Vector/Unboxed/Mutable/Growable/Linear/Borrow/Internal.hs
@@ -777,9 +777,10 @@ withContent ::
 {-# INLINE withContent #-}
 withContent =
   Unsafe.toLinear2 \vector action ->
-    unsafeSrunBO_ $
-      action (getContents (Unsafe.coerce vector))
-        Control.<&> \result -> (result, vector)
+    -- The growable borrow is handed back through `reviveAlias`, as the scalar delimiters do: see Note [Restoring a borrow must break its Core identity] in "Control.Monad.Borrow.Pure.BO.Internal".
+    unsafeSrunBO_ Control.do
+      result <- action (getContents (Unsafe.coerce vector))
+      (result,) Control.<$> reviveAlias vector
 
 -- | A result-discarding variant of 'withContent'.
 withContent_ ::

--- a/test-inspection/PureBorrow/Inspection/Sublifetime.hs
+++ b/test-inspection/PureBorrow/Inspection/Sublifetime.hs
@@ -45,6 +45,7 @@ module PureBorrow.Inspection.Sublifetime (
 
 import Control.Functor.Linear qualified as Control
 import Control.Monad.Borrow.Pure.BO
+import Control.Monad.Borrow.Pure.BO.Unsafe (reviveAlias)
 import Control.Monad.Borrow.Pure.Lifetime.Token.Unsafe (EndToken (..))
 import Data.Ref.Linear (Ref)
 import Data.Ref.Linear.Borrow qualified as Ref
@@ -52,6 +53,7 @@ import Prelude.Linear
 import PureBorrow.Inspection.Flags (expectFailIfBecause, isSlowAPI)
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.Inspection
+import Unsafe.Linear qualified as Unsafe
 import Prelude qualified as NonLinear
 
 {- | 'srunBO' at a concrete carrier.
@@ -124,15 +126,21 @@ reborrowingValueRefAt ref =
     )
     Control.<&> \(old, mut) -> mut `lseq` old
 
-{- | The specification 'reborrowingValueRefAt' must meet: 'bumpRef' on the caller's own borrow, with no sublifetime anywhere.
+{- | The specification 'reborrowingValueRefAt' must meet: 'bumpRef' on the caller's own borrow, plus the one 'reviveAlias' through which the delimiter restores that borrow.
 
-Note the signature — no rank-2 argument and no @/\\@ — so an equality says the reborrow left no residue at all, not merely that it allocated no token.
+Note the signature — no rank-2 argument and no @/\\@ — so an equality says the reborrow left no sublifetime residue at all, not merely that it allocated no token.
+The 'reviveAlias' is not residue of the sublifetime; it is the delimiter's entire remaining cost, and it is load-bearing rather than incidental — see Note [Restoring a borrow must break its Core identity] in "Control.Monad.Borrow.Pure.BO.Internal".
+Naming it here is what keeps these equalities honest: an earlier revision of this module asserted equality with the bare body, which said the delimiter compiled to nothing at all, and that was exactly the property that made it unsound.
+
+The specification has to reach for 'Unsafe.toLinear' because it mentions the caller's borrow twice, once to bump through and once to restore, which is precisely what the delimiter does with 'Unsafe.toLinear2'.
 -}
 bumpRefAt :: Mut α (Ref Int) %1 -> BO α Int
 {-# NOINLINE bumpRefAt #-}
-bumpRefAt ref = Control.do
+bumpRefAt = Unsafe.toLinear \ref -> Control.do
   (old, spent) <- bumpRef ref
-  spent `lseq` Control.pure old
+  spent `lseq` Control.do
+    restored <- reviveAlias ref
+    Control.pure (restored `lseq` old)
 
 {- | The specification 'reborrowingRefAt' must meet: 'bumpRefAt', plus the application that hands the runtime-erased 'EndToken' to the 'After' the continuation returned.
 
@@ -140,9 +148,11 @@ That application is the one thing a delimiter taking an @'After' β r@ cannot dr
 -}
 bumpRefAfterAt :: forall α. Mut α (Ref Int) %1 -> BO α Int
 {-# NOINLINE bumpRefAfterAt #-}
-bumpRefAfterAt ref = Control.do
+bumpRefAfterAt = Unsafe.toLinear \ref -> Control.do
   (old, spent) <- bumpRef ref
-  spent `lseq` Control.pure (withEnd (UnsafeEnd @α) (After old))
+  spent `lseq` Control.do
+    restored <- reviveAlias ref
+    Control.pure (restored `lseq` withEnd (UnsafeEnd @α) (After old))
 
 -- | The other 'srunBO' client, on the shared side, with the restored borrow dropped as above.
 sharingRefAt :: Mut α (Ref Int) %1 -> BO α Int
@@ -162,19 +172,25 @@ sharingValueRefAt :: Mut α (Ref Int) %1 -> BO α Int
 sharingValueRefAt ref =
   sharing ref (\shared -> Ref.copyRef shared) Control.<&> \(seen, mut) -> mut `lseq` seen
 
-{- | The specification 'sharingValueRefAt' must meet: read through the caller's own borrow, with no sublifetime anywhere.
+{- | The specification 'sharingValueRefAt' must meet: read through the caller's own borrow, plus the restoring 'reviveAlias', with no sublifetime anywhere.
 
 'Data.Ref.Linear.Borrow.copyRef' reads through a borrow of either kind, so the 'Mut' serves here where the probes pass a 'Share' narrowed to the sublifetime.
+The 'Unsafe.toLinear' is there for the same reason as in 'bumpRefAt'.
 -}
 copyRefAt :: Mut α (Ref Int) %1 -> BO α Int
 {-# NOINLINE copyRefAt #-}
-copyRefAt ref = Ref.copyRef ref
+copyRefAt = Unsafe.toLinear \ref -> Control.do
+  seen <- Ref.copyRef ref
+  restored <- reviveAlias ref
+  Control.pure (restored `lseq` seen)
 
 -- | The specification 'sharingRefAt' must meet: 'copyRefAt' plus the end-token application, as 'bumpRefAfterAt' is to 'bumpRefAt'.
 copyRefAfterAt :: forall α. Mut α (Ref Int) %1 -> BO α Int
 {-# NOINLINE copyRefAfterAt #-}
-copyRefAfterAt ref =
-  Ref.copyRef ref Control.<&> \seen -> withEnd (UnsafeEnd @α) (After seen)
+copyRefAfterAt = Unsafe.toLinear \ref -> Control.do
+  seen <- Ref.copyRef ref
+  restored <- reviveAlias ref
+  Control.pure (restored `lseq` withEnd (UnsafeEnd @α) (After seen))
 
 {- | Every obligation below describes the statically erased delimiters, so under @+slow@ — where the sublifetime is a genuine runtime token by construction — each one is expected to fail rather than to be skipped.
 That inversion is what keeps them honest: an obligation that also holds of the allocating implementation is no evidence about this one, and turns the group red under @+slow@ until it is either sharpened or dropped.
@@ -182,6 +198,9 @@ That inversion is what keeps them honest: an obligation that also holds of the a
 Two plausible-looking obligations were dropped for exactly that reason.
 @'hasNoType' \'srunBOAt ''SomeNow@ holds under both, because 'MkSomeNow' wraps a nullary 'Now' and case-of-known-constructor removes the box either way.
 @'hasNoType' \'reborrowingRefAt ''Now@ likewise: through 'reborrowing'' the token itself is always erased, and what the allocating version actually leaves behind is the 'Linearly' that produced it.
+
+The four borrow-scope equalities now pin the 'Control.Monad.Borrow.Pure.BO.Unsafe.reviveAlias' barrier as well, because their specifications name it.
+That matters beyond bookkeeping: the runtime regressions in "Control.Monad.Borrow.Pure.BOSpec" observe a wrong /answer/, so on a compiler that stopped performing the merge they would go vacuously green rather than red, and these equalities would be the only thing left that notices the barrier being dropped.
 -}
 tests :: TestTree
 tests =

--- a/test/Control/Monad/Borrow/Pure/BOSpec.hs
+++ b/test/Control/Monad/Borrow/Pure/BOSpec.hs
@@ -1,8 +1,13 @@
 {-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE ImpredicativeTypes #-}
 {-# LANGUAGE LinearTypes #-}
+{-# LANGUAGE QualifiedDo #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE NoImplicitPrelude #-}
+{-# OPTIONS_GHC -Wno-name-shadowing #-}
 
 module Control.Monad.Borrow.Pure.BOSpec (
   module Control.Monad.Borrow.Pure.BOSpec,
@@ -11,12 +16,23 @@ module Control.Monad.Borrow.Pure.BOSpec (
 import Control.Functor.Linear qualified as Control
 import Control.Monad.Borrow.Pure
 import Control.Monad.Borrow.Pure.BO qualified as BO
+import Control.Monad.Borrow.Pure.Experimental.Borrows qualified as Borrows
+import Control.Syntax.DataFlow qualified as DataFlow
 import Data.Functor.Linear qualified as Data
+import Data.HashMap.RobinHood.Mutable.Linear.Borrow qualified as HashMap
+import Data.Ref.Linear qualified as Ref
+import Data.Ref.Linear.Borrow qualified as RefBorrow
 import Data.Type.Equality ((:~:))
+import Data.Vector qualified as V
+import Data.Vector.Mutable.Growable.Linear.Borrow qualified as Growable
+import Data.Vector.Unboxed qualified as U
+import Data.Vector.Unboxed.Mutable.Growable.Linear.Borrow qualified as Unboxed
+import Prelude.Linear (Ur (..), consume, dup, lseq, unur, ($), (&))
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (testCase, (@?=))
 import Unsafe.Linear qualified as Unsafe
-import Prelude (Int, ($), (+))
+import Prelude (Int, Maybe (..), otherwise, show, (+), (-), (<>), (>=))
+import Prelude qualified as NonLinear
 
 assocBorrowEqTypingCase ::
   forall (bk :: BO.BorrowKind) α β γ a.
@@ -33,10 +49,386 @@ test_instanceMethods :: TestTree
 test_instanceMethods =
   testGroup
     "BO instance methods"
-    [ testCase "linear liftA2" $
+    [ testCase "linear liftA2" do
         linearly (\lin -> runBO_ lin (Control.liftA2 addLinear (Control.pure 20) (Control.pure 22))) @?= (42 :: Int)
-    , testCase "non-linear liftA2" $
+    , testCase "non-linear liftA2" do
         linearly (\lin -> runBO_ lin (Data.liftA2 addLinear (Data.pure 20) (Data.pure 22))) @?= (42 :: Int)
-    , testCase "linear sequencing" $
+    , testCase "linear sequencing" do
         linearly (\lin -> runBO_ lin (Control.pure () Control.>> Control.pure 42)) @?= (42 :: Int)
     ]
+
+{-
+Note [Observing a borrow scope's writes through the borrow it restores]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The kernels below share one shape: read the length through a borrow, hand that borrow to a scope whose body grows the vector, then read the length again through the borrow the scope handed back.
+The second read must observe the growth.
+
+They live here rather than with the growable vector's own tests because the growable vector is the instrument, not the subject.
+What is under test is the delimiter -- see Note [Restoring a borrow must break its Core identity] in "Control.Monad.Borrow.Pure.BO.Internal" -- and a growable vector is simply the resource this package ships whose length and buffer are read outside the state token, so a delimiter that hands back the caller's own binder lets common-subexpression elimination serve the second read from the first.
+
+Two details are load-bearing, and both were established by measuring variants against the pre-fix delimiter rather than by reasoning.
+
+Both reads must end up inlined into one Core body: each kernel is therefore a @NOINLINE@ top-level binding with no helper standing between the borrow and either read.
+Moving the pre-scope read behind its own @NOINLINE@ helper, or reaching the post-scope read through a recursive worker, makes the kernel pass on the broken delimiter -- vacuous, not merely weaker.
+The scope must write the header; which projection each side reads does not matter, and @capacity@ before against @size@ after merges just as readily.
+
+Two details that look load-bearing are not.
+The reallocation matters only for the stale-/buffer/ symptom that 'elementAcrossReborrowing' and 'writeAcrossReborrowing' observe; the stale-/length/ symptom reproduces on a push that fits in the existing capacity.
+And the @NOINLINE@ on each kernel is insurance rather than a requirement -- a plain CAF in the style of the other spec helpers reproduces too.
+
+Most of these fail as wrong data rather than as a crash: at -O2 before the fix the post-scope read is deleted outright and the pre-scope length is returned in its place.
+'writeAcrossReborrowing' is the exception, and is the one that reaches the shape which corrupted the heap downstream: it writes at an index the fresh length admits, through a header that still names the old, shorter buffer.
+It fails here as a bounds error only because 'Growable.modify' is the checked operation; the unchecked 'Growable.unsafeSet' at the same index would run off the end of the allocation, which is what the downstream SIGSEGV was.
+
+There is deliberately no 'sharing' or 'sharing_' kernel.
+Those delimiters hand their callback a 'Share', nothing in the API writes a growable header through a 'Share', and the 'Mut' that would be needed was consumed by the delimiter -- so such a kernel would pass on the broken build and would be evidence of nothing.
+They are fixed all the same, because the obligation belongs to the delimiter rather than to the set of writes that happen to be reachable today, but that half of the fix is prophylactic and is pinned by the Core obligations in @pure-borrow-inspection@ instead.
+-}
+
+seeded :: [Int]
+seeded = [10, 20, 30]
+
+appended :: Int -> [Int]
+appended count = NonLinear.map (100 +) (NonLinear.enumFromTo 0 (count - 1))
+
+-- | The model every kernel below is compared against: the length before, the length after, and the contents.
+grown :: Int -> (Int, Int, [Int])
+grown count = (3, 3 + count, seeded <> appended count)
+
+pushRange ::
+  (α >= β) =>
+  Int ->
+  Int ->
+  Mut α (Growable.GrowableVector Int) %1 ->
+  BO β (Mut α (Growable.GrowableVector Int))
+{-# INLINE pushRange #-}
+pushRange index count vector
+  | index >= count = Control.pure vector
+  | otherwise = Control.do
+      vector <- Growable.push (100 + index) vector
+      pushRange (index + 1) count vector
+
+pushRangeUnboxed ::
+  (α >= β) =>
+  Int ->
+  Int ->
+  Mut α (Unboxed.GrowableVector Int) %1 ->
+  BO β (Mut α (Unboxed.GrowableVector Int))
+{-# INLINE pushRangeUnboxed #-}
+pushRangeUnboxed index count vector
+  | index >= count = Control.pure vector
+  | otherwise = Control.do
+      vector <- Unboxed.push (100 + index) vector
+      pushRangeUnboxed (index + 1) count vector
+
+-- | 'reborrowing': the scope returns a value alongside the restored borrow.
+lengthAcrossReborrowing :: Int -> (Int, Int, [Int])
+{-# NOINLINE lengthAcrossReborrowing #-}
+lengthAcrossReborrowing count =
+  unur $ linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <-
+        borrowM (Growable.fromVector (V.fromList seeded) ownerLinear)
+      Growable.size vector & \(Ur before, vector) -> Control.do
+        ((), vector) <-
+          reborrowing vector \short ->
+            consume Data.<$> pushRange 0 count short
+        Growable.size vector & \(Ur after, vector) ->
+          vector `lseq` pureAfter (report before after (reclaim lend))
+
+-- | 'reborrowing'': the scope returns its value @After@ the sublifetime.
+lengthAcrossReborrowingAfter :: Int -> (Int, Int, [Int])
+{-# NOINLINE lengthAcrossReborrowingAfter #-}
+lengthAcrossReborrowingAfter count =
+  unur $ linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <-
+        borrowM (Growable.fromVector (V.fromList seeded) ownerLinear)
+      Growable.size vector & \(Ur before, vector) -> Control.do
+        ((), vector) <-
+          reborrowing' vector \short ->
+            (\short -> After (consume short)) Data.<$> pushRange 0 count short
+        Growable.size vector & \(Ur after, vector) ->
+          vector `lseq` pureAfter (report before after (reclaim lend))
+
+-- | 'reborrowing_': the scope discards its value.
+lengthAcrossReborrowingDiscarding :: Int -> (Int, Int, [Int])
+{-# NOINLINE lengthAcrossReborrowingDiscarding #-}
+lengthAcrossReborrowingDiscarding count =
+  unur $ linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <-
+        borrowM (Growable.fromVector (V.fromList seeded) ownerLinear)
+      Growable.size vector & \(Ur before, vector) -> Control.do
+        vector <-
+          reborrowing_ vector \short ->
+            consume Data.<$> pushRange 0 count short
+        Growable.size vector & \(Ur after, vector) ->
+          vector `lseq` pureAfter (report before after (reclaim lend))
+
+-- | The same as 'lengthAcrossReborrowing', on the unboxed growable vector.
+lengthAcrossReborrowingUnboxed :: Int -> (Int, Int, [Int])
+{-# NOINLINE lengthAcrossReborrowingUnboxed #-}
+lengthAcrossReborrowingUnboxed count =
+  unur $ linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <-
+        borrowM (Unboxed.fromVector (U.fromList seeded) ownerLinear)
+      Unboxed.size vector & \(Ur before, vector) -> Control.do
+        ((), vector) <-
+          reborrowing vector \short ->
+            consume Data.<$> pushRangeUnboxed 0 count short
+        Unboxed.size vector & \(Ur after, vector) ->
+          vector `lseq` pureAfter (reportUnboxed before after (reclaim lend))
+
+{- | 'Growable.withContent', which delimits a fixed view of the growable vector the same way.
+
+Growth happens after the scope rather than inside it, because the fixed view the callback receives deliberately cannot grow.
+Unlike its neighbours this kernel passes on the broken delimiter and cannot be made to fail: the callback receives a bare slice with no header to write, so nothing the scope does can make a merged header read stale.
+It is kept as a forward-looking guard on a delimiter that shares the defective shape, not as regression coverage — 'Growable.withContent' restores through the barrier for the same prophylactic reason 'sharing' does.
+-}
+lengthAcrossContentScope :: Int -> (Int, Int, [Int])
+{-# NOINLINE lengthAcrossContentScope #-}
+lengthAcrossContentScope count =
+  unur $ linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <-
+        borrowM (Growable.fromVector (V.fromList seeded) ownerLinear)
+      Growable.size vector & \(Ur before, vector) -> Control.do
+        ((), vector) <-
+          Growable.withContent vector \contents ->
+            Control.pure (consume contents)
+        vector <- pushRange 0 count vector
+        Growable.size vector & \(Ur after, vector) ->
+          vector `lseq` pureAfter (report before after (reclaim lend))
+
+{- | The same read-grow-read shape, repeated inside a recursive 'BO' loop.
+
+The straight-line kernels above already reproduce, but a loop is what supplies the inlining depth and the loop-invariant read the downstream report describes, so this covers a read floated out of the loop as well as one merged with its neighbour.
+Each round appends one element and records the length it observes afterwards, so a stale read is caught on the round that made it stale rather than only at the end.
+-}
+lengthsAcrossReborrowingLoop :: Int -> ([Int], [Int])
+{-# NOINLINE lengthsAcrossReborrowingLoop #-}
+lengthsAcrossReborrowingLoop rounds =
+  unur $ linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <-
+        borrowM (Growable.fromVector (V.fromList seeded) ownerLinear)
+      (Ur observed, vector) <- go 0 vector
+      vector `lseq` pureAfter do
+        Growable.toVector (reclaim lend) & \(Ur contents) ->
+          Ur (observed, V.toList contents)
+  where
+    go ::
+      forall α.
+      Int ->
+      Mut α (Growable.GrowableVector Int) %1 ->
+      BO α (Ur [Int], Mut α (Growable.GrowableVector Int))
+    {-# INLINE go #-}
+    go index vector
+      | index >= rounds = Control.pure (Ur [], vector)
+      | otherwise = Control.do
+          ((), vector) <-
+            reborrowing vector \short ->
+              consume Data.<$> Growable.push (100 + index) short
+          Growable.size vector & \(Ur seen, vector) -> Control.do
+            (Ur rest, vector) <- go (index + 1) vector
+            Control.pure (Ur (seen : rest), vector)
+
+{- | An element read through the restored borrow, rather than a length.
+
+The kernels above all materialize their contents from @'reclaim' lend@, which is the owner and never the expression the delimiter resurrects, so their contents component is correct even on the broken build and only their lengths discriminate.
+This one reads back through the borrow the scope handed over, so it is the kernel that actually witnesses a stale /buffer/: the push reallocates, the following 'Growable.modify' lands in the new allocation only, and a restored borrow still naming the old header reads the value from before the bump.
+-}
+elementAcrossReborrowing :: Int -> Int
+{-# NOINLINE elementAcrossReborrowing #-}
+elementAcrossReborrowing bumpBy =
+  unur $ linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <-
+        borrowM (Growable.fromVector (V.fromList seeded) ownerLinear)
+      ((), vector) <-
+        reborrowing vector \short -> Control.do
+          short <- Growable.push 100 short
+          short <- Growable.modify 1 (addLinear bumpBy) short
+          Control.pure (consume short)
+      (Ur seen, vector) <- Growable.copyAtMut 1 vector
+      vector `lseq` pureAfter (consume (reclaim lend) `lseq` Ur seen)
+
+{- | A write through the restored borrow, at an index only the post-scope length admits.
+
+This is the shape that corrupted the heap downstream.
+'Growable.modify' is bounds-checked, so on the broken build it raises rather than scribbling past the allocation; the unchecked 'Growable.unsafeSet' at the same index is what the downstream solver was doing.
+-}
+writeAcrossReborrowing :: Int -> [Int]
+{-# NOINLINE writeAcrossReborrowing #-}
+writeAcrossReborrowing count =
+  unur $ linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <-
+        borrowM (Growable.fromVector (V.fromList seeded) ownerLinear)
+      -- The read before the scope is what the bounds check inside 'Growable.modify'
+      -- gets merged with; without it there is nothing for the stale read to be
+      -- served from, and this kernel passes even on the broken delimiter.
+      Growable.size vector & \(Ur before, vector) -> Control.do
+        vector <-
+          reborrowing_ vector \short ->
+            consume Data.<$> pushRange 0 count short
+        vector <- Growable.modify (before + count - 1) (addLinear 1) vector
+        vector `lseq` pureAfter do
+          Growable.toVector (reclaim lend) & \(Ur contents) ->
+            Ur (V.toList contents)
+
+{- | The same shape on a plain 'Ref.Ref', whose reads bypass the state token in exactly the same way.
+
+'RefBorrow.copyRef' bottoms out in 'Data.Ref.Linear.unsafeReadRef', so this is the smallest instrument that exhibits the defect at all — no vector involved.
+The reads go through their own 'reborrowing' because 'RefBorrow.copyRef' consumes the borrow it reads.
+-}
+valueAcrossReborrowingRef :: Int -> (Int, Int)
+{-# NOINLINE valueAcrossReborrowingRef #-}
+valueAcrossReborrowingRef start =
+  linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (ref, lend) <- borrowM (Ref.new start ownerLinear)
+      (before, ref) <- reborrowing ref RefBorrow.copyRef
+      ((), ref) <-
+        reborrowing ref \short ->
+          consume Data.<$> RefBorrow.modify (addLinear 1) short
+      (after, ref) <- reborrowing ref RefBorrow.copyRef
+      ref `lseq` pureAfter (consume (Ref.free (reclaim lend)) `lseq` (before, after))
+
+{- | The same shape on the Robin Hood table, which replaces its backing array on growth.
+
+A stale read here is a stale /array/, not a stale count, so the lookup afterwards is the interesting assertion: on the broken delimiter it reports the key as absent after eight successful inserts.
+-}
+entriesAcrossReborrowingHashMap :: Int -> (Int, Int, Maybe Int)
+{-# NOINLINE entriesAcrossReborrowingHashMap #-}
+entriesAcrossReborrowingHashMap count =
+  unur $ linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (table, lend) <- borrowM (HashMap.empty @Int @Int 0 ownerLinear)
+      (Ur before, table) <- HashMap.size table
+      table <-
+        reborrowing_ table \short ->
+          consume Data.<$> insertRange 0 count short
+      (Ur after, table) <- HashMap.size table
+      (Ur found, table) <- HashMap.lookup 0 table
+      table `lseq` pureAfter (consume (reclaim lend) `lseq` Ur (before, after, found))
+
+{- | The plural delimiter, which restores a whole 'Borrows.Muts' bundle.
+
+Like the 'Growable.withContent' kernel this one passes on the broken build, because 'Borrows.reborrowings'' restores through 'reclaim'' inside an @After@ and so picks up 'withEnd'\'s @nospec@ barrier by accident.
+It is here as a guard on that accident: erasing that delimiter the way 'reborrowing'' was erased would remove it, and this kernel is what would then go red.
+-}
+lengthAcrossPluralReborrowing :: Int -> (Int, Int, [Int])
+{-# NOINLINE lengthAcrossPluralReborrowing #-}
+lengthAcrossPluralReborrowing count =
+  unur $ linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <-
+        borrowM (Growable.fromVector (V.fromList seeded) ownerLinear)
+      Growable.size vector & \(Ur before, vector) -> Control.do
+        bundle <-
+          Borrows.reborrowings_
+            (vector Borrows.:- Borrows.BNil)
+            \(short Borrows.:- Borrows.BNil) ->
+              consume Data.<$> pushRange 0 count short
+        case bundle of
+          vector Borrows.:- Borrows.BNil ->
+            Growable.size vector & \(Ur after, vector) ->
+              vector `lseq` pureAfter (report before after (reclaim lend))
+
+insertRange ::
+  Int ->
+  Int ->
+  Mut α (HashMap.HashMap Int Int) %1 ->
+  BO α (Mut α (HashMap.HashMap Int Int))
+{-# INLINE insertRange #-}
+insertRange index count table
+  | index >= count = Control.pure table
+  | otherwise = Control.do
+      (Ur _, table) <- HashMap.insert index (100 + index) table
+      insertRange (index + 1) count table
+
+report ::
+  Int ->
+  Int ->
+  Growable.GrowableVector Int %1 ->
+  Ur (Int, Int, [Int])
+{-# INLINE report #-}
+report before after vector =
+  Growable.toVector vector & \(Ur contents) ->
+    Ur (before, after, V.toList contents)
+
+reportUnboxed ::
+  Int ->
+  Int ->
+  Unboxed.GrowableVector Int %1 ->
+  Ur (Int, Int, [Int])
+{-# INLINE reportUnboxed #-}
+reportUnboxed before after vector =
+  Unboxed.toVector vector & \(Ur contents) ->
+    Ur (before, after, U.toList contents)
+
+{- | Regression coverage for the erased borrow scopes.
+
+See Note [Observing a borrow scope's writes through the borrow it restores].
+-}
+test_scopeRestoresAUsableBorrow :: TestTree
+test_scopeRestoresAUsableBorrow =
+  testGroup
+    "a borrow scope's writes are visible through the borrow it restores"
+    [ testGroup "reborrowing" (cases lengthAcrossReborrowing)
+    , testGroup "reborrowing'" (cases lengthAcrossReborrowingAfter)
+    , testGroup "reborrowing_" (cases lengthAcrossReborrowingDiscarding)
+    , testGroup "reborrowing, unboxed" (cases lengthAcrossReborrowingUnboxed)
+    , testGroup "withContent" (cases lengthAcrossContentScope)
+    , testCase "reborrowing in a loop" do
+        lengthsAcrossReborrowingLoop 8
+          @?= (NonLinear.map (4 +) (NonLinear.enumFromTo 0 7), seeded <> appended 8)
+    , testGroup
+        "an element read back through the restored borrow"
+        [ testCase (show bumpBy <> " added") do
+            elementAcrossReborrowing bumpBy @?= 20 + bumpBy
+        | bumpBy <- [1, 5, 41]
+        ]
+    , testGroup
+        "a write through the restored borrow lands in the grown buffer"
+        [ testCase (show count <> " appended") do
+            writeAcrossReborrowing count
+              @?= seeded <> NonLinear.init (appended count) <> [100 + count]
+        | count <- [1, 2, 5, 17]
+        ]
+    , testGroup
+        "Ref"
+        [ testCase (show start) do
+            valueAcrossReborrowingRef start @?= (start, start + 1)
+        | start <- [0, 1, 41]
+        ]
+    , testGroup "reborrowings (plural)" (cases lengthAcrossPluralReborrowing)
+    , testGroup
+        "RobinHood HashMap"
+        [ testCase (show count <> " inserted") do
+            entriesAcrossReborrowingHashMap count @?= (0, count, Just 100)
+        | count <- [1, 8, 33]
+        ]
+    ]
+  where
+    cases :: (Int -> (Int, Int, [Int])) -> [TestTree]
+    cases kernel =
+      [ testCase (show count <> " appended") (kernel count @?= grown count)
+      | count <- counts
+      ]
+    counts :: [Int]
+    counts = [1, 2, 3, 5, 17, 33, 1025]


### PR DESCRIPTION
Fixes the heap corruption reported downstream (the herbrand CDCL solver) against `c35dace` ("perf: erase the sublifetime in the four borrow scopes", #36), while keeping that commit's win.

## What was wrong

The erased delimiters handed the caller back **the very Core variable they were given**:

```haskell
unsafeBorrowScope = Unsafe.toLinear2 \mut k ->
  unsafeSrunBO_ $ k (unsafeCastAlias mut) Control.<&> \r -> (r, mut)
```

Not every read of a borrowed resource is threaded through the `BO` state token.
A growable vector keeps its length and backing buffer behind a `Ref`, and `size`, `capacity`, `getContents` and `unsafeGet` read it through `unsafeReadRef#`, which opens its own `runRW#` and is therefore a plain function of the borrow as far as GHC is concerned.
What kept that honest is that every operation replacing the header writes through the `NOINLINE` `unsafeWriteRef#` and hands back the reference *that write* returned, so a read after a growth scrutinises a different expression than a read before it.

Returning the caller's own occurrence threw that data dependency away, and CSE did the rest: a post-scope read became syntactically the pre-scope read, and the later one was deleted — serving a stale length and a stale buffer across every growth the scope performed.

### Core evidence

A probe that reads `size`, pushes three elements inside `reborrowing`, and reads `size` again, at `-O2` on ghc-9.12.4:

| build | `unsafeReadRef#` in `$wsizeGrowSize` | returns |
| --- | --- | --- |
| `main` | **3** | `(# …, bx1, bx1, wild #)` — post-scope read deleted, `after == before` |
| same body, no `reborrowing` | 4 | `(# …, bx1, bx10, … #)` — correct |
| `--flags=+slow` | 4 | correct |

`+slow` was correct **by accident**: its restored borrow comes out of `reclaim'` inside an `After`, extracted by `withEnd`, whose `withDict` desugars through the wired-in `nospec` and survives every Core-to-Core pass.
That also explains why #35 (erasing `srunBO`/`srunBO_`) was innocent — neither takes a borrow and gives it back.

### End-to-end

herbrand `cdcl-dry -i data/tests/sudoku-9x9.cnf`, built against this checkout:

| pure-borrow | result |
| --- | --- |
| `main` | `freeGroup: block size is zero` / SIGSEGV, 3/3 |
| `main --flags=+slow` | `Satisfiable ()`, 3/3 |
| **this branch** | `Satisfiable ()`, 5/5 |

## The fix

A trusted primitive in `BO.Internal`, exported from `BO.Unsafe`:

```haskell
reviveAlias :: Alias ak a %1 -> BO α (Alias ak a)
{-# OPAQUE reviveAlias #-}
reviveAlias a = BO \s -> (# s, a #)
```

Both properties are load-bearing, and `Note [Restoring a borrow must break its Core identity]` says why:

* **`OPAQUE`, not `NOINLINE`** — a `NOINLINE` version is an equally good barrier today, but only because that one demand signature comes out lazy so no worker/wrapper split occurs. `OPAQUE` is the pragma GHC documents as suppressing inlining, W/W, specialisation and rules together.
* **In `BO`, not pure** — a pure barrier depends on nothing the scope produced, so neither it nor the reads consuming it would be stopped from floating above the scope body. Consuming the token pins the restoration after the scope's effects.

Applied to every delimiter that hands a borrow back: `unsafeBorrowScope`, `unsafeBorrowScope_`, `unsafeBorrowScope'`, `Reborrowable (Share α)`, `withContent`/`withContent_` ×3, and — via a plural `reviveAliases` — `reborrowings'`.

## What is kept

No lifetime token, no `Linearly`, no lender, no `After` plumbing. What remains is one out-of-line call per scope exit that returns its argument: ~0.7 ns on aarch64-darwin, plus the loop-carried borrow no longer being unboxable past it — together 14–20% of a tight L1-resident loop that does *nothing but* the scope.

**No benchmark this repository ships resolves that.** `copy-at` before/after has byte-identical allocation and a timing difference inside machine noise (the pure-`vector` control itself moved 15% between runs), and its `pure-borrow/direct-copy` arm does not reach a scope at all in a default build. `qsort-bench` takes one `reborrowing'` per `divideAndConquer'` *call* rather than per node, and the FFT recursion amortises one exit over O(log n) butterfly work — a null result from either would be evidence of nothing.

## Tests

`Control.Monad.Borrow.Pure.BOSpec` gains read-grow-read kernels over the growable vector (boxed and unboxed), a plain `Ref`, and the Robin Hood table; plus one that reads an element back *through the restored borrow*, one that writes through it at an index only the fresh length admits, and a loop variant. **42 of 59 fail with `src/` reverted.**

Three groups pass either way and are labelled as forward-looking guards, not regression coverage — `sharing*` (callback gets a `Share`, and nothing writes a header through one), `withContent` (callback gets a bare slice with no header), and `reborrowings'` (the `nospec` accident above). All are fixed anyway: the obligation belongs to the delimiter, not to the set of writes reachable today.

The four Core equalities from c35dace asserted the delimiters were Core-identical to their delimiter-free bodies — the wrong specification, since compiling to nothing at all is what made them unsound. They now compare against the body **plus the one `reviveAlias`**, so they still fail under `+slow` and now pin the barrier's presence. That matters: the runtime regressions observe a wrong *answer*, so on a compiler that stopped performing this merge they would go vacuously green rather than red.

## Recorded, not fixed

* The barrier is one-directional: it stops a post-scope read being served from a pre-scope one, but nothing stops a pre-scope read sinking below the scope.
* `Control.Concurrent.DivideConquer.Linear` duplicates its `Mut` binder across threads at `ini`/`ini'` — same shape, unreachable for every shipped kernel, since `qsortDC`/`fftDC` use fixed vectors whose `size` is a pure projection of an immutable field rather than a `readMutVar#`.
* Threading the header reads through the state token would remove the hazard entirely. That is the durable fix; it is an API break and is not attempted here.

Also codifies in `AGENTS.md` that a `Note [...]` block is a dev note belonging in a plain block comment rather than in Haddock, and moves the one pre-existing violation.

## Verification

`cabal build all`, 368 tasty tests, 35 Core obligations and the doctests, green at `-O2` with default flags **and** with `--flags=+slow`. `fourmolu --mode check` and `cabal check` clean.

Reviewed adversarially at both the plan and implementation stages by subagents that did not write the change, on four lenses each (soundness, linear-ownership, performance, and concurrency/test-adequacy). Their findings are what added the `Reborrowable`/`reborrowings'` delimiters, corrected two measured claims in the Note, and produced the element-read, write-through and `Ref`/`HashMap` kernels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
