### PR TITLE
feat(loop): iterate over GC-owned elements without moving them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,9 @@
   `Data.HashMap.RobinHood.Mutable.Linear` is the owned table, whose operations are ordinary linear functions; `Data.HashMap.RobinHood.Mutable.Linear.Borrow` keeps one behind a linear `Ref` so that it can be mutated, and grown, through a `Mut` borrow.
   Its keys and values are GC-owned, and it caches a fingerprint per slot so that a key with a cheap hash and an expensive equality is rejected without a full comparison.
   This adds a dependency on `hashable`.
+- `forReborrowingUr_` and `iforReborrowingUr_` loop over a container whose elements are already GC-owned, taking a `Foldable t => t a` and handing the body an unrestricted `a`.
+  `forReborrowing_` binds each element linearly, so such a caller had to `move` it back out — a deep copy per element, for a value nothing owned linearly in the first place.
+  Measured on a three-element list payload, the `move` costs 72 bytes and ~4.7 ns per element; these variants cost neither.
 - `subShare` shortens a `Share` without opening a scope, and `Par` is an applicative for parallel composition inside `BO`, with directly inlinable methods.
 - `BO.Unsafe` exports `unsafeCastAlias`, a `coerceLin` retagging that replaces a bare `unsafeCoerce`.
 

--- a/bench/suite/PureBorrow/Bench/ScopeDensity.hs
+++ b/bench/suite/PureBorrow/Bench/ScopeDensity.hs
@@ -1,5 +1,8 @@
 {-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE QualifiedDo #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -73,9 +76,12 @@ module PureBorrow.Bench.ScopeDensity (
   reborrowingsLoop,
 ) where
 
+import Control.DeepSeq (force)
+import Control.Exception (evaluate)
 import Control.Functor.Linear qualified as Control
 import Control.Monad.Borrow.Pure
 import Control.Monad.Borrow.Pure.Experimental.Borrows
+import Control.Monad.Borrow.Pure.Experimental.Loop (forReborrowingUr_, forReborrowing_)
 import Control.Monad.Borrow.Pure.Experimental.Reborrowable (locally_)
 import Control.Syntax.DataFlow qualified as DataFlow
 import Data.Ref.Linear qualified as Ref
@@ -436,6 +442,105 @@ reborrowingsLoop iterations =
               Control.pure (consume leftScoped `lseq` consume rightScoped)
           go (i - 1) bundle leftLend rightLend
 
