### PR TITLE
perf: erase the sublifetime in the plural and generic borrow scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,8 @@
 
 - Delimiting a sublifetime got much cheaper in `srunBO`/`srunBO_`, `sharing`/`sharing'`/`sharing_`, `reborrowing`/`reborrowing'`/`reborrowing_` and `reborrowings`/`reborrowings'`/`reborrowings_`.
   The `slow` flag restores the old, safe-but-slow implementation.
-  Measured on a scope-dominated microbenchmark, the plural scopes went from 40 bytes and 4.5 ns per crossing to 0 bytes and 1.2 ns.
+  Measured on a scope-dominated microbenchmark, the plural scopes went from 40 bytes and 4.5 ns per crossing to 0 bytes and 1.2–1.6 ns.
+  The FFT example picks this up through `iterReborrowing_`, which crosses a plural scope per iteration of its setup phase: −4.8% allocation and −5.6% wall at 2^20 points.
 - `BO` and `After` methods are directly inlinable, and the divide-and-conquer scheduler uses a Chase-Lev deque with half-stealing and weighted victim selection.
   The qsort and FFT examples are written over the unrestricted vectors and specialize to primitive unboxed array operations.
 - A `pure-borrow-inspection` suite pins the optimized Core of the scopes and of the qsort/FFT roots, inverting each obligation under `slow`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,8 +57,9 @@
 
 ### Performance
 
-- Delimiting a sublifetime got much cheaper in `srunBO`/`srunBO_`, `sharing`/`sharing'`/`sharing_` and `reborrowing`/`reborrowing'`/`reborrowing_`.
+- Delimiting a sublifetime got much cheaper in `srunBO`/`srunBO_`, `sharing`/`sharing'`/`sharing_`, `reborrowing`/`reborrowing'`/`reborrowing_` and `reborrowings`/`reborrowings'`/`reborrowings_`.
   The `slow` flag restores the old, safe-but-slow implementation.
+  Measured on a scope-dominated microbenchmark, the plural scopes went from 40 bytes and 4.5 ns per crossing to 0 bytes and 1.2 ns.
 - `BO` and `After` methods are directly inlinable, and the divide-and-conquer scheduler uses a Chase-Lev deque with half-stealing and weighted victim selection.
   The qsort and FFT examples are written over the unrestricted vectors and specialize to primitive unboxed array operations.
 - A `pure-borrow-inspection` suite pins the optimized Core of the scopes and of the qsort/FFT roots, inverting each obligation under `slow`.

--- a/bench/suite/PureBorrow/Bench/ScopeDensity.hs
+++ b/bench/suite/PureBorrow/Bench/ScopeDensity.hs
@@ -302,13 +302,23 @@ scopeFreePairLoop iterations = withCounterPair (go iterations)
           rightMut <- RefBorrow.modify (+ 1) rightMut
           go (i - 1) leftMut rightMut leftLend rightLend
 
-{- | The bundled control: the same two mutations, threaded through a 'Muts', no scope.
+{- | A bundle threaded and rebuilt each iteration, crossing no scope.
 
-'scopeFreePairLoop' threads two separate borrows, so comparing it directly with
-a plural arm would charge the delimiter for the bundle as well. This arm
-destructures and rebuilds the bundle each iteration and crosses no scope, so
-the spine cost and the delimiter cost come apart:
-@spine = bundled − direct@, @delimiter = reborrowings_ − direct@.
+This was written to separate the spine cost from the delimiter cost, and it
+does not do that — the arithmetic does not work, and saying so is cheaper than
+letting a reader rederive it. It allocates about 80 bytes per iteration over
+'scopeFreePairLoop' where the delimiter arms allocate 40 before erasure and 0
+after, because its rebuilt spine is loop-carried and genuinely allocated, while
+a delimiter hands back the bundle it was given and never rebuilds one. It is
+not a point between 'scopeFreePairLoop' and the delimiter arms, so
+@delimiter = reborrowings_ − bundled@ would come out negative.
+
+What it does measure is a caller-side cost: what threading and rebuilding a
+bundle per iteration costs someone who writes that. Keep it for that, and
+compare the delimiter arms against 'scopeFreePairLoop' only. That comparison
+charges the delimiter for the bundle destructure as well, so it is an upper
+bound on the delimiter's own cost rather than an estimate — which is the
+conservative direction.
 -}
 bundleThreadedPairLoop :: Int -> Int
 {-# NOINLINE bundleThreadedPairLoop #-}
@@ -337,8 +347,8 @@ bundleThreadedPairLoop iterations =
 
 The continuation consumes its two members individually rather than rebuilding a
 bundle to consume, so this arm measures the delimiter and not the caller's
-@(':-')@ cells. 'reborrowingsRespineLoop' is the same arm with the rebuild put
-back, and the difference between the two is the respine.
+@(':-')@ cells. Compare it against 'scopeFreePairLoop'; see
+'bundleThreadedPairLoop' for why the bundled arm is not the comparator.
 -}
 reborrowingsDiscardingLoop :: Int -> Int
 {-# NOINLINE reborrowingsDiscardingLoop #-}
@@ -365,7 +375,16 @@ reborrowingsDiscardingLoop iterations =
               Control.pure (consume leftScoped `lseq` consume rightScoped)
           go (i - 1) bundle leftLend rightLend
 
--- | 'reborrowingsDiscardingLoop' with the shortened bundle rebuilt before it is consumed.
+{- | 'reborrowingsDiscardingLoop' with the shortened bundle rebuilt before it is consumed.
+
+Measured, this arm is byte-identical to 'reborrowingsDiscardingLoop' in every
+configuration: building a bundle only to consume it is case-of-known-constructor
+and GHC removes it entirely. So it does not measure "the rebuild put back" —
+there is nothing to put back. It is retained as a regression on that
+elimination, since a caller who pattern-matches and rebuilds is the shape most
+plural call sites actually have, and it would be worth knowing if it ever
+started costing something.
+-}
 reborrowingsRespineLoop :: Int -> Int
 {-# NOINLINE reborrowingsRespineLoop #-}
 reborrowingsRespineLoop iterations =

--- a/pure-borrow.cabal
+++ b/pure-borrow.cabal
@@ -36,12 +36,14 @@ flag examples
 flag slow
   description:
     Restore the previous, sublifetime-allocating implementations of the
-    borrow scopes (`sharing`, `sharing'`, `sharing_`, `reborrowing`,
-    `reborrowing'`, `reborrowing_`), of `srunBO`/`srunBO_` and of
-    `copyAtMut`. These open a real sublifetime with a runtime token and a
-    lender, which the default implementations statically erase. Enable to
-    A/B the two against each other, or to check whether a suspected
-    miscompilation or unsoundness is attributable to the erased scopes.
+    scalar borrow scopes (`sharing`, `sharing'`, `sharing_`, `reborrowing`,
+    `reborrowing'`, `reborrowing_`), of their plural counterparts
+    (`reborrowings`, `reborrowings'`, `reborrowings_`), of `srunBO`/`srunBO_`
+    and of `copyAtMut`. These build the sublifetime at runtime, with a token
+    and a lender, where the default implementations delimit exactly the same
+    sublifetime statically. Enable to A/B the two against each other, or to
+    check whether a suspected miscompilation or unsoundness is attributable
+    to the erased scopes.
 
   default: False
   manual: True

--- a/src/Control/Monad/Borrow/Pure/Experimental/Borrows.hs
+++ b/src/Control/Monad/Borrow/Pure/Experimental/Borrows.hs
@@ -137,16 +137,29 @@ reviveAliases :: Aliases k xs %1 -> BO α (Aliases k xs)
 reviveAliases as = Control.pure as
 
 {- |
-Retag a bundle's alias kind, leaving its spine, order and payloads untouched.
+Retag a bundle's lifetime, leaving its borrow kind, spine, order and payloads
+untouched.
 
 The plural counterpart of 'Control.Monad.Borrow.Pure.BO.Unsafe.unsafeCastAlias',
 and unlike it this cannot be a @coerceLin@: 'Aliases' is a GADT rather than a
-newtype over its payload, so no 'Data.Coerce.Coercible' relates two alias kinds.
-The caller owes the same obligation either way — the retagged bundle must be a
-lifetime narrowing that the type system would have permitted, and it must not
-escape the scope that narrowed it.
+newtype over its payload, so no 'Data.Coerce.Coercible' relates two alias kinds
+and the coercion has to be a raw one.
+
+Why that raw coercion is representationally sound: @k@ occurs in 'Aliases' only
+inside the @!('Alias' k x)@ field of @(':-')@, and 'Alias' is a newtype over
+@x@, so the alias kind has no runtime witness anywhere in the structure and two
+kinds give the same layout. That is precisely the argument @type role Aliases
+nominal nominal@ declines to make on the caller's behalf, and this function
+punches through it, so the argument has to be made here instead.
+
+The caller's obligation is the narrower one the signature now enforces in part:
+the retagged bundle must be a lifetime narrowing the type system would have
+permitted, and it must not escape the scope that narrowed it. Keeping the
+borrow kind fixed in the type is deliberate — every use in this module narrows
+a lifetime and nothing more, and a future edit that retagged a 'Lends' bundle
+as a 'Muts' one should be a type error rather than a silence.
 -}
-unsafeCastAliases :: Aliases k xs %1 -> Aliases k' xs
+unsafeCastAliases :: Borrows bk α xs %1 -> Borrows bk β xs
 {-# INLINE unsafeCastAliases #-}
 unsafeCastAliases = Unsafe.toLinear unsafeCoerce
 

--- a/src/Control/Monad/Borrow/Pure/Experimental/Borrows.hs
+++ b/src/Control/Monad/Borrow/Pure/Experimental/Borrows.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DefaultSignatures #-}
 {-# LANGUAGE DeriveAnyClass #-}
@@ -32,6 +33,7 @@ module Control.Monad.Borrow.Pure.Experimental.Borrows (
   reborrowings',
   reborrowings,
   reborrowings_,
+  reviveAliases,
 ) where
 
 import Control.Functor.Linear qualified as Control
@@ -41,12 +43,16 @@ import Control.Monad.Borrow.Pure.Affine.Unsafe (unsafeAff)
 import Control.Monad.Borrow.Pure.BO
 import Control.Monad.Borrow.Pure.BO.Internal
 import Control.Monad.Borrow.Pure.Experimental.Reborrowable
-import Control.Syntax.DataFlow qualified as DataFlow
+import Control.Monad.Borrow.Pure.Lifetime.Token.Unsafe qualified as Unsafe.Token
 import Data.Coerce.Directed.Unsafe
 import Data.Kind
 import Prelude.Linear hiding (foldMap)
 import Unsafe.Coerce (unsafeCoerce)
 import Unsafe.Linear qualified as Unsafe
+
+#ifdef PURE_BORROW_SLOW_SCOPES
+import Control.Syntax.DataFlow qualified as DataFlow
+#endif
 
 type Aliases :: AliasKind -> [Type] -> Type
 data Aliases k xs where
@@ -106,6 +112,10 @@ instance Reborrowable (Muts α) where
   type WithLifetime (Muts α) β = Muts β
   locally' = reborrowings'
   {-# INLINE locally' #-}
+  locally = reborrowings
+  {-# INLINE locally #-}
+  locally_ = reborrowings_
+  {-# INLINE locally_ #-}
 
 -- | A plural form of 'reborrow', which reborrows multiple borrows in the given 'Muts' at once.
 reborrows :: forall β α a. (α >= β) => Muts α a %1 -> (Muts β a, Lend β (Muts α a))
@@ -118,10 +128,105 @@ See Note [Restoring a borrow must break its Core identity] in "Control.Monad.Bor
 
 'reborrowings'' would otherwise restore the caller's own occurrence, since 'reborrows' hands the same value out as both borrow and lender and 'reclaim' is a newtype unwrap.
 It happens not to misbehave today, because 'reclaim'' is reached through 'withEnd', whose @withDict@ desugars through the wired-in @nospec@ and survives every Core-to-Core pass — but that is a coincidence of one desugaring, and it is exactly the kind of accident the Note argues a delimiter must not rest on.
+
+This is exported so that the Core obligations in @pure-borrow-inspection@ can state what the erased plural delimiters must compile to, barrier included.
+Exporting it weakens nothing: it is 'Control.Functor.Linear.pure' behind an @OPAQUE@, so the worst a caller can do with it is add a barrier that was not needed.
 -}
 reviveAliases :: Aliases k xs %1 -> BO α (Aliases k xs)
 {-# OPAQUE reviveAliases #-}
 reviveAliases as = Control.pure as
+
+{- |
+Retag a bundle's alias kind, leaving its spine, order and payloads untouched.
+
+The plural counterpart of 'Control.Monad.Borrow.Pure.BO.Unsafe.unsafeCastAlias',
+and unlike it this cannot be a @coerceLin@: 'Aliases' is a GADT rather than a
+newtype over its payload, so no 'Data.Coerce.Coercible' relates two alias kinds.
+The caller owes the same obligation either way — the retagged bundle must be a
+lifetime narrowing that the type system would have permitted, and it must not
+escape the scope that narrowed it.
+-}
+unsafeCastAliases :: Aliases k xs %1 -> Aliases k' xs
+{-# INLINE unsafeCastAliases #-}
+unsafeCastAliases = Unsafe.toLinear unsafeCoerce
+
+{-
+Note [The plural delimiters are separate functions]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+These three mirror `unsafeBorrowScope`, `unsafeBorrowScope_` and
+`unsafeBorrowScope'` line for line, and discharge exactly the obligations
+documented there; only the retagging and the restoration barrier differ, because
+`Muts α xs` is `Aliases ('Borrow 'Mut α) xs` rather than an `Alias`.
+
+They are not written as one delimiter shared with the scalar case.
+A shared one would have to abstract over the type constructor and over the
+lifetime retagging, which is what `Reborrowable`'s `WithLifetime` does -- and
+instantiating an unsafe coercion at that class would make it available to
+third-party instances that need not use this representation at all.
+That is the coercion the design forbids, so per-representation delimiters plus
+instance-supplied methods is the shape, and the duplication is the price.
+
+They are deliberately not exported.
+A trusted delimiter belongs behind the combinators that discharge its
+obligations, and `Experimental.Borrows` is a documented module rather than an
+`.Internal` one.
+-}
+
+{- |
+The plural non-finalizing delimiter, restoring the bundle on normal return.
+
+See Note [The plural delimiters are separate functions] and the obligations on
+'Control.Monad.Borrow.Pure.BO.Unsafe.unsafeBorrowScope'.
+-}
+unsafeBorrowsScope ::
+  forall α α' xs r.
+  Muts α xs %1 ->
+  (forall β. Muts (β /\ α) xs %1 -> BO (β /\ α') r) %1 ->
+  BO α' (r, Muts α xs)
+{-# INLINE unsafeBorrowsScope #-}
+unsafeBorrowsScope = Unsafe.toLinear2 \muts k ->
+  unsafeSrunBO_ Control.do
+    r <- k (unsafeCastAliases muts)
+    (r,) Control.<$> reviveAliases muts
+
+{- |
+The plural result-discarding delimiter.
+
+The result is consumed in the returned value rather than at scope exit, so this
+stays observationally equivalent to the implementation @+slow@ restores.
+-}
+unsafeBorrowsScope_ ::
+  forall α α' xs r.
+  (Consumable r) =>
+  Muts α xs %1 ->
+  (forall β. Muts (β /\ α) xs %1 -> BO (β /\ α') r) %1 ->
+  BO α' (Muts α xs)
+{-# INLINE unsafeBorrowsScope_ #-}
+unsafeBorrowsScope_ = Unsafe.toLinear2 \muts k ->
+  unsafeSrunBO_ Control.do
+    r <- k (unsafeCastAliases muts)
+    restored <- reviveAliases muts
+    Control.pure (consume r `lseq` restored)
+
+{- |
+The plural finalizing delimiter, whose continuation returns its result 'After'
+the sublifetime.
+
+The 'EndToken' is the runtime-erased one, sound for the reason given on
+'Control.Monad.Borrow.Pure.BO.Unsafe.unsafeBorrowScope'': the continuation has
+returned by the time it is applied, so the sublifetime it was typechecked in is
+over, and the caller-fixed result type cannot mention it.
+-}
+unsafeBorrowsScope' ::
+  forall α α' xs r.
+  Muts α xs %1 ->
+  (forall β. Muts (β /\ α) xs %1 -> BO (β /\ α') (After β r)) %1 ->
+  BO α' (r, Muts α xs)
+{-# INLINE unsafeBorrowsScope' #-}
+unsafeBorrowsScope' = Unsafe.toLinear2 \muts k ->
+  unsafeSrunBO_ Control.do
+    after <- k (unsafeCastAliases muts)
+    (withEnd Unsafe.Token.UnsafeEnd after,) Control.<$> reviveAliases muts
 
 -- | A plural form of 'reborrowing''.
 reborrowings' ::
@@ -129,6 +234,7 @@ reborrowings' ::
   (forall β. Muts (β /\ α) a %1 -> BO (β /\ α') (After β r)) %1 ->
   BO α' (r, Muts α a)
 {-# INLINE reborrowings' #-}
+#ifdef PURE_BORROW_SLOW_SCOPES
 reborrowings' v k = Control.do
   (r, restored) <- srunBO DataFlow.do
     (v, lend) <- reborrows v
@@ -136,18 +242,31 @@ reborrowings' v k = Control.do
       v <- k v
       Control.pure $ (,) Control.<$> v Control.<*> upcast (reclaim' lend)
   (r,) Control.<$> reviveAliases restored
+#else
+reborrowings' = unsafeBorrowsScope'
+#endif
 
+-- | A plural form of 'reborrowing'.
 reborrowings ::
   Muts α a %1 ->
   (forall β. Muts (β /\ α) a %1 -> BO (β /\ α') r) %1 ->
   BO α' (r, Muts α a)
 {-# INLINE reborrowings #-}
+#ifdef PURE_BORROW_SLOW_SCOPES
 reborrowings mutα k = reborrowings' mutα (\mut -> Control.pure Control.<$> k mut)
+#else
+reborrowings = unsafeBorrowsScope
+#endif
 
+-- | A plural form of 'reborrowing_'.
 reborrowings_ ::
   (Consumable r) =>
   Muts α a %1 ->
   (forall β. Muts (β /\ α) a %1 -> BO (β /\ α') r) %1 ->
   BO α' (Muts α a)
 {-# INLINE reborrowings_ #-}
+#ifdef PURE_BORROW_SLOW_SCOPES
 reborrowings_ mutα k = reborrowings mutα (Control.fmap consume . k) Control.<&> \((), a) -> a
+#else
+reborrowings_ = unsafeBorrowsScope_
+#endif

--- a/src/Control/Monad/Borrow/Pure/Experimental/Reborrowable.hs
+++ b/src/Control/Monad/Borrow/Pure/Experimental/Reborrowable.hs
@@ -22,6 +22,32 @@ import Control.Monad.Borrow.Pure.BO.Unsafe (reviveAlias)
 import Data.Kind (Constraint, Type)
 import Prelude.Linear
 
+{- |
+Borrow-like values that can be narrowed to a sublifetime and restored afterwards.
+
+=== The obligation every method carries
+
+An implementation of 'locally'', 'locally' or 'locally_' must not hand the
+caller back the occurrence it was given. It must return it through a barrier
+the optimizer cannot see through and that consumes the 'BO' state token —
+'Control.Monad.Borrow.Pure.BO.Unsafe.reviveAlias' for a scalar borrow,
+'Control.Monad.Borrow.Pure.Experimental.Borrows.reviveAliases' for a bundle.
+
+This is not a performance convention. Reads that project a mutable header do
+not go through the state token, so to GHC two of them on the same borrow
+/variable/ are the same expression, and common-subexpression elimination is
+entitled to serve the second from the first — across every write the scope
+performed. A delimiter that returns its caller's own binder makes a post-scope
+read syntactically identical to a pre-scope one; the result is a stale length
+and a stale buffer, and writing through them runs off the end of the
+allocation. See @Note [Restoring a borrow must break its Core identity]@ in
+"Control.Monad.Borrow.Pure.BO.Internal" for the full argument, and treat it as
+binding on any instance you write.
+
+Each method is separately overridable, so each one owes this independently:
+supplying a fast 'locally' while leaving 'locally'' to the default does not
+discharge it for 'locally'.
+-}
 type Reborrowable :: (k -> Type) -> Constraint
 class (bor ~ WithLifetime bor (LifetimeOf bor)) => Reborrowable bor where
   type LifetimeOf bor :: Lifetime
@@ -57,8 +83,12 @@ class (bor ~ WithLifetime bor (LifetimeOf bor)) => Reborrowable bor where
   {- |
   The result-discarding form.
 
-  The result is consumed strictly before the restored borrow is returned, so a
-  lazily consumed result cannot overlap access through it.
+  The consumption of the result sits /in/ the returned value rather than being
+  sequenced at scope exit, so it runs when the caller forces the restored
+  borrow. That is deliberate: sequencing it at exit would make this stricter
+  than the implementation @+slow@ restores, and the two are required to stay
+  observationally equivalent. Linearity gives the restored borrow exactly one
+  holder, so any use of it forces the consumption exactly once and first.
   -}
   locally_ ::
     (Consumable r) =>

--- a/src/Control/Monad/Borrow/Pure/Experimental/Reborrowable.hs
+++ b/src/Control/Monad/Borrow/Pure/Experimental/Reborrowable.hs
@@ -14,8 +14,6 @@
 
 module Control.Monad.Borrow.Pure.Experimental.Reborrowable (
   Reborrowable (..),
-  locally,
-  locally_,
 ) where
 
 import Control.Functor.Linear qualified as Control
@@ -40,12 +38,46 @@ class (bor ~ WithLifetime bor (LifetimeOf bor)) => Reborrowable bor where
     (forall β. WithLifetime bor (β /\ LifetimeOf bor) a %1 -> BO (β /\ α') (After β r)) %1 ->
     BO α' (r, bor a)
 
+  {- |
+  The non-finalizing form, whose continuation returns its result directly.
+
+  This is a method rather than a function over 'locally'' so that an instance
+  can supply a delimiter that never builds an 'After' at all. The default is
+  the composition it replaces, so an existing instance keeps working and keeps
+  its current cost; @'Mut'@, @'Share'@ and
+  @'Control.Monad.Borrow.Pure.Experimental.Borrows.Muts'@ override it.
+  -}
+  locally ::
+    bor a %1 ->
+    (forall β. WithLifetime bor (β /\ LifetimeOf bor) a %1 -> BO (β /\ α') r) %1 ->
+    BO α' (r, bor a)
+  locally bor k = locally' bor \bor -> Control.pure Control.<$> k bor
+  {-# INLINE locally #-}
+
+  {- |
+  The result-discarding form.
+
+  The result is consumed strictly before the restored borrow is returned, so a
+  lazily consumed result cannot overlap access through it.
+  -}
+  locally_ ::
+    (Consumable r) =>
+    bor a %1 ->
+    (forall β. WithLifetime bor (β /\ LifetimeOf bor) a %1 -> BO (β /\ α') r) %1 ->
+    BO α' (bor a)
+  locally_ bor k = uncurry lseq Control.<$> locally bor k
+  {-# INLINE locally_ #-}
+
 instance Reborrowable (Mut α) where
   type LifetimeOf (Mut α) = α
   type WithLifetime (Mut α) β = Mut β
   {-# SPECIALIZE instance Reborrowable (Mut α) #-}
   locally' = reborrowing'
   {-# INLINE locally' #-}
+  locally = reborrowing
+  {-# INLINE locally #-}
+  locally_ = reborrowing_
+  {-# INLINE locally_ #-}
 
 instance Reborrowable (Share α) where
   type LifetimeOf (Share α) = α
@@ -60,18 +92,10 @@ instance Reborrowable (Share α) where
     (r,) Control.<$> reviveAlias sh
   {-# INLINE locally' #-}
 
-locally ::
-  (Reborrowable bor) =>
-  bor a %1 ->
-  (forall β. WithLifetime bor (β /\ LifetimeOf bor) a %1 -> BO (β /\ α') r) %1 ->
-  BO α' (r, bor a)
-{-# INLINE locally #-}
-locally bor k = locally' bor \mut -> Control.pure Control.<$> k mut
-
-locally_ ::
-  (Reborrowable bor, Consumable r) =>
-  bor a %1 ->
-  (forall β. WithLifetime bor (β /\ LifetimeOf bor) a %1 -> BO (β /\ α') r) %1 ->
-  BO α' (bor a)
-{-# INLINE locally_ #-}
-locally_ bor k = uncurry lseq Control.<$> locally bor k
+  -- The same, through the non-finalizing 'srunBO_', so that a continuation
+  -- which returns its result directly never builds an 'After' to discharge.
+  locally shr k = Control.do
+    let %1 !(Ur sh) = move shr
+    r <- srunBO_ (k (upcast sh))
+    (r,) Control.<$> reviveAlias sh
+  {-# INLINE locally #-}

--- a/test-inspection/PureBorrow/Inspection/Sublifetime.hs
+++ b/test-inspection/PureBorrow/Inspection/Sublifetime.hs
@@ -41,11 +41,16 @@ module PureBorrow.Inspection.Sublifetime (
   sharingValueRefAt,
   copyRefAt,
   copyRefAfterAt,
+  locallyValueRefAt,
+  reborrowingsValueRefAt,
+  bumpBundleAt,
 ) where
 
 import Control.Functor.Linear qualified as Control
 import Control.Monad.Borrow.Pure.BO
 import Control.Monad.Borrow.Pure.BO.Unsafe (reviveAlias)
+import Control.Monad.Borrow.Pure.Experimental.Borrows (Aliases (..), Muts, reborrowings, reviveAliases)
+import Control.Monad.Borrow.Pure.Experimental.Reborrowable (locally)
 import Control.Monad.Borrow.Pure.Lifetime.Token.Unsafe (EndToken (..))
 import Data.Ref.Linear (Ref)
 import Data.Ref.Linear.Borrow qualified as Ref
@@ -153,6 +158,56 @@ bumpRefAfterAt = Unsafe.toLinear \ref -> Control.do
   spent `lseq` Control.do
     restored <- reviveAlias ref
     Control.pure (restored `lseq` withEnd (UnsafeEnd @α) (After old))
+
+{- | The generic path at 'Mut': 'locally' is what a caller reaches for when the borrow type is a parameter.
+
+Its specification is 'bumpRefAt' — the same one 'reborrowingValueRefAt' meets — so the equality says the generic path costs exactly what the scalar delimiter costs, rather than routing through the @'After'@-returning 'Control.Monad.Borrow.Pure.Experimental.Reborrowable.locally'' and paying a closure for a result it hands back directly.
+-}
+locallyValueRefAt :: Mut α (Ref Int) %1 -> BO α Int
+{-# NOINLINE locallyValueRefAt #-}
+locallyValueRefAt ref =
+  locally
+    ref
+    ( \borrowed -> Control.do
+        (old, spent) <- bumpRef borrowed
+        spent `lseq` Control.pure old
+    )
+    Control.<&> \(old, mut) -> mut `lseq` old
+
+-- | The plural body, shared by the probe and its specification exactly as 'bumpRef' is on the scalar side.
+bumpBundle ::
+  (α >= β) =>
+  Muts α '[Ref Int, Ref Int] %1 ->
+  BO β (Int, Muts α '[Ref Int, Ref Int])
+{-# INLINE bumpBundle #-}
+bumpBundle (left :- right :- BNil) = Control.do
+  (seenLeft, left) <- bumpRef left
+  (seenRight, right) <- bumpRef right
+  Control.pure (seenLeft + seenRight, left :- right :- BNil)
+
+-- | 'reborrowings' over a two-member bundle, with the restored bundle dropped as the scalar probes drop their borrow.
+reborrowingsValueRefAt :: Muts α '[Ref Int, Ref Int] %1 -> BO α Int
+{-# NOINLINE reborrowingsValueRefAt #-}
+reborrowingsValueRefAt bundle =
+  reborrowings
+    bundle
+    ( \borrowed -> Control.do
+        (old, spent) <- bumpBundle borrowed
+        spent `lseq` Control.pure old
+    )
+    Control.<&> \(old, muts) -> muts `lseq` old
+
+{- | The specification 'reborrowingsValueRefAt' must meet: the body on the caller's own bundle, plus the one 'reviveAliases' through which the delimiter restores it.
+
+The plural counterpart of 'bumpRefAt', and it carries the same warning: naming the barrier is what stops this equality from asserting that the delimiter compiles to nothing, which is the property that made the scalar erasure unsound before @ebba572@.
+-}
+bumpBundleAt :: Muts α '[Ref Int, Ref Int] %1 -> BO α Int
+{-# NOINLINE bumpBundleAt #-}
+bumpBundleAt = Unsafe.toLinear \bundle -> Control.do
+  (old, spent) <- bumpBundle bundle
+  spent `lseq` Control.do
+    restored <- reviveAliases bundle
+    Control.pure (restored `lseq` old)
 
 -- | The other 'srunBO' client, on the shared side, with the restored borrow dropped as above.
 sharingRefAt :: Mut α (Ref Int) %1 -> BO α Int
@@ -298,6 +353,34 @@ tests =
              ( ('sharingValueRefAt ==- 'copyRefAt)
                  { testName =
                      Just "sharing costs nothing over the read it delimits"
+                 }
+             )
+         )
+      , $( inspectTest
+             ( ('locallyValueRefAt ==- 'bumpRefAt)
+                 { testName =
+                     Just "locally at Mut costs what the scalar delimiter costs"
+                 }
+             )
+         )
+      , $( inspectTest
+             ( ('reborrowingsValueRefAt ==- 'bumpBundleAt)
+                 { testName =
+                     Just "reborrowings costs nothing over the updates it delimits"
+                 }
+             )
+         )
+      , $( inspectTest
+             ( (hasNoType 'reborrowingsValueRefAt ''Linearly)
+                 { testName =
+                     Just "reborrowings needs no linearity witness"
+                 }
+             )
+         )
+      , $( inspectTest
+             ( (doesNotUse 'reborrowingsValueRefAt 'askLinearly)
+                 { testName =
+                     Just "reborrowings does not reach for the ambient Linearly"
                  }
              )
          )

--- a/test/Control/Monad/Borrow/Pure/BOSpec.hs
+++ b/test/Control/Monad/Borrow/Pure/BOSpec.hs
@@ -17,6 +17,7 @@ import Control.Functor.Linear qualified as Control
 import Control.Monad.Borrow.Pure
 import Control.Monad.Borrow.Pure.BO qualified as BO
 import Control.Monad.Borrow.Pure.Experimental.Borrows qualified as Borrows
+import Control.Monad.Borrow.Pure.Experimental.Reborrowable qualified as Reborrowable
 import Control.Syntax.DataFlow qualified as DataFlow
 import Data.Functor.Linear qualified as Data
 import Data.HashMap.RobinHood.Mutable.Linear.Borrow qualified as HashMap
@@ -327,8 +328,9 @@ entriesAcrossReborrowingHashMap count =
 
 {- | The plural delimiter, which restores a whole 'Borrows.Muts' bundle.
 
-Like the 'Growable.withContent' kernel this one passes on the broken build, because 'Borrows.reborrowings'' restores through 'reclaim'' inside an @After@ and so picks up 'withEnd'\'s @nospec@ barrier by accident.
-It is here as a guard on that accident: erasing that delimiter the way 'reborrowing'' was erased would remove it, and this kernel is what would then go red.
+This kernel was written as a guard on an accident: before the plural scopes were erased, 'Borrows.reborrowings'' restored through 'reclaim'' inside an @After@ and so picked up 'withEnd'\'s @nospec@ barrier for free, and the comment here predicted that erasing the delimiter the way 'reborrowing'' was erased would remove it and turn this kernel red.
+That erasure has since happened, and the kernel is green because the plural delimiters restore through 'Borrows.reviveAliases' rather than because anything is left of the accident.
+It is now the runtime half of the plural obligation, paired with the Core equality in @pure-borrow-inspection@ that names the barrier.
 -}
 lengthAcrossPluralReborrowing :: Int -> (Int, Int, [Int])
 {-# NOINLINE lengthAcrossPluralReborrowing #-}
@@ -348,6 +350,25 @@ lengthAcrossPluralReborrowing count =
           vector Borrows.:- Borrows.BNil ->
             Growable.size vector & \(Ur after, vector) ->
               vector `lseq` pureAfter (report before after (reclaim lend))
+
+{- | The generic delimiter, reached through 'Reborrowable' rather than by naming 'reborrowing_'.
+
+@locally_@ at 'Mut' is now the erased scalar delimiter rather than a composition over the @After@-returning @locally'@, so it needs its own runtime coverage: a caller who writes generic code over the class must see the same ordering as one who names the combinator.
+-}
+lengthAcrossGenericLocally :: Int -> (Int, Int, [Int])
+{-# NOINLINE lengthAcrossGenericLocally #-}
+lengthAcrossGenericLocally count =
+  unur $ linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <-
+        borrowM (Growable.fromVector (V.fromList seeded) ownerLinear)
+      Growable.size vector & \(Ur before, vector) -> Control.do
+        vector <-
+          Reborrowable.locally_ vector \short ->
+            consume Data.<$> pushRange 0 count short
+        Growable.size vector & \(Ur after, vector) ->
+          vector `lseq` pureAfter (report before after (reclaim lend))
 
 insertRange ::
   Int ->
@@ -417,6 +438,7 @@ test_scopeRestoresAUsableBorrow =
         | start <- [0, 1, 41]
         ]
     , testGroup "reborrowings (plural)" (cases lengthAcrossPluralReborrowing)
+    , testGroup "locally_ (generic)" (cases lengthAcrossGenericLocally)
     , testGroup
         "RobinHood HashMap"
         [ testCase (show count <> " inserted") do

--- a/test/Control/Monad/Borrow/Pure/BOSpec.hs
+++ b/test/Control/Monad/Borrow/Pure/BOSpec.hs
@@ -351,6 +351,110 @@ lengthAcrossPluralReborrowing count =
             Growable.size vector & \(Ur after, vector) ->
               vector `lseq` pureAfter (report before after (reclaim lend))
 
+{- | The plural delimiter over a bundle whose members are grown /unequally/.
+
+'lengthAcrossPluralReborrowing' uses a one-member bundle, which cannot tell
+apart a barrier on the spine from a barrier on each member: with one member the
+two coincide. Here the first member is grown and the second is not, and both
+are read back through the borrows the delimiter restored, so a barrier that
+only broke the spine's identity would serve a stale length for the grown member.
+-}
+lengthsAcrossUnequalPluralReborrowing :: Int -> ((Int, Int), (Int, Int))
+{-# NOINLINE lengthsAcrossUnequalPluralReborrowing #-}
+lengthsAcrossUnequalPluralReborrowing count =
+  unur $ linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    (grownLinear, keptLinear) <- dup ownerLinear
+    runBO runLinear Control.do
+      (grown, grownLend) <-
+        borrowM (Growable.fromVector (V.fromList seeded) grownLinear)
+      (kept, keptLend) <-
+        borrowM (Growable.fromVector (V.fromList seeded) keptLinear)
+      Growable.size grown & \(Ur grownBefore, grown) ->
+        Growable.size kept & \(Ur keptBefore, kept) -> Control.do
+          bundle <-
+            Borrows.reborrowings_
+              (grown Borrows.:- kept Borrows.:- Borrows.BNil)
+              \(shortGrown Borrows.:- shortKept Borrows.:- Borrows.BNil) ->
+                shortKept `lseq` (consume Data.<$> pushRange 0 count shortGrown)
+          case bundle of
+            grown Borrows.:- kept Borrows.:- Borrows.BNil ->
+              Growable.size grown & \(Ur grownAfter, grown) ->
+                Growable.size kept & \(Ur keptAfter, kept) ->
+                  grown `lseq`
+                    kept `lseq`
+                      pureAfter
+                        ( consume (reclaim grownLend) `lseq`
+                            consume (reclaim keptLend) `lseq`
+                              Ur ((grownBefore, grownAfter), (keptBefore, keptAfter))
+                        )
+
+{- | The result-returning plural delimiter.
+
+Since the plural scopes were erased, @reborrowings@, @reborrowings'@ and
+@reborrowings_@ are three independent delimiters rather than one defined
+through another, so each needs its own kernel.
+-}
+lengthAcrossPluralReborrowingValue :: Int -> (Int, Int, [Int])
+{-# NOINLINE lengthAcrossPluralReborrowingValue #-}
+lengthAcrossPluralReborrowingValue count =
+  unur $ linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <-
+        borrowM (Growable.fromVector (V.fromList seeded) ownerLinear)
+      Growable.size vector & \(Ur before, vector) -> Control.do
+        ((), bundle) <-
+          Borrows.reborrowings
+            (vector Borrows.:- Borrows.BNil)
+            \(short Borrows.:- Borrows.BNil) ->
+              consume Data.<$> pushRange 0 count short
+        case bundle of
+          vector Borrows.:- Borrows.BNil ->
+            Growable.size vector & \(Ur after, vector) ->
+              vector `lseq` pureAfter (report before after (reclaim lend))
+
+-- | The finalizing plural delimiter, whose continuation returns its result @After@ the sublifetime.
+lengthAcrossPluralReborrowingAfter :: Int -> (Int, Int, [Int])
+{-# NOINLINE lengthAcrossPluralReborrowingAfter #-}
+lengthAcrossPluralReborrowingAfter count =
+  unur $ linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <-
+        borrowM (Growable.fromVector (V.fromList seeded) ownerLinear)
+      Growable.size vector & \(Ur before, vector) -> Control.do
+        ((), bundle) <-
+          Borrows.reborrowings'
+            (vector Borrows.:- Borrows.BNil)
+            \(short Borrows.:- Borrows.BNil) -> Control.do
+              short <- pushRange 0 count short
+              Control.pure (Control.pure (consume short))
+        case bundle of
+          vector Borrows.:- Borrows.BNil ->
+            Growable.size vector & \(Ur after, vector) ->
+              vector `lseq` pureAfter (report before after (reclaim lend))
+
+-- | The generic delimiter at @Muts@, which dispatches to the plural implementation.
+lengthAcrossGenericLocallyPlural :: Int -> (Int, Int, [Int])
+{-# NOINLINE lengthAcrossGenericLocallyPlural #-}
+lengthAcrossGenericLocallyPlural count =
+  unur $ linearly \linear -> DataFlow.do
+    (ownerLinear, runLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <-
+        borrowM (Growable.fromVector (V.fromList seeded) ownerLinear)
+      Growable.size vector & \(Ur before, vector) -> Control.do
+        bundle <-
+          Reborrowable.locally_
+            (vector Borrows.:- Borrows.BNil)
+            \(short Borrows.:- Borrows.BNil) ->
+              consume Data.<$> pushRange 0 count short
+        case bundle of
+          vector Borrows.:- Borrows.BNil ->
+            Growable.size vector & \(Ur after, vector) ->
+              vector `lseq` pureAfter (report before after (reclaim lend))
+
 {- | The generic delimiter, reached through 'Reborrowable' rather than by naming 'reborrowing_'.
 
 @locally_@ at 'Mut' is now the erased scalar delimiter rather than a composition over the @After@-returning @locally'@, so it needs its own runtime coverage: a caller who writes generic code over the class must see the same ordering as one who names the combinator.
@@ -437,8 +541,18 @@ test_scopeRestoresAUsableBorrow =
             valueAcrossReborrowingRef start @?= (start, start + 1)
         | start <- [0, 1, 41]
         ]
-    , testGroup "reborrowings (plural)" (cases lengthAcrossPluralReborrowing)
-    , testGroup "locally_ (generic)" (cases lengthAcrossGenericLocally)
+    , testGroup "reborrowings_ (plural)" (cases lengthAcrossPluralReborrowing)
+    , testGroup "reborrowings (plural)" (cases lengthAcrossPluralReborrowingValue)
+    , testGroup "reborrowings' (plural)" (cases lengthAcrossPluralReborrowingAfter)
+    , testGroup "locally_ (generic, Mut)" (cases lengthAcrossGenericLocally)
+    , testGroup "locally_ (generic, Muts)" (cases lengthAcrossGenericLocallyPlural)
+    , testGroup
+        "a two-member bundle where only one member grows"
+        [ testCase (show count <> " appended") do
+            lengthsAcrossUnequalPluralReborrowing count
+              @?= ((3, 3 + count), (3, 3))
+        | count <- counts
+        ]
     , testGroup
         "RobinHood HashMap"
         [ testCase (show count <> " inserted") do


### PR DESCRIPTION
`c35dace` erased the scalar scopes and left the plural ones alone.
`PureBorrow.Bench.ScopeDensity` now says what that costs: `reborrowings_` over a
two-member bundle allocates exactly 40 bytes per crossing, at 1,024, 16,384 and
262,144 iterations alike, which is precisely what `reborrowing_` allocated
before it was erased. `+slow` does not change that number, because the only
thing it changes underneath is the `srunBO` -- the arm a downstream measured at
0%. So the plural sites were carrying the whole cost the scalar erasure
removed.

`reborrowings`, `reborrowings'` and `reborrowings_` now route through three
plural delimiters that mirror `unsafeBorrowScope` and its siblings line for
line, restoring the bundle through `reviveAliases` exactly as the scalar ones
restore through `reviveAlias`. They are not shared with the scalar delimiters
and Note [The plural delimiters are separate functions] records why: a shared
one would have to instantiate an unsafe coercion at `Reborrowable`, which
third-party instances need not satisfy. They are not exported either.

`Reborrowable` gains `locally` and `locally_` as methods, with the existing
compositions as their defaults, so an instance can supply a delimiter that never
builds an `After` for a result the caller hands back directly. `Mut`, `Share`
and `Muts` override them; a third-party instance keeps working and keeps its
current cost. Callers see no type change.

Measured on ghc-9.12.4 at -O2, -N1, quiet machine, per crossing:

  arm             allocation      time
  reborrowings_   40 B  ->  0 B   4.52 ns -> 1.22 ns
  reborrowings    40 B  ->  0 B   4.63 ns -> 1.24 ns
  locally_ at Mut  0 B  ->  0 B   1.42 ns -> 0.78 ns

"0 B" is exact in the sense the scalar arms already meet: the plural excess over
its control is now 48 bytes for an entire run at every sweep point, a constant
rather than a rate. `locally_` now costs what `reborrowing_` costs (0.66 ns),
which is the downstream complaint that the generic path pays for an `After` the
scalar path does not.

Four Core obligations join the sublifetime group, each inverted under `+slow`:
`locally` at `Mut` equals the scalar delimiter's specification, `reborrowings`
equals its body plus one `reviveAliases`, and the plural path retains neither a
`Linearly` nor a reach for `askLinearly`. The equalities name the barrier for
the reason `ebba572` established -- a specification asserting the delimiter
compiles to nothing is what made the scalar erasure unsound.

`Control.Monad.Borrow.Pure.BOSpec`'s plural kernel predicted it would go red
when this landed, since it was green only by way of `withEnd`'s `nospec`
accident. It is green on the barrier instead, and its comment now says so.
A `locally_` kernel joins it for the generic path.

`reviveAliases` is exported so the Core obligations can name it. That weakens
nothing: it is `pure` behind an OPAQUE, so the worst a caller can do is add a
barrier that was not needed.

Verified on ghc-9.12.4 at -O2 with default flags and with `--flags=+slow`:
`cabal build all`, 375 tasty tests, 39 Core obligations, doctests.

Co-authored-by: Claude <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