+{- | The element a loop arm carries when its elements are GC-owned.
+
+A list rather than an 'Int', because the cost under test is a 'move', and
+'move' on an @Int@ is free while 'move' on a boxed structure is a traversal.
+Downstream the elements were e-graph nodes carrying a 'String', so a short list
+is the honest shape: small enough to be realistic, big enough that copying it
+is not free.
+-}
+type Payload = [Int]
+
+payloads :: Int -> [Payload]
+payloads count =
+  [ [i, i + 1, i + 2]
+  | i <- NonLinear.enumFromTo 1 count
+  ]
+
+{- | A loop over GC-owned elements through 'forReborrowing_', which forces a 'move'.
+
+This is the shape a caller is pushed into today when their elements are already
+unrestricted: the combinator binds each element linearly, so the body has to
+'move' it back out before it can be used nonlinearly, and for a structured
+element that is a deep copy per iteration.
+-}
+loopOwnedElements :: [Payload] -> Int
+{-# NOINLINE loopOwnedElements #-}
+loopOwnedElements elements = withCounter \mut lend -> Control.do
+  mut <-
+    forReborrowing_ mut elements \scoped payload ->
+      move payload & \(Ur payload) ->
+        consume Control.<$> RefBorrow.modify (+ payloadIntValue payload) scoped
+  consume mut `lseq` Control.pure (finishCounter lend)
+
+{- | 'forReborrowing_' over an element whose 'move' is free.
+
+Separates the two costs the arm above conflates. An @Int@ element still binds
+linearly and still goes through the combinator's @StateT@/@Ap@ tower, but
+moving it is a no-op, so this arm minus 'loopUnrestrictedElements' is the
+tower and 'loopOwnedElements' minus this arm is the deep copy.
+-}
+loopCheapMoveElements :: [Int] -> Int
+{-# NOINLINE loopCheapMoveElements #-}
+loopCheapMoveElements elements = withCounter \mut lend -> Control.do
+  mut <-
+    forReborrowing_ mut elements \scoped value ->
+      move value & \(Ur value) ->
+        consume Control.<$> RefBorrow.modify (+ value) scoped
+  consume mut `lseq` Control.pure (finishCounter lend)
+
+-- | The scope-free control for 'loopCheapMoveElements'.
+loopScopeFreeInts :: [Int] -> Int
+{-# NOINLINE loopScopeFreeInts #-}
+loopScopeFreeInts elements = withCounter (go elements)
+  where
+    go ::
+      forall α.
+      [Int] ->
+      Mut α (Ref.Ref Int) %1 ->
+      Lend α (Ref.Ref Int) %1 ->
+      BO α (After α (Ur Int))
+    go [] mut lend = consume mut `lseq` Control.pure (finishCounter lend)
+    go (value : rest) mut lend = Control.do
+      mut <- RefBorrow.modify (+ value) mut
+      go rest mut lend
+
+-- | The same loop through 'forReborrowingUr_', which needs no 'move'.
+loopUnrestrictedElements :: [Payload] -> Int
+{-# NOINLINE loopUnrestrictedElements #-}
+loopUnrestrictedElements elements = withCounter \mut lend -> Control.do
+  mut <-
+    forReborrowingUr_ mut elements \scoped payload ->
+      consume Control.<$> RefBorrow.modify (+ payloadIntValue payload) scoped
+  consume mut `lseq` Control.pure (finishCounter lend)
+
+-- | The unrestricted reader for a 'Payload'; forces the whole element so no arm can skip it.
+payloadIntValue :: Payload -> Int
+{-# INLINE payloadIntValue #-}
+payloadIntValue = NonLinear.sum
+
+{- | The scope-free control for the loop arms: the same additions, no scope, no combinator.
+
+Subtracting this from the two arms above gives the per-element cost of the loop
+machinery; subtracting the two arms from each other gives the cost of the
+'move' alone, which is the quantity a downstream report could only bound.
+-}
+loopScopeFree :: [Payload] -> Int
+{-# NOINLINE loopScopeFree #-}
+loopScopeFree elements = withCounter (go elements)
+  where
+    go ::
+      forall α.
+      [Payload] ->
+      Mut α (Ref.Ref Int) %1 ->
+      Lend α (Ref.Ref Int) %1 ->
+      BO α (After α (Ur Int))
+    go [] mut lend = consume mut `lseq` Control.pure (finishCounter lend)
+    go (payload : rest) mut lend = Control.do
+      mut <- RefBorrow.modify (+ payloadIntValue payload) mut
+      go rest mut lend
+
 {- | The iteration counts swept.
 
 Three points, an order of magnitude apart, so that the per-crossing cost comes
@@ -444,6 +549,20 @@ own setup.
 -}
 iterationCounts :: [Int]
 iterationCounts = [1024, 16384, 262144]
+
+{- | The element counts the loop arms sweep, which stop short of the scalar sweep.
+
+Their input is a list of lists, so at 262,144 elements the payload's own
+footprint is tens of megabytes and the arms become cache- and GC-bound. Measured
+there, the per-element time difference grows with @n@ — 0.9, 3.4, then 58 ns —
+instead of staying flat, and the allocation-free arm comes out /slower/ than the
+one that deep-copies every element, which its allocation figures say is
+impossible. That is the fixture measuring its own input rather than the
+combinator, so the timed sweep stops where the signal is still the combinator's.
+Allocation is exact at every size and stays linear well past this point.
+-}
+loopElementCounts :: [Int]
+loopElementCounts = [1024, 16384]
 
 test_scopeDensity :: [Benchmark]
 test_scopeDensity =
@@ -474,5 +593,18 @@ test_scopeDensity =
               ]
           ]
       | iterations <- iterationCounts
+      ]
+  , bgroup
+      "scope-density-loop"
+      [ env (evaluate (force (payloads elementCount, [1 .. elementCount]))) \(~(elements, ints)) ->
+          bgroup
+            (NonLinear.show elementCount)
+            [ bench "direct" $ nf loopScopeFree elements
+            , bench "forReborrowing_/move" $ nf loopOwnedElements elements
+            , bench "forReborrowingUr_" $ nf loopUnrestrictedElements elements
+            , bench "direct/Int" $ nf loopScopeFreeInts ints
+            , bench "forReborrowing_/Int" $ nf loopCheapMoveElements ints
+            ]
+      | elementCount <- loopElementCounts
       ]
   ]

--- a/pure-borrow.cabal
+++ b/pure-borrow.cabal
@@ -188,6 +188,7 @@ test-suite pure-borrow-test
     Control.Monad.Borrow.Pure.CopyableSpec
     Control.Monad.Borrow.Pure.Experimental.Borrows.TypingCases
     Control.Monad.Borrow.Pure.Experimental.BorrowsSpec
+    Control.Monad.Borrow.Pure.Experimental.LoopSpec
     Control.Monad.Borrow.Pure.Lifetime.TypingCases
     Control.Monad.Borrow.Pure.LifetimeSpec
     Data.HashMap.RobinHood.Mutable.Linear.BorrowSpec

--- a/src/Control/Monad/Borrow/Pure/Experimental/Loop.hs
+++ b/src/Control/Monad/Borrow/Pure/Experimental/Loop.hs
@@ -32,8 +32,10 @@ module Control.Monad.Borrow.Pure.Experimental.Loop (
   forReborrowing,
   forReborrowingOf_,
   forReborrowing_,
+  forReborrowingUr_,
   iforReborrowingOf_,
   iforReborrowing_,
+  iforReborrowingUr_,
   Fold,
   Foldable (..),
   IndexedFold,
@@ -57,6 +59,7 @@ import Control.Monad.Borrow.Pure.BO.Unsafe
 import Control.Monad.Borrow.Pure.Experimental.Reborrowable
 import Control.Monad.Borrow.Pure.Utils (coerceLin)
 import Data.Bifunctor.Linear qualified as Bi
+import Data.Foldable qualified as NonLinear
 import Data.Functor.Linear qualified as Data
 import Data.HashMap.Mutable.Linear qualified as LHM
 import Data.List.NonEmpty.Linear (NonEmpty)
@@ -210,6 +213,67 @@ iforReborrowing_ ::
   BO α (bor xs)
 {-# INLINE iforReborrowing_ #-}
 iforReborrowing_ = iforReborrowingOf_ ifoldMap
+
+{- |
+'forReborrowing_' for a container whose elements are already GC-owned.
+
+The elements arrive through an ordinary arrow and reach the body through one
+too, so a caller who already holds unrestricted values does not have to move
+them into linear ownership and back out again. Use this whenever the elements
+come from a source that owns them nonlinearly — a 'NonLinear.Foldable' of
+plain values, the result of a @toList@ — and reserve 'forReborrowing_' for
+elements this loop genuinely takes ownership of.
+
+The distinction is where the caller's elements come from, not which one is
+faster. Feeding GC-owned values to 'forReborrowing_' costs a 'move' per
+element, and for a structured element that 'move' is a deep copy — but the
+reason to avoid it is that the copy buys nothing: a nonlinearly bound value may
+be consumed repeatedly, so there is nothing for the loop to take ownership of.
+
+The bundle is still threaded linearly and still reborrowed once per element;
+only the element multiplicity differs.
+-}
+forReborrowingUr_ ::
+  (NonLinear.Foldable t, Reborrowable bor) =>
+  bor xs %1 ->
+  t a ->
+  ( forall β.
+    WithLifetime bor (β /\ LifetimeOf bor) xs %1 ->
+    a ->
+    BO (β /\ α) ()
+  ) ->
+  BO α (bor xs)
+{-# INLINE forReborrowingUr_ #-}
+forReborrowingUr_ bors as k = go bors (NonLinear.toList as)
+  where
+    -- Direct strict recursion rather than a fold through a monoid: with the
+    -- elements unrestricted there is no linear state to thread but the bundle
+    -- itself, so the @StateT@/@Ap@ tower the linear variants need buys nothing
+    -- here.
+    go bors' [] = Control.pure bors'
+    go bors' (a : rest) = Control.do
+      bors' <- locally_ bors' \short -> k short a
+      go bors' rest
+
+-- | 'iforReborrowing_' for a container whose elements are already GC-owned; see 'forReborrowingUr_'.
+iforReborrowingUr_ ::
+  (NonLinear.Foldable t, Reborrowable bor) =>
+  bor xs %1 ->
+  t a ->
+  ( forall β.
+    WithLifetime bor (β /\ LifetimeOf bor) xs %1 ->
+    Int ->
+    a ->
+    BO (β /\ α) ()
+  ) ->
+  BO α (bor xs)
+{-# INLINE iforReborrowingUr_ #-}
+iforReborrowingUr_ bors as k = go 0 bors (NonLinear.toList as)
+  where
+    go !_ bors' [] = Control.pure bors'
+    go !i bors' (a : rest) = Control.do
+      bors' <- locally_ bors' \short -> k short i a
+      go (i + 1) bors' rest
 
 toListOf :: Fold s a %1 -> s %1 -> [a]
 {-# INLINE toListOf #-}

--- a/test/Control/Monad/Borrow/Pure/Experimental/LoopSpec.hs
+++ b/test/Control/Monad/Borrow/Pure/Experimental/LoopSpec.hs
@@ -1,0 +1,148 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE ImpredicativeTypes #-}
+{-# LANGUAGE LinearTypes #-}
+{-# LANGUAGE QualifiedDo #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# OPTIONS_GHC -Wno-name-shadowing #-}
+
+module Control.Monad.Borrow.Pure.Experimental.LoopSpec (
+  module Control.Monad.Borrow.Pure.Experimental.LoopSpec,
+) where
+
+import Control.Functor.Linear qualified as Control
+import Control.Monad.Borrow.Pure
+import Control.Monad.Borrow.Pure.Experimental.Loop qualified as Loop
+import Control.Syntax.DataFlow qualified as DataFlow
+import Data.Functor.Linear qualified as Data
+import Data.Ref.Linear qualified as Ref
+import Data.Ref.Linear.Borrow qualified as RefBorrow
+import Data.Vector qualified as V
+import Data.Vector.Mutable.Growable.Linear.Borrow qualified as Growable
+import Prelude.Linear (Ur (..), consume, dup, lseq, move, unur, ($), (&), (*), (+))
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (testCase, (@?=))
+import Prelude (Int, String, sum)
+import Prelude qualified as NonLinear
+
+{- | Sum a list into a borrowed counter with the linear combinator, moving each element in.
+
+This is the shape a caller with GC-owned elements is pushed into by
+'Loop.forReborrowing_': the element binds linearly, so it has to be moved back
+out before the body can read it.
+-}
+sumThroughLinearLoop :: [Int] -> Int
+{-# NOINLINE sumThroughLinearLoop #-}
+sumThroughLinearLoop values =
+  unur $ linearly \linear -> DataFlow.do
+    (runLinear, refLinear) <- dup linear
+    runBO runLinear Control.do
+      (counter, lend) <- borrowM (Ref.new (0 :: Int) refLinear)
+      counter <-
+        Loop.forReborrowing_ counter values \scoped value ->
+          move value & \(Ur value) ->
+            consume Data.<$> RefBorrow.modify (+ value) scoped
+      counter `lseq` pureAfter (move (Ref.free (reclaim lend)))
+
+-- | The same sum with the unrestricted-element combinator, which needs no 'move'.
+sumThroughUnrestrictedLoop :: [Int] -> Int
+{-# NOINLINE sumThroughUnrestrictedLoop #-}
+sumThroughUnrestrictedLoop values =
+  unur $ linearly \linear -> DataFlow.do
+    (runLinear, refLinear) <- dup linear
+    runBO runLinear Control.do
+      (counter, lend) <- borrowM (Ref.new (0 :: Int) refLinear)
+      counter <-
+        Loop.forReborrowingUr_ counter values \scoped value ->
+          consume Data.<$> RefBorrow.modify (+ value) scoped
+      counter `lseq` pureAfter (move (Ref.free (reclaim lend)))
+
+{- | The unrestricted combinator over an element no capability class describes.
+
+'String' has no 'Movable' instance requirement here because the element never
+binds linearly, which is the whole point: a caller whose elements are already
+GC-owned owes the loop nothing.
+-}
+lengthsThroughUnrestrictedLoop :: [String] -> Int
+{-# NOINLINE lengthsThroughUnrestrictedLoop #-}
+lengthsThroughUnrestrictedLoop values =
+  unur $ linearly \linear -> DataFlow.do
+    (runLinear, refLinear) <- dup linear
+    runBO runLinear Control.do
+      (counter, lend) <- borrowM (Ref.new (0 :: Int) refLinear)
+      counter <-
+        Loop.forReborrowingUr_ counter values \scoped value ->
+          consume Data.<$> RefBorrow.modify (+ NonLinear.length value) scoped
+      counter `lseq` pureAfter (move (Ref.free (reclaim lend)))
+
+-- | The indexed unrestricted combinator, weighting each element by its position.
+weightedThroughUnrestrictedLoop :: [Int] -> Int
+{-# NOINLINE weightedThroughUnrestrictedLoop #-}
+weightedThroughUnrestrictedLoop values =
+  unur $ linearly \linear -> DataFlow.do
+    (runLinear, refLinear) <- dup linear
+    runBO runLinear Control.do
+      (counter, lend) <- borrowM (Ref.new (0 :: Int) refLinear)
+      counter <-
+        Loop.iforReborrowingUr_ counter values \scoped index value ->
+          consume Data.<$> RefBorrow.modify (+ (index * value)) scoped
+      counter `lseq` pureAfter (move (Ref.free (reclaim lend)))
+
+{- | The unrestricted combinator grows a borrowed vector, once per element.
+
+The growable vector is the instrument rather than the subject, as in
+"Control.Monad.Borrow.Pure.BOSpec": each iteration writes the header, so a
+combinator that handed back the caller's own occurrence would report a stale
+length here.
+-}
+growThroughUnrestrictedLoop :: [Int] -> (Int, [Int])
+{-# NOINLINE growThroughUnrestrictedLoop #-}
+growThroughUnrestrictedLoop values =
+  unur $ linearly \linear -> DataFlow.do
+    (runLinear, vectorLinear) <- dup linear
+    runBO runLinear Control.do
+      (vector, lend) <- borrowM (Growable.fromVector (V.fromList []) vectorLinear)
+      vector <-
+        Loop.forReborrowingUr_ vector values \scoped value ->
+          consume Data.<$> Growable.push value scoped
+      Growable.size vector & \(Ur finalSize, vector) ->
+        vector `lseq`
+          pureAfter
+            ( Growable.toVector (reclaim lend) & \(Ur contents) ->
+                Ur (finalSize, V.toList contents)
+            )
+
+test_unrestrictedElementLoops :: TestTree
+test_unrestrictedElementLoops =
+  testGroup
+    "loops over GC-owned elements"
+    [ testGroup
+        "forReborrowingUr_ agrees with forReborrowing_ plus move"
+        [ testCase (NonLinear.show values) do
+            sumThroughUnrestrictedLoop values @?= sumThroughLinearLoop values
+        | values <- [[], [7], [1, 2, 3], [10, 20, 30, 40, 50]]
+        ]
+    , testGroup
+        "and with the ordinary sum"
+        [ testCase (NonLinear.show values) do
+            sumThroughUnrestrictedLoop values @?= sum values
+        | values <- [[], [7], [1, 2, 3], NonLinear.enumFromTo 1 64]
+        ]
+    , testCase "an element with no capability instances at all" do
+        lengthsThroughUnrestrictedLoop ["", "ab", "cde"] @?= 5
+    , testGroup
+        "iforReborrowingUr_ supplies ascending indices from zero"
+        [ testCase (NonLinear.show values) do
+            weightedThroughUnrestrictedLoop values
+              @?= sum (NonLinear.zipWith (NonLinear.*) (NonLinear.enumFrom 0) values)
+        | values <- [[], [5], [1, 2, 3], [10, 20, 30, 40]]
+        ]
+    , testGroup
+        "a write through the borrow each iteration restored is visible to the next"
+        [ testCase (NonLinear.show values) do
+            growThroughUnrestrictedLoop values
+              @?= (NonLinear.length values, values)
+        | values <- [[], [1], [1, 2, 3], NonLinear.enumFromTo 1 33]
+        ]
+    ]


### PR DESCRIPTION
`forReborrowing_` binds each element linearly, so a caller whose elements are
already unrestricted has to `move` each one back out before the body can read
it. For a structured element that is a deep copy per iteration, and it buys
nothing: a nonlinearly bound value may be consumed repeatedly, so there is no
ownership for the loop to take. Requiring `Movable` there contradicts this
repository's own multiplicity rule, which is reason enough to fix it
independently of cost.

`forReborrowingUr_` and `iforReborrowingUr_` take a `Foldable t => t a` at
ordinary multiplicity and hand the body an unrestricted `a`. The bundle is
still threaded linearly and still reborrowed once per element; only the element
multiplicity differs. They are a separate family rather than a multiplicity
generalisation of the existing one, because the choice between them is where
the caller's elements come from, not which is faster -- the haddock says so.

R4 gains a `scope-density-loop` group that decomposes the cost four ways.
Measured on ghc-9.12.4 at -O2, -N1, quiet machine, per element, stable across
1,024 and 16,384:

  arm                            ns/elem     B/elem
  direct (no scope)                 9.6         16
  forReborrowingUr_                10.5         16
  forReborrowing_ + move           15.5         88
  direct/Int                        6.3         16
  forReborrowing_/Int               7.0         16

So the `move` costs 72 B and ~4.7 ns per element, and the new family removes
both. Downstream could only bound this by subtracting two experiments that
differed in scope count as well as in the move; it is now isolated.

The Int arms answer the other half, and negatively. `forReborrowing_` over an
element whose `move` is free costs ~0.7 ns and *no* allocation over its
scope-free control -- the same as the new family costs over its own. The
`StateT`/`Ap` tower a downstream report identified as a per-element cost does
not survive -O2 here, so rewriting it is not justified by measurement and is
not attempted. Recorded rather than acted on.

Two fixture notes. The loop arms hold their input in `env` and force it: built
inside the timed region, the payload's own allocation dominated and produced a
per-element difference that grew with n (0.9, 3.4, 58 ns) and ranked the
allocation-free arm slower than the copying one. They also stop at 16,384
rather than 262,144, where the list-of-lists footprint makes the arms cache-
and GC-bound; allocation stays exact and linear well past that.

`Control.Monad.Borrow.Pure.Experimental.LoopSpec` checks the new family against
`forReborrowing_` plus `move` and against an ordinary `sum`, covers an element
type with no capability instances at all, checks `iforReborrowingUr_`'s indices,
and grows a borrowed vector once per element so that a combinator handing back
the caller's own occurrence would report a stale length.

Verified on ghc-9.12.4 at -O2, default and `--flags=+slow`: `cabal build all`,
420 tasty tests, 39 Core obligations, doctests, fourmolu.

Co-authored-by: Claude <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
